### PR TITLE
Update the kfp lab to run with TF 2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: clean install 
+all: clean install
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+all: clean install 
+
+.PHONY: clean
+clean:
+	@find . -name '*.pyc' -delete
+	@find . -name '*.pytest_cache' -delete
+	@find . -name '__pycache__' -delete
+	@find . -name '*egg-info' -delete
+
+.PHONY: install
+install:
+	@pip install -U pip
+	@pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 all: clean install
 
 .PHONY: clean

--- a/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
@@ -40,7 +40,7 @@
     "PROJECT_ID = !(gcloud config get-value project)\n",
     "PROJECT_ID = PROJECT_ID[0]\n",
     "REGION = \"us-central1\"\n",
-    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-vertex\""
+    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\""
    ]
   },
   {
@@ -339,9 +339,10 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-3.m78",
+   "kernel": "python3",
+   "name": "tf2-gpu.2-6.m86",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m78"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m86"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -358,7 +359,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
@@ -40,7 +40,7 @@
     "PROJECT_ID = !(gcloud config get-value project)\n",
     "PROJECT_ID = PROJECT_ID[0]\n",
     "REGION = \"us-central1\"\n",
-    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-vertex\""
+    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\""
    ]
   },
   {
@@ -255,9 +255,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-3.m86",
+   "name": "tf2-gpu.2-6.m86",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m86"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m86"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex.ipynb
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-vertex\"\n",
+    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\"\n",
     "PIPELINE_ROOT = f\"{ARTIFACT_STORE}/pipeline\"\n",
     "DATA_ROOT = f\"{ARTIFACT_STORE}/data\"\n",
     "\n",
@@ -444,9 +444,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-3.m86",
+   "name": "tf2-gpu.2-6.m86",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m86"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m86"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex.ipynb
@@ -296,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-vertex\"\n",
+    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\"\n",
     "PIPELINE_ROOT = f\"{ARTIFACT_STORE}/pipeline\"\n",
     "DATA_ROOT = f\"{ARTIFACT_STORE}/data\"\n",
     "\n",
@@ -454,9 +454,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-3.m86",
+   "name": "tf2-gpu.2-6.m86",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m86"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m86"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough_vertex.ipynb
@@ -62,7 +62,7 @@
     "PROJECT_ID = !(gcloud config get-value core/project)\n",
     "PROJECT_ID = PROJECT_ID[0]\n",
     "\n",
-    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-vertex\"\n",
+    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\"\n",
     "\n",
     "DATA_ROOT = f\"{ARTIFACT_STORE}/data\"\n",
     "JOB_DIR_ROOT = f\"{ARTIFACT_STORE}/jobs\"\n",
@@ -890,9 +890,10 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-3.m75",
+   "kernel": "python3",
+   "name": "tf2-gpu.2-6.m86",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m75"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m86"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -909,7 +910,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
     "PROJECT_ID = !(gcloud config get-value core/project)\n",
     "PROJECT_ID = PROJECT_ID[0]\n",
     "\n",
-    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-vertex\"\n",
+    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\"\n",
     "\n",
     "DATA_ROOT = f\"{ARTIFACT_STORE}/data\"\n",
     "JOB_DIR_ROOT = f\"{ARTIFACT_STORE}/jobs\"\n",
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,9 +93,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/\n"
+     ]
+    }
+   ],
    "source": [
     "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
    ]
