### PR TITLE
tame pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,4 @@ repos:
     rev: v2.12.1
     hooks:
     -   id: pylint
+        args: ["--disable", "unexpected-keyword-arg,no-value-for-parameter,too-many-function-args"]


### PR DESCRIPTION
remove rules that cause trouble for multiple functions of the same name with different signatures