### PR TITLE
Precommit cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,11 +19,6 @@ repos:
     -   id: fix-byte-order-marker
     -   id: trailing-whitespace
     -   id: mixed-line-ending
-#-   repo: https://github.com/pre-commit/mirrors-mypy
-#    rev: v0.910
-#    hooks:
-#    -   id: mypy
-#        args: [--ignore-missing-imports]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.9.3
     hooks:
@@ -41,20 +36,6 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
--   repo: https://github.com/asottile/blacken-docs
-    rev: v1.11.0
-    hooks:
-    -   id: blacken-docs
-        additional_dependencies: [black==20.8b1]
-#-   repo: https://github.com/tomcatling/black-nb
-#    rev: '0.6'
-#    hooks:
-#    -   id: black-nb
-#        args: [-l 80]
-#-   repo: https://github.com/s-weigand/flake8-nb
-#    rev: v0.3.1
-#    hooks:
-#    -   id: flake8-nb
 -   repo: https://github.com/pycqa/pylint
     rev: v2.11.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,24 +19,24 @@ repos:
     -   id: fix-byte-order-marker
     -   id: trailing-whitespace
     -   id: mixed-line-ending
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
-    hooks:
-    -   id: isort
-        args: ["--profile", "black"]
--   repo: https://github.com/psf/black
-    rev: 21.10b0
-    hooks:
-    -   id: black
-        args: [-l 80]
-    -   id: black-jupyter
-        args: [-l 80]
--   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
-    hooks:
-    -   id: pyupgrade
-        args: [--py36-plus]
--   repo: https://github.com/pycqa/pylint
-    rev: v2.11.1
-    hooks:
-    -   id: pylint
+#-   repo: https://github.com/pre-commit/mirrors-isort
+#    rev: v5.9.3
+#    hooks:
+#    -   id: isort
+#        args: ["--profile", "black"]
+#-   repo: https://github.com/psf/black
+#    rev: 21.10b0
+#    hooks:
+#    -   id: black
+#        args: [-l 80]
+#    -   id: black-jupyter
+#        args: [-l 80]
+#-   repo: https://github.com/asottile/pyupgrade
+#    rev: v2.29.0
+#    hooks:
+#    -   id: pyupgrade
+#        args: [--py36-plus]
+#-   repo: https://github.com/pycqa/pylint
+#    rev: v2.11.1
+#    hooks:
+#    -   id: pylint


### PR DESCRIPTION
- remove unused precommit hooks
- temporarily comment out failing hooks, so precommit-ci becomes possible