### PR TITLE
added bq mk command

### DIFF
--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline.ipynb
@@ -594,7 +594,7 @@
    "source": [
     "### Exercise\n",
     "\n",
-    "1. Create BigQuery Dataset with DATASET_ID variable by using the `bq mk` command.\n",
+    "1. Create BigQuery Dataset with DATASET_ID variable by using the `bq mk --force` command.\n",
     "2. Run the pipeline using the `kfp` command line. Here are some of the variable\n",
     "you will have to use to pass to the pipeline:\n",
     "\n",
@@ -625,9 +625,7 @@
     "To access the KFP UI in your environment use the following URI:\n",
     "\n",
     "https://[ENDPOINT]\n",
-    "\n",
-    "\n",
-    "**NOTE that your pipeline run may fail due to the bug in a BigQuery component that does not handle certain race conditions. If you observe the pipeline failure, retry the run from the KFP UI**\n"
+    "\n"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline.ipynb
@@ -594,7 +594,8 @@
    "source": [
     "### Exercise\n",
     "\n",
-    "Run the pipeline using the `kfp` command line. Here are some of the variable\n",
+    "1. Create BigQuery Dataset with DATASET_ID variable by using the `bq mk` command.\n",
+    "2. Run the pipeline using the `kfp` command line. Here are some of the variable\n",
     "you will have to use to pass to the pipeline:\n",
     "\n",
     "- EXPERIMENT_NAME is set to the experiment used to run the pipeline. You can choose any name you want. If the experiment does not exist it will be created by the command\n",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline.ipynb
@@ -594,7 +594,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bq mk $DATASET_ID\n",
+    "!bq mk --force $DATASET_ID\n",
+    "\n",
     "!kfp --endpoint $ENDPOINT run submit \\\n",
     "-e $EXPERIMENT_NAME \\\n",
     "-r $RUN_ID \\\n",
@@ -637,9 +638,7 @@
     "To access the KFP UI in your environment use the following URI:\n",
     "\n",
     "https://[ENDPOINT]\n",
-    "\n",
-    "\n",
-    "**NOTE that your pipeline run may fail due to the bug in a BigQuery component that does not handle certain race conditions. If you observe the pipeline failure, retry the run from the KFP UI**\n"
+    "\n"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline.ipynb
@@ -594,6 +594,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!bq mk $DATASET_ID\n",
     "!kfp --endpoint $ENDPOINT run submit \\\n",
     "-e $EXPERIMENT_NAME \\\n",
     "-r $RUN_ID \\\n",


### PR DESCRIPTION
Added `bq mk` command to avoid dataset Already Exists errors.

Since this pipeline has multiple bq ops and they try to create dataset if not exists, it raises the error at the first run.
(Only one BQ op is successful and the others fail.)

## Error 
<img width="639" alt="Screen Shot 2021-10-29 at 13 47 12" src="https://user-images.githubusercontent.com/6895245/139378881-9d888e18-019e-4824-af13-162fd06a80d9.png">

## Log
<img width="1412" alt="Screen Shot 2021-10-29 at 13 47 38" src="https://user-images.githubusercontent.com/6895245/139378903-7ceeeed0-8b5e-481f-a0bc-07955ad410a0.png">

