### PR TITLE
Update streaming_count.py

### DIFF
--- a/notebooks/building_production_ml_systems/labs/taxicab_traffic/streaming_count.py
+++ b/notebooks/building_production_ml_systems/labs/taxicab_traffic/streaming_count.py
@@ -22,9 +22,8 @@ class CountFn(beam.CombineFn):
     def create_accumulator(self):
         return 0
 
-    def add_input(
-        self, count, input
-    ):  # pylint: disable=redefined-builtin,unused-argument
+    def add_input(self, count, element):
+        del element
         return count + 1
 
     def merge_accumulators(self, accumulators):

--- a/notebooks/building_production_ml_systems/solutions/taxicab_traffic/streaming_count.py
+++ b/notebooks/building_production_ml_systems/solutions/taxicab_traffic/streaming_count.py
@@ -22,9 +22,8 @@ class CountFn(beam.CombineFn):
     def create_accumulator(self):
         return 0
 
-    def add_input(
-        self, count, input
-    ):  # pylint: disable=redefined-builtin,unused-argument
+    def add_input(self, count, element):
+        del element
         return count + 1
 
     def merge_accumulators(self, accumulators):


### PR DESCRIPTION
resolving `pylint` issues.
renaming `input` (builtin collision) with `element`, in line with [Beam doc](https://beam.apache.org/releases/pydoc/2.34.0/_modules/apache_beam/transforms/combinefn_lifecycle_pipeline.html#CallSequenceEnforcingCombineFn.add_input) .