@@ -109,9 +117,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BigQuery error in mk operation: Dataset 'qwiklabs-\n",
+      "gcp-04-05130841e161:covertype_dataset' already exists.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Waiting on bqjob_r2dc7ccec298aa74e_0000017dc077a02b_1 ... (2s) Current status: DONE   \n"
+     ]
+    }
+   ],
    "source": [
     "%%bash\n",
     "\n",
@@ -153,9 +177,309 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Query complete after 0.01s: 100%|██████████| 2/2 [00:00<00:00, 593.76query/s]                         \n",
+      "Downloading: 100%|██████████| 100000/100000 [00:01<00:00, 92077.11rows/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Elevation</th>\n",
+       "      <th>Aspect</th>\n",
+       "      <th>Slope</th>\n",
+       "      <th>Horizontal_Distance_To_Hydrology</th>\n",
+       "      <th>Vertical_Distance_To_Hydrology</th>\n",
+       "      <th>Horizontal_Distance_To_Roadways</th>\n",
+       "      <th>Hillshade_9am</th>\n",
+       "      <th>Hillshade_Noon</th>\n",
+       "      <th>Hillshade_3pm</th>\n",
+       "      <th>Horizontal_Distance_To_Fire_Points</th>\n",
+       "      <th>Wilderness_Area</th>\n",
+       "      <th>Soil_Type</th>\n",
+       "      <th>Cover_Type</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2085</td>\n",
+       "      <td>256</td>\n",
+       "      <td>18</td>\n",
+       "      <td>150</td>\n",
+       "      <td>27</td>\n",
+       "      <td>738</td>\n",
+       "      <td>176</td>\n",
+       "      <td>248</td>\n",
+       "      <td>208</td>\n",
+       "      <td>914</td>\n",
+       "      <td>Cache</td>\n",
+       "      <td>C2702</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2125</td>\n",
+       "      <td>256</td>\n",
+       "      <td>20</td>\n",
+       "      <td>30</td>\n",
+       "      <td>12</td>\n",
+       "      <td>871</td>\n",
+       "      <td>169</td>\n",
+       "      <td>248</td>\n",
+       "      <td>215</td>\n",
+       "      <td>300</td>\n",
+       "      <td>Cache</td>\n",
+       "      <td>C2702</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2146</td>\n",
+       "      <td>256</td>\n",
+       "      <td>34</td>\n",
+       "      <td>150</td>\n",
+       "      <td>62</td>\n",
+       "      <td>1253</td>\n",
+       "      <td>122</td>\n",
+       "      <td>237</td>\n",
+       "      <td>239</td>\n",
+       "      <td>511</td>\n",
+       "      <td>Cache</td>\n",
+       "      <td>C2702</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2186</td>\n",
+       "      <td>256</td>\n",
+       "      <td>38</td>\n",
+       "      <td>210</td>\n",
+       "      <td>102</td>\n",
+       "      <td>1294</td>\n",
+       "      <td>109</td>\n",
+       "      <td>232</td>\n",
+       "      <td>244</td>\n",
+       "      <td>552</td>\n",
+       "      <td>Cache</td>\n",
+       "      <td>C2702</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2831</td>\n",
+       "      <td>256</td>\n",
+       "      <td>25</td>\n",
+       "      <td>277</td>\n",
+       "      <td>183</td>\n",
+       "      <td>1706</td>\n",
+       "      <td>153</td>\n",
+       "      <td>246</td>\n",
+       "      <td>225</td>\n",
+       "      <td>1485</td>\n",
+       "      <td>Commanche</td>\n",
+       "      <td>C2705</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99995</th>\n",
+       "      <td>3136</td>\n",
+       "      <td>254</td>\n",
+       "      <td>12</td>\n",
+       "      <td>319</td>\n",
+       "      <td>60</td>\n",
+       "      <td>5734</td>\n",
+       "      <td>193</td>\n",
+       "      <td>248</td>\n",
+       "      <td>193</td>\n",
+       "      <td>2467</td>\n",
+       "      <td>Rawah</td>\n",
+       "      <td>C7746</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99996</th>\n",
+       "      <td>3242</td>\n",
+       "      <td>254</td>\n",
+       "      <td>12</td>\n",
+       "      <td>636</td>\n",
+       "      <td>148</td>\n",
+       "      <td>3551</td>\n",
+       "      <td>193</td>\n",
+       "      <td>248</td>\n",
+       "      <td>193</td>\n",
+       "      <td>2010</td>\n",
+       "      <td>Commanche</td>\n",
+       "      <td>C7757</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99997</th>\n",
+       "      <td>2071</td>\n",
+       "      <td>255</td>\n",
+       "      <td>12</td>\n",
+       "      <td>234</td>\n",
+       "      <td>63</td>\n",
+       "      <td>342</td>\n",
+       "      <td>192</td>\n",
+       "      <td>247</td>\n",
+       "      <td>193</td>\n",
+       "      <td>247</td>\n",
+       "      <td>Cache</td>\n",
+       "      <td>C2706</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99998</th>\n",
+       "      <td>3248</td>\n",
+       "      <td>255</td>\n",
+       "      <td>12</td>\n",
+       "      <td>730</td>\n",
+       "      <td>113</td>\n",
+       "      <td>725</td>\n",
+       "      <td>192</td>\n",
+       "      <td>247</td>\n",
+       "      <td>193</td>\n",
+       "      <td>2724</td>\n",
+       "      <td>Commanche</td>\n",
+       "      <td>C7756</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99999</th>\n",
+       "      <td>3153</td>\n",
+       "      <td>255</td>\n",
+       "      <td>12</td>\n",
+       "      <td>404</td>\n",
+       "      <td>116</td>\n",
+       "      <td>2139</td>\n",
+       "      <td>192</td>\n",
+       "      <td>247</td>\n",
+       "      <td>193</td>\n",
+       "      <td>994</td>\n",
+       "      <td>Commanche</td>\n",
+       "      <td>C7756</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100000 rows × 13 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       Elevation  Aspect  Slope  Horizontal_Distance_To_Hydrology  \\\n",
+       "0           2085     256     18                               150   \n",
+       "1           2125     256     20                                30   \n",
+       "2           2146     256     34                               150   \n",
+       "3           2186     256     38                               210   \n",
+       "4           2831     256     25                               277   \n",
+       "...          ...     ...    ...                               ...   \n",
+       "99995       3136     254     12                               319   \n",
+       "99996       3242     254     12                               636   \n",
+       "99997       2071     255     12                               234   \n",
+       "99998       3248     255     12                               730   \n",
+       "99999       3153     255     12                               404   \n",
+       "\n",
+       "       Vertical_Distance_To_Hydrology  Horizontal_Distance_To_Roadways  \\\n",
+       "0                                  27                              738   \n",
+       "1                                  12                              871   \n",
+       "2                                  62                             1253   \n",
+       "3                                 102                             1294   \n",
+       "4                                 183                             1706   \n",
+       "...                               ...                              ...   \n",
+       "99995                              60                             5734   \n",
+       "99996                             148                             3551   \n",
+       "99997                              63                              342   \n",
+       "99998                             113                              725   \n",
+       "99999                             116                             2139   \n",
+       "\n",
+       "       Hillshade_9am  Hillshade_Noon  Hillshade_3pm  \\\n",
+       "0                176             248            208   \n",
+       "1                169             248            215   \n",
+       "2                122             237            239   \n",
+       "3                109             232            244   \n",
+       "4                153             246            225   \n",
+       "...              ...             ...            ...   \n",
+       "99995            193             248            193   \n",
+       "99996            193             248            193   \n",
+       "99997            192             247            193   \n",
+       "99998            192             247            193   \n",
+       "99999            192             247            193   \n",
+       "\n",
+       "       Horizontal_Distance_To_Fire_Points Wilderness_Area Soil_Type  \\\n",
+       "0                                     914           Cache     C2702   \n",
+       "1                                     300           Cache     C2702   \n",
+       "2                                     511           Cache     C2702   \n",
+       "3                                     552           Cache     C2702   \n",
+       "4                                    1485       Commanche     C2705   \n",
+       "...                                   ...             ...       ...   \n",
+       "99995                                2467           Rawah     C7746   \n",
+       "99996                                2010       Commanche     C7757   \n",
+       "99997                                 247           Cache     C2706   \n",
+       "99998                                2724       Commanche     C7756   \n",
+       "99999                                 994       Commanche     C7756   \n",
+       "\n",
+       "       Cover_Type  \n",
+       "0               5  \n",
+       "1               2  \n",
+       "2               2  \n",
+       "3               2  \n",
+       "4               1  \n",
+       "...           ...  \n",
+       "99995           1  \n",
+       "99996           0  \n",
+       "99997           2  \n",
+       "99998           1  \n",
+       "99999           1  \n",
+       "\n",
+       "[100000 rows x 13 columns]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%bigquery\n",
     "SELECT *\n",
@@ -174,9 +498,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting on bqjob_r5a7884b4b3f9b36e_0000017dc0785a09_1 ... (2s) Current status: DONE   \n"
+     ]
+    }
+   ],
    "source": [
     "!bq query \\\n",
     "-n 0 \\\n",
@@ -191,9 +523,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting on bqjob_r5afaa542f2b8d2b6_0000017dc0787100_1 ... (0s) Current status: DONE   \n"
+     ]
+    }
+   ],
    "source": [
     "!bq extract \\\n",
     "--destination_format CSV \\\n",
@@ -210,9 +550,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting on bqjob_r3ec5593e063f5190_0000017dc0787e66_1 ... (2s) Current status: DONE   \n"
+     ]
+    }
+   ],
    "source": [
     "!bq query \\\n",
     "-n 0 \\\n",
@@ -227,9 +575,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting on bqjob_r173603abafae738d_0000017dc078917b_1 ... (0s) Current status: DONE   \n"
+     ]
+    }
+   ],
    "source": [
     "!bq extract \\\n",
     "--destination_format CSV \\\n",
@@ -239,9 +595,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(40009, 13)\n",
+      "(9836, 13)\n"
+     ]
+    }
+   ],
    "source": [
     "df_train = pd.read_csv(TRAINING_FILE_PATH)\n",
     "df_validation = pd.read_csv(VALIDATION_FILE_PATH)\n",
@@ -861,9 +1226,10 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-3.m75",
+   "kernel": "python3",
+   "name": "tf2-gpu.2-6.m86",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m75"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m86"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -880,7 +1246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/tfx_pipelines/pipeline/labs/tfx_pipeline_vertex.ipynb
+++ b/notebooks/tfx_pipelines/pipeline/labs/tfx_pipeline_vertex.ipynb
@@ -52,7 +52,7 @@
     "!python -c \"import tensorflow as tf; print(f'TF version: {tf.__version__}')\"\n",
     "!python -c \"import tfx; print(f'TFX version: {tfx.__version__}')\"\n",
     "!python -c \"import kfp; print(f'KFP version: {kfp.__version__}')\"\n",
-    "print(f\"aiplatform: {aiplatform.__version__}\")"
+    "print(f\"aiplatform: {vertex_ai.__version__}\")"
    ]
   },
   {

--- a/notebooks/tfx_pipelines/pipeline/solutions/tfx_pipeline_vertex.ipynb
+++ b/notebooks/tfx_pipelines/pipeline/solutions/tfx_pipeline_vertex.ipynb
@@ -52,7 +52,7 @@
     "!python -c \"import tensorflow as tf; print(f'TF version: {tf.__version__}')\"\n",
     "!python -c \"import tfx; print(f'TFX version: {tfx.__version__}')\"\n",
     "!python -c \"import kfp; print(f'KFP version: {kfp.__version__}')\"\n",
-    "print(f\"aiplatform: {aiplatform.__version__}\")"
+    "print(f\"vertex_ai: {vertex_ai.__version__}\")"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Requirements for MLOps Vertex
+google-cloud-aiplatform==1.7.1
+kfp==1.8.1
+tfx==1.4.0

--- a/scripts/enable_services.sh
+++ b/scripts/enable_services.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+gcloud services enable \
+  compute.googleapis.com \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com \
+  monitoring.googleapis.com \
+  logging.googleapis.com \
+  notebooks.googleapis.com \
+  aiplatform.googleapis.com \
+  bigquery.googleapis.com \
+  artifactregistry.googleapis.com \
+  cloudbuild.googleapis.com \
+  container.googleapis.com

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,3 +1,18 @@
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 REPO_ROOT_DIR="$(dirname $(cd $(dirname $BASH_SOURCE) && pwd))"
 SCRIPTS_DIR="$REPO_ROOT_DIR/scripts"
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,5 @@
+REPO_ROOT_DIR="$(dirname $(cd $(dirname $BASH_SOURCE) && pwd))"
+SCRIPTS_DIR="$REPO_ROOT_DIR/scripts"
+
+PROJECT_ID=$(gcloud config list project --format "value(core.project)")
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")

--- a/scripts/setup_cloud_build_for_mlops_vertex.sh
+++ b/scripts/setup_cloud_build_for_mlops_vertex.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. $(cd $(dirname $BASH_SOURCE) && pwd)/env.sh
+
+
+CLOUD_BUILD_SERVICE_ACCOUNT="$PROJECT_NUMBER@cloudbuild.gserviceaccount.com"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member serviceAccount:$CLOUD_BUILD_SERVICE_ACCOUNT \
+  --role roles/editor

--- a/scripts/setup_cloud_build_for_mlops_vertex.sh
+++ b/scripts/setup_cloud_build_for_mlops_vertex.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 . $(cd $(dirname $BASH_SOURCE) && pwd)/env.sh
 
 
-CLOUD_BUILD_SERVICE_ACCOUNT="$PROJECT_NUMBER@cloudbuild.gserviceaccount.com"
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com \
+  --role roles/editor
 
 gcloud projects add-iam-policy-binding $PROJECT_ID \
-  --member serviceAccount:$CLOUD_BUILD_SERVICE_ACCOUNT \
-  --role roles/editor
+    --member serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com \
+    --role roles/storage.objectAdmin

--- a/scripts/setup_cloud_build_for_mlops_vertex.sh
+++ b/scripts/setup_cloud_build_for_mlops_vertex.sh
@@ -24,3 +24,12 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 gcloud projects add-iam-policy-binding $PROJECT_ID \
     --member serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com \
     --role roles/storage.objectAdmin
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com \
+    --role roles/aiplatform.user
+
+gcloud iam service-accounts add-iam-policy-binding \
+    $PROJECT_NUMBER-compute@developer.gserviceaccount.com \
+    --member serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com \
+    --role roles/iam.serviceAccountUser


### PR DESCRIPTION
### Description

This PR updates the walkthrough lab, the pipeline lab, and the cicd lab from the kfp lab series so that they run on JupyterLab TF 2.6 enterprise in the environment described in the [requirements.txt](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/update-kfp-labs-to-tf2.6/requirements.txt) file. 

To ease the setup, this PR also creates 

* a [requirement.txt](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/update-kfp-labs-to-tf2.6/requirements.txt) with all the MLOps Vertex Python dependencies

*  a [Makefile](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/update-kfp-labs-to-tf2.6/Makefile) to ease the dependency installation and artifacts cleanup (`make clean` and `make install`)

* a [setup_cloud_build_for_mlops_vertex.sh](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/update-kfp-labs-to-tf2.6/scripts/setup_cloud_build_for_mlops_vertex.sh) script that configures CloudBuild with the right IAM roles

### Testing instructions

* On a fresh TF 2.6 JuypterLab cd into the repo and type 'make install' to install the dependencies

* On CloudShell, run ./scripts/setup_cloud_build_for_mlops_vertex.sh

* Test the 3 lab solutions: [walkthrough](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/update-kfp-labs-to-tf2.6/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb), [pipeline](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/update-kfp-labs-to-tf2.6/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex.ipynb), and [cicd](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/update-kfp-labs-to-tf2.6/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb)