### PR TITLE
fix relative path

### DIFF
--- a/notebooks/tfx_pipelines/guided_projects/guided_project_2.ipynb
+++ b/notebooks/tfx_pipelines/guided_projects/guided_project_2.ipynb
@@ -356,8 +356,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FEATURE_PY = \"../../tfx_pipelines/pipeline/solutions/pipeline/features.py\"\n",
-    "PREPROC_PY = \"../../tfx_pipelines/pipeline/solutions/pipeline/preprocessing.py\""
+    "FEATURE_PY = \"../../pipeline/solutions/pipeline/features.py\"\n",
+    "PREPROC_PY = \"../../pipeline/solutions/pipeline/preprocessing.py\""
    ]
   },
   {


### PR DESCRIPTION
because there is an earlier ` %cd` statement above which otherwise makes this cell fail.