### PR TITLE
Implement a Vertex AutoML pipeline for the covertype dataset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,7 @@ install:
 	@pip install -U pip
 	@pip install -r requirements.txt
 	@pre-commit install
+
+.PHONY: precommit
+precommit:
+	@pre-commit run --all-files

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,4 @@ clean:
 install:
 	@pip install -U pip
 	@pip install -r requirements.txt
+	@pre-commit install

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
@@ -127,7 +127,6 @@
     ")\n",
     "from kfp.v2 import dsl\n",
     "\n",
-    "\n",
     "PIPELINE_ROOT = os.getenv(\"PIPELINE_ROOT\")\n",
     "PROJECT = os.getenv(\"PROJECT\")\n",
     "DATASET_PATH = os.getenv(\"DATASET_PATH\")\n",
@@ -170,7 +169,7 @@
     "        dedicated_resources_machine_type=SERVING_MACHINE_TYPE,\n",
     "        dedicated_resources_min_replica_count=1,\n",
     "        dedicated_resources_max_replica_count=1,\n",
-    "    )"
+    "    )\n"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
@@ -1,0 +1,523 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Continuous Training with Kubeflow Pipeline and Vertex AI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Learning Objectives:**\n",
+    "1. Learn how to use KF pre-built components\n",
+    "1. Learn how to build a KF pipeline with these components\n",
+    "1. Learn how to compile, upload, and run a KF pipeline\n",
+    "\n",
+    "\n",
+    "In this lab, you will build, deploy, and run a KFP pipeline that orchestrates the **Vertex AI** services to train, tune, and deploy a **scikit-learn** model using the Google pre-built components."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "from google.cloud import aiplatform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"\n",
+    "PROJECT = !(gcloud config get-value project)\n",
+    "PROJECT = PROJECT[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: PATH=/home/jupyter/.local/bin:/home/jupyter/.local/bin:/home/jupyter/.local/bin:/home/jupyter/.local/bin:/usr/local/cuda/bin:/opt/conda/bin:/opt/conda/condabin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set `PATH` to include the directory containing KFP CLI\n",
+    "PATH = %env PATH\n",
+    "%env PATH=/home/jupyter/.local/bin:{PATH}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Understanding the pipeline design\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The workflow implemented by the pipeline is defined using a Python based Domain Specific Language (DSL). The pipeline's DSL is in the `pipeline_vertex/pipeline_prebuilt.py` file that we will generate below.\n",
+    "\n",
+    "The pipeline's DSL has been designed to avoid hardcoding any environment specific settings like file paths or connection strings. These settings are provided to the pipeline code through a set of environment variables.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building and deploying the pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us write the pipeline to disk:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Kubeflow Covertype Pipeline.'"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#%%writefile ./pipeline_vertex/pipeline_vertex_automl.py\n",
+    "# Copyright 2021 Google LLC\n",
+    "\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\"); you may not\n",
+    "# use this file except in compliance with the License. You may obtain a copy of\n",
+    "# the License at\n",
+    "\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\"\n",
+    "# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either\n",
+    "# express or implied. See the License for the specific language governing\n",
+    "# permissions and limitations under the License.\n",
+    "\n",
+    "\"\"\"Kubeflow Covertype Pipeline.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from google_cloud_pipeline_components.aiplatform import (\n",
+    "    AutoMLTabularTrainingJobRunOp,\n",
+    "    EndpointCreateOp,\n",
+    "    ModelDeployOp,\n",
+    "    TabularDatasetCreateOp,\n",
+    ")\n",
+    "from kfp.v2 import dsl\n",
+    "\n",
+    "PIPELINE_ROOT = os.getenv(\"PIPELINE_ROOT\")\n",
+    "PROJECT = os.getenv(\"PROJECT\")\n",
+    "DATASET_PATH = os.getenv(\"DATASET_PATH\")\n",
+    "PIPELINE_NAME = os.getenv(\"PIPELINE_NAME\", \"covertype\")\n",
+    "DISPLAY_NAME = os.getenv(\"MODEL_DISPLAY_NAME\", PIPELINE_NAME)\n",
+    "TARGET_COLUMN = os.getenv(\"TARGET_COLUMN\", \"Cover_Type\")\n",
+    "SERVING_MACHINE_TYPE = os.getenv(\"SERVING_MACHINE_TYPE\", \"n1-standard-16\")\n",
+    "\n",
+    "\n",
+    "@dsl.pipeline(\n",
+    "    name=f\"{PIPELINE_NAME}-vertex-automl-pipeline\",\n",
+    "    description=f\"AutoML Vertex Pipeline for {PIPELINE_NAME}\",\n",
+    "    pipeline_root=PIPELINE_ROOT,\n",
+    ")\n",
+    "def create_pipeline():\n",
+    "\n",
+    "    dataset_create_task = TabularDatasetCreateOp(\n",
+    "        display_name=DISPLAY_NAME,\n",
+    "        gcs_source=DATASET_PATH,\n",
+    "        project=PROJECT,\n",
+    "    )\n",
+    "\n",
+    "    automl_training_task = AutoMLTabularTrainingJobRunOp(\n",
+    "        project=PROJECT,\n",
+    "        display_name=DISPLAY_NAME,\n",
+    "        optimization_prediction_type=\"classification\",\n",
+    "        dataset=dataset_create_task.outputs[\"dataset\"],\n",
+    "        target_column=TARGET_COLUMN,\n",
+    "    )\n",
+    "\n",
+    "    endpoint_create_task = EndpointCreateOp(\n",
+    "        project=PROJECT,\n",
+    "        display_name=DISPLAY_NAME,\n",
+    "    )\n",
+    "\n",
+    "    model_deploy_task = ModelDeployOp(  # pylint: disable=unused-variable\n",
+    "        model=automl_training_task.outputs[\"model\"],\n",
+    "        endpoint=endpoint_create_task.outputs[\"endpoint\"],\n",
+    "        deployed_model_display_name=DISPLAY_NAME,\n",
+    "        dedicated_resources_machine_type=SERVING_MACHINE_TYPE,\n",
+    "        dedicated_resources_min_replica_count=1,\n",
+    "        dedicated_resources_max_replica_count=1,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compile the pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let stat by defining the environment variables that will be passed to the pipeline compiler:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us make sure that the `ARTIFACT_STORE` has been created, and let us create it if not:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CommandException: \"mb\" command does not support \"file://\" URLs. Did you mean to use a gs:// URL?\n"
+     ]
+    }
+   ],
+   "source": [
+    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:** In case the artifact store was not created and properly set before hand, you may need\n",
+    "to run in **CloudShell** the following command to allow Vertex AI to access it:\n",
+    "\n",
+    "```\n",
+    "PROJECT=$(gcloud config get-value project)\n",
+    "PROJECT_NUMBER=$(gcloud projects list --filter=\"name=$PROJECT\" --format=\"value(PROJECT_NUMBER)\")\n",
+    "gcloud projects add-iam-policy-binding $PROJECT \\\n",
+    "    --member=\"serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com\" \\\n",
+    "    --role=\"roles/storage.objectAdmin\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Use the CLI compiler to compile the pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: PIPELINE_ROOT=gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/pipeline\n",
+      "env: PROJECT=qwiklabs-gcp-04-05130841e161\n",
+      "env: REGION=us-central1\n",
+      "env: DATASET_PATH=gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/data/training/dataset.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "ARTIFACT_STORE = f\"gs://{PROJECT}-kfp-artifact-store\"\n",
+    "PIPELINE_ROOT = f\"{ARTIFACT_STORE}/pipeline\"\n",
+    "DATASET_PATH = f\"{ARTIFACT_STORE}/data/training/dataset.csv\"\n",
+    "\n",
+    "%env PIPELINE_ROOT={PIPELINE_ROOT}\n",
+    "%env PROJECT={PROJECT}\n",
+    "%env REGION={REGION}\n",
+    "%env DATASET_PATH={DATASET_PATH}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We compile the pipeline from the Python file we generated into a JSON description using the following command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PIPELINE_JSON = \"covertype_automl_vertex_pipeline.json\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/data/training/dataset.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "from kfp.v2 import compiler\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    pipeline_func=create_pipeline,\n",
+    "    package_path=PIPELINE_JSON,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dsl-compile-v2 --py pipeline_vertex/pipeline_prebuilt.py --output $PIPELINE_JSON"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:** You can also use the Python SDK to compile the pipeline:\n",
+    "\n",
+    "```python\n",
+    "from kfp.v2 import compiler\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    pipeline_func=create_pipeline, \n",
+    "    package_path=PIPELINE_JSON,\n",
+    ")\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result is the pipeline file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"pipelineSpec\": {\n",
+      "    \"components\": {\n",
+      "      \"comp-tabulardataset-create\": {\n",
+      "        \"executorLabel\": \"exec-tabulardataset-create\",\n",
+      "        \"outputDefinitions\": {\n",
+      "          \"artifacts\": {\n",
+      "            \"dataset\": {\n",
+      "              \"artifactType\": {\n",
+      "                \"schemaTitle\": \"google.VertexDataset\",\n"
+     ]
+    }
+   ],
+   "source": [
+    "!head {PIPELINE_JSON}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy the pipeline package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/data/training/dataset.csv'"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "DATASET_PATH"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/data/training/dataset.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "!gsutil ls $DATASET_PATH"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.pipeline_jobs:Creating PipelineJob\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob created. Resource name: projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:To use this PipelineJob in another session:\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:pipeline_job = aiplatform.PipelineJob.get('projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725')\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:View Pipeline Job:\n",
+      "https://console.cloud.google.com/vertex-ai/locations/us-central1/pipelines/runs/covertype-vertex-automl-pipeline-20220107195725?project=481343644334\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n"
+     ]
+    }
+   ],
+   "source": [
+    "aiplatform.init(project=PROJECT, location=REGION)\n",
+    "\n",
+    "pipeline = aiplatform.PipelineJob(\n",
+    "    display_name=\"automl_covertype_kfp_pipeline\",\n",
+    "    template_path=PIPELINE_JSON,\n",
+    "    enable_caching=True,\n",
+    ")\n",
+    "\n",
+    "pipeline.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copyright 2021 Google LLC\n",
+    "\n",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "you may not use this file except in compliance with the License.\n",
+    "You may obtain a copy of the License at\n",
+    "\n",
+    "    https://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    "Unless required by applicable law or agreed to in writing, software\n",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "See the License for the specific language governing permissions and\n",
+    "limitations under the License."
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "tf2-gpu.2-6.m86",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m86"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
@@ -6,7 +6,7 @@
     "tags": []
    },
    "source": [
-    "# Continuous Training with Kubeflow Pipeline and Vertex AI"
+    "# Continuous Training with AutoML Vertex Pipelines"
    ]
   },
   {
@@ -14,12 +14,12 @@
    "metadata": {},
    "source": [
     "**Learning Objectives:**\n",
-    "1. Learn how to use KF pre-built components\n",
-    "1. Learn how to build a KF pipeline with these components\n",
-    "1. Learn how to compile, upload, and run a KF pipeline\n",
+    "1. Learn how to use Vertex AutoML pre-built components\n",
+    "1. Learn how to build a Vertex AutoML pipeline with these components\n",
+    "1. Learn how to compile, upload, and run the a Vertex AutoML pipeline\n",
     "\n",
     "\n",
-    "In this lab, you will build, deploy, and run a KFP pipeline that orchestrates the **Vertex AI** services to train, tune, and deploy a **scikit-learn** model using the Google pre-built components."
+    "In this lab, you will build, deploy, and run a Vertex AutoML pipeline that orchestrates the **Vertex AutoML AI** services to train, tune, and deploy a model. "
    ]
   },
   {
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,19 +53,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "env: PATH=/home/jupyter/.local/bin:/home/jupyter/.local/bin:/home/jupyter/.local/bin:/home/jupyter/.local/bin:/usr/local/cuda/bin:/opt/conda/bin:/opt/conda/condabin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Set `PATH` to include the directory containing KFP CLI\n",
     "PATH = %env PATH\n",
@@ -104,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,6 +126,7 @@
     "    TabularDatasetCreateOp,\n",
     ")\n",
     "from kfp.v2 import dsl\n",
+    "\n",
     "\n",
     "PIPELINE_ROOT = os.getenv(\"PIPELINE_ROOT\")\n",
     "PROJECT = os.getenv(\"PROJECT\")\n",
@@ -203,17 +196,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CommandException: \"mb\" command does not support \"file://\" URLs. Did you mean to use a gs:// URL?\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
    ]
@@ -243,20 +228,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "env: PIPELINE_ROOT=gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/pipeline\n",
-      "env: PROJECT=qwiklabs-gcp-04-05130841e161\n",
-      "env: REGION=us-central1\n",
-      "env: DATASET_PATH=gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/data/training/dataset.csv\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ARTIFACT_STORE = f\"gs://{PROJECT}-kfp-artifact-store\"\n",
     "PIPELINE_ROOT = f\"{ARTIFACT_STORE}/pipeline\"\n",
@@ -277,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,26 +293,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  \"pipelineSpec\": {\n",
-      "    \"components\": {\n",
-      "      \"comp-tabulardataset-create\": {\n",
-      "        \"executorLabel\": \"exec-tabulardataset-create\",\n",
-      "        \"outputDefinitions\": {\n",
-      "          \"artifacts\": {\n",
-      "            \"dataset\": {\n",
-      "              \"artifactType\": {\n",
-      "                \"schemaTitle\": \"google.VertexDataset\",\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!head {PIPELINE_JSON}"
    ]
@@ -354,32 +311,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.pipeline_jobs:Creating PipelineJob\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob created. Resource name: projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:To use this PipelineJob in another session:\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:pipeline_job = aiplatform.PipelineJob.get('projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523')\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:View Pipeline Job:\n",
-      "https://console.cloud.google.com/vertex-ai/locations/us-central1/pipelines/runs/covertype-vertex-automl-pipeline-20220107224523?project=481343644334\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
-      "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
-      "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
-      "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
-      "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
-      "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
-      "PipelineState.PIPELINE_STATE_RUNNING\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "aiplatform.init(project=PROJECT, location=REGION)\n",
     "\n",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "**Learning Objectives:**\n",
     "1. Learn how to use Vertex AutoML pre-built components\n",
-    "1. Learn how to build a Vertex AutoML pipeline with these components\n",
+    "1. Learn how to build a Vertex AutoML pipeline with these components using BigQuery as a data source\n",
     "1. Learn how to compile, upload, and run the a Vertex AutoML pipeline\n",
     "\n",
     "\n",
@@ -35,8 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from datetime import datetime\n",
-    "\n",
     "from google.cloud import aiplatform"
    ]
   },
@@ -82,7 +80,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Building and deploying the pipeline"
    ]
@@ -129,11 +129,12 @@
     "\n",
     "PIPELINE_ROOT = os.getenv(\"PIPELINE_ROOT\")\n",
     "PROJECT = os.getenv(\"PROJECT\")\n",
-    "DATASET_PATH = os.getenv(\"DATASET_PATH\")\n",
+    "DATASET_SOURCE = os.getenv(\"DATASET_SOURCE\")\n",
     "PIPELINE_NAME = os.getenv(\"PIPELINE_NAME\", \"covertype\")\n",
     "DISPLAY_NAME = os.getenv(\"MODEL_DISPLAY_NAME\", PIPELINE_NAME)\n",
     "TARGET_COLUMN = os.getenv(\"TARGET_COLUMN\", \"Cover_Type\")\n",
     "SERVING_MACHINE_TYPE = os.getenv(\"SERVING_MACHINE_TYPE\", \"n1-standard-16\")\n",
+    "\n",
     "\n",
     "\n",
     "@dsl.pipeline(\n",
@@ -145,7 +146,7 @@
     "\n",
     "    dataset_create_task = TabularDatasetCreateOp(\n",
     "        display_name=DISPLAY_NAME,\n",
-    "        gcs_source=DATASET_PATH,\n",
+    "        bq_source=DATASET_SOURCE,\n",
     "        project=PROJECT,\n",
     "    )\n",
     "\n",
@@ -183,7 +184,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let stat by defining the environment variables that will be passed to the pipeline compiler:"
+    "Let start by defining the environment variables that will be passed to the pipeline compiler:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ARTIFACT_STORE = f\"gs://{PROJECT}-kfp-artifact-store\"\n",
+    "PIPELINE_ROOT = f\"{ARTIFACT_STORE}/pipeline\"\n",
+    "DATASET_SOURCE = f\"bq://{PROJECT}.covertype_dataset.covertype\"\n",
+    "\n",
+    "%env PIPELINE_ROOT={PIPELINE_ROOT}\n",
+    "%env PROJECT={PROJECT}\n",
+    "%env REGION={REGION}\n",
+    "%env DATASET_SOURCE={DATASET_SOURCE}"
    ]
   },
   {
@@ -223,22 +240,6 @@
    "metadata": {},
    "source": [
     "#### Use the CLI compiler to compile the pipeline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ARTIFACT_STORE = f\"gs://{PROJECT}-kfp-artifact-store\"\n",
-    "PIPELINE_ROOT = f\"{ARTIFACT_STORE}/pipeline\"\n",
-    "DATASET_PATH = f\"{ARTIFACT_STORE}/data/training/dataset.csv\"\n",
-    "\n",
-    "%env PIPELINE_ROOT={PIPELINE_ROOT}\n",
-    "%env PROJECT={PROJECT}\n",
-    "%env REGION={REGION}\n",
-    "%env DATASET_PATH={DATASET_PATH}"
    ]
   },
   {
@@ -346,9 +347,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-6.m86",
+   "name": "tf2-gpu.2-6.m87",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m86"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m87"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
@@ -16,7 +16,7 @@
     "**Learning Objectives:**\n",
     "1. Learn how to use Vertex AutoML pre-built components\n",
     "1. Learn how to build a Vertex AutoML pipeline with these components using BigQuery as a data source\n",
-    "1. Learn how to compile, upload, and run the a Vertex AutoML pipeline\n",
+    "1. Learn how to compile, upload, and run the Vertex AutoML pipeline\n",
     "\n",
     "\n",
     "In this lab, you will build, deploy, and run a Vertex AutoML pipeline that orchestrates the **Vertex AutoML AI** services to train, tune, and deploy a model. "
@@ -183,7 +183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let start by defining the environment variables that will be passed to the pipeline compiler:"
+    "Let's start by defining the environment variables that will be passed to the pipeline compiler:"
    ]
   },
   {
@@ -216,22 +216,6 @@
    "outputs": [],
    "source": [
     "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Note:** In case the artifact store was not created and properly set before hand, you may need\n",
-    "to run in **CloudShell** the following command to allow Vertex AI to access it:\n",
-    "\n",
-    "```\n",
-    "PROJECT=$(gcloud config get-value project)\n",
-    "PROJECT_NUMBER=$(gcloud projects list --filter=\"name=$PROJECT\" --format=\"value(PROJECT_NUMBER)\")\n",
-    "gcloud projects add-iam-policy-binding $PROJECT \\\n",
-    "    --member=\"serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com\" \\\n",
-    "    --role=\"roles/storage.objectAdmin\"\n",
-    "```"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
@@ -83,7 +83,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The workflow implemented by the pipeline is defined using a Python based Domain Specific Language (DSL). The pipeline's DSL is in the `pipeline_vertex/pipeline_prebuilt.py` file that we will generate below.\n",
+    "The workflow implemented by the pipeline is defined using a Python based Domain Specific Language (DSL). The pipeline's DSL is in the `pipeline_vertex/pipeline_vertex_automl.py` file that we will generate below.\n",
     "\n",
     "The pipeline's DSL has been designed to avoid hardcoding any environment specific settings like file paths or connection strings. These settings are provided to the pipeline code through a set of environment variables.\n"
    ]
@@ -106,20 +106,9 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Kubeflow Covertype Pipeline.'"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#%%writefile ./pipeline_vertex/pipeline_vertex_automl.py\n",
+    "%%writefile ./pipeline_vertex/pipeline_vertex_automl.py\n",
     "# Copyright 2021 Google LLC\n",
     "\n",
     "# Licensed under the Apache License, Version 2.0 (the \"License\"); you may not\n",
@@ -134,15 +123,8 @@
     "# express or implied. See the License for the specific language governing\n",
     "# permissions and limitations under the License.\n",
     "\n",
-    "\"\"\"Kubeflow Covertype Pipeline.\"\"\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 74,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\"\"\"Kubeflow Covertype Pipeline.\"\"\"\n",
+    "\n",
     "import os\n",
     "\n",
     "from google_cloud_pipeline_components.aiplatform import (\n",
@@ -261,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -295,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,33 +286,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/data/training/dataset.csv\n"
-     ]
-    }
-   ],
-   "source": [
-    "from kfp.v2 import compiler\n",
-    "\n",
-    "compiler.Compiler().compile(\n",
-    "    pipeline_func=create_pipeline,\n",
-    "    package_path=PIPELINE_JSON,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!dsl-compile-v2 --py pipeline_vertex/pipeline_prebuilt.py --output $PIPELINE_JSON"
+    "!dsl-compile-v2 --py pipeline_vertex/pipeline_vertex_automl.py --output $PIPELINE_JSON"
    ]
   },
   {
@@ -392,43 +352,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/data/training/dataset.csv'"
-      ]
-     },
-     "execution_count": 54,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "DATASET_PATH"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gs://qwiklabs-gcp-04-05130841e161-kfp-artifact-store/data/training/dataset.csv\n"
-     ]
-    }
-   ],
-   "source": [
-    "!gsutil ls $DATASET_PATH"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [
@@ -437,26 +360,22 @@
      "output_type": "stream",
      "text": [
       "INFO:google.cloud.aiplatform.pipeline_jobs:Creating PipelineJob\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob created. Resource name: projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob created. Resource name: projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523\n",
       "INFO:google.cloud.aiplatform.pipeline_jobs:To use this PipelineJob in another session:\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:pipeline_job = aiplatform.PipelineJob.get('projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725')\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:pipeline_job = aiplatform.PipelineJob.get('projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523')\n",
       "INFO:google.cloud.aiplatform.pipeline_jobs:View Pipeline Job:\n",
-      "https://console.cloud.google.com/vertex-ai/locations/us-central1/pipelines/runs/covertype-vertex-automl-pipeline-20220107195725?project=481343644334\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "https://console.cloud.google.com/vertex-ai/locations/us-central1/pipelines/runs/covertype-vertex-automl-pipeline-20220107224523?project=481343644334\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
       "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
       "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
       "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
       "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
       "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
-      "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
-      "PipelineState.PIPELINE_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107195725 current state:\n",
+      "INFO:google.cloud.aiplatform.pipeline_jobs:PipelineJob projects/481343644334/locations/us-central1/pipelineJobs/covertype-vertex-automl-pipeline-20220107224523 current state:\n",
       "PipelineState.PIPELINE_STATE_RUNNING\n"
      ]
     }

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl.ipynb
@@ -136,7 +136,6 @@
     "SERVING_MACHINE_TYPE = os.getenv(\"SERVING_MACHINE_TYPE\", \"n1-standard-16\")\n",
     "\n",
     "\n",
-    "\n",
     "@dsl.pipeline(\n",
     "    name=f\"{PIPELINE_NAME}-vertex-automl-pipeline\",\n",
     "    description=f\"AutoML Vertex Pipeline for {PIPELINE_NAME}\",\n",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/pipeline_vertex_automl.py
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/pipeline_vertex_automl.py
@@ -33,7 +33,6 @@ TARGET_COLUMN = os.getenv("TARGET_COLUMN", "Cover_Type")
 SERVING_MACHINE_TYPE = os.getenv("SERVING_MACHINE_TYPE", "n1-standard-16")
 
 
-
 @dsl.pipeline(
     name=f"{PIPELINE_NAME}-vertex-automl-pipeline",
     description=f"AutoML Vertex Pipeline for {PIPELINE_NAME}",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/pipeline_vertex_automl.py
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/pipeline_vertex_automl.py
@@ -26,11 +26,12 @@ from kfp.v2 import dsl
 
 PIPELINE_ROOT = os.getenv("PIPELINE_ROOT")
 PROJECT = os.getenv("PROJECT")
-DATASET_PATH = os.getenv("DATASET_PATH")
+DATASET_SOURCE = os.getenv("DATASET_SOURCE")
 PIPELINE_NAME = os.getenv("PIPELINE_NAME", "covertype")
 DISPLAY_NAME = os.getenv("MODEL_DISPLAY_NAME", PIPELINE_NAME)
 TARGET_COLUMN = os.getenv("TARGET_COLUMN", "Cover_Type")
 SERVING_MACHINE_TYPE = os.getenv("SERVING_MACHINE_TYPE", "n1-standard-16")
+
 
 
 @dsl.pipeline(
@@ -42,7 +43,7 @@ def create_pipeline():
 
     dataset_create_task = TabularDatasetCreateOp(
         display_name=DISPLAY_NAME,
-        gcs_source=DATASET_PATH,
+        bq_source=DATASET_SOURCE,
         project=PROJECT,
     )
 

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/pipeline_vertex_automl.py
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/pipeline_vertex_automl.py
@@ -1,0 +1,69 @@
+# Copyright 2021 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+
+# https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Kubeflow Covertype Pipeline."""
+
+import os
+
+from google_cloud_pipeline_components.aiplatform import (
+    AutoMLTabularTrainingJobRunOp,
+    EndpointCreateOp,
+    ModelDeployOp,
+    TabularDatasetCreateOp,
+)
+from kfp.v2 import dsl
+
+PIPELINE_ROOT = os.getenv("PIPELINE_ROOT")
+PROJECT = os.getenv("PROJECT")
+DATASET_PATH = os.getenv("DATASET_PATH")
+PIPELINE_NAME = os.getenv("PIPELINE_NAME", "covertype")
+DISPLAY_NAME = os.getenv("MODEL_DISPLAY_NAME", PIPELINE_NAME)
+TARGET_COLUMN = os.getenv("TARGET_COLUMN", "Cover_Type")
+SERVING_MACHINE_TYPE = os.getenv("SERVING_MACHINE_TYPE", "n1-standard-16")
+
+
+@dsl.pipeline(
+    name=f"{PIPELINE_NAME}-vertex-automl-pipeline",
+    description=f"AutoML Vertex Pipeline for {PIPELINE_NAME}",
+    pipeline_root=PIPELINE_ROOT,
+)
+def create_pipeline():
+
+    dataset_create_task = TabularDatasetCreateOp(
+        display_name=DISPLAY_NAME,
+        gcs_source=DATASET_PATH,
+        project=PROJECT,
+    )
+
+    automl_training_task = AutoMLTabularTrainingJobRunOp(
+        project=PROJECT,
+        display_name=DISPLAY_NAME,
+        optimization_prediction_type="classification",
+        dataset=dataset_create_task.outputs["dataset"],
+        target_column=TARGET_COLUMN,
+    )
+
+    endpoint_create_task = EndpointCreateOp(
+        project=PROJECT,
+        display_name=DISPLAY_NAME,
+    )
+
+    model_deploy_task = ModelDeployOp(  # pylint: disable=unused-variable
+        model=automl_training_task.outputs["model"],
+        endpoint=endpoint_create_task.outputs["endpoint"],
+        deployed_model_display_name=DISPLAY_NAME,
+        dedicated_resources_machine_type=SERVING_MACHINE_TYPE,
+        dedicated_resources_min_replica_count=1,
+        dedicated_resources_max_replica_count=1,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ google-cloud-aiplatform==1.7.1
 google-cloud-pipeline-components==0.2.1
 kfp==1.8.10
 tfx==1.4.0
+pre-commit


### PR DESCRIPTION
This PR implements the solution for a Vertex AutoML pipeline on the covertype dataset taking its data source from BiqQuery.

Please test and review!

**Testing notes:** You'll need to run the [kubeflow walkthrough lab](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb) solution first to create the bq table this lab needs as data source. To install the MLOps dependencies type `make install` on the JupyterLab terminal at the repo top-level. Then run the two following scripts in `./scripts` in **CloudShell** (not in the JupyterLab terminal):
* [./scripts/enable_services.sh](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/scripts/enable_services.sh)
* [./scripts/setup_cloud_build_for_mlops_vertex.sh](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/scripts/setup_cloud_build_for_mlops_vertex.sh)
