### PR TITLE
explicitly push after `build`

### DIFF
--- a/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
@@ -18,6 +18,12 @@ steps:
   dir:  # TODO
 
 
+# Push the trainer image, to make it available in the compile step
+- name: # TODO
+  args: # TODO
+  dir:  # TODO
+
+
 # Compile the pipeline
 - name: 'gcr.io/$PROJECT_ID/kfp-cli-vertex'
   args:

--- a/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
@@ -14,18 +14,21 @@
 steps:
 # Build the trainer image
 - name: 'gcr.io/cloud-builders/docker'
+  id: 'Build the trainer image'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/trainer_image_covertype_vertex:latest', '.']
   dir: trainer_image_vertex
 
 
 # Push the trainer image, to make it available in the compile step
 - name: 'gcr.io/cloud-builders/docker'
+  id: 'Push the trainer image'
   args: ['push', 'gcr.io/$PROJECT_ID/trainer_image_covertype_vertex:latest']
   dir: trainer_image_vertex
 
 
 # Compile the pipeline
 - name: 'gcr.io/$PROJECT_ID/kfp-cli-vertex'
+  id: 'Compile the pipeline'
   args:
   - '-c'
   - |
@@ -42,6 +45,7 @@ steps:
 
 # Run the pipeline
 - name: 'gcr.io/$PROJECT_ID/kfp-cli-vertex'
+  id: 'Run the pipeline'
   args:
   - '-c'
   - |

--- a/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
@@ -18,6 +18,12 @@ steps:
   dir: trainer_image_vertex
 
 
+# Push the trainer image, to make it available in the compile step
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', 'gcr.io/$PROJECT_ID/trainer_image_covertype_vertex:latest']
+  dir: trainer_image_vertex
+
+
 # Compile the pipeline
 - name: 'gcr.io/$PROJECT_ID/kfp-cli-vertex'
   args:


### PR DESCRIPTION
So that the compile step has access to this new container.

Otherwise, at first run, this build will fail; _and_ in later runs it will always use the second latest version, as opposed to the latest version.

Note that the Cloud Build doc allows for this "double" push:
"If you want to store the image as part of your build flow and want to display the image in the build results, use both the Docker push command and the images field in your build config file."
https://cloud.google.com/build/docs/building/build-containers#store-images