### PR TITLE
Fix model evaluator bug in tfx pipeline

### DIFF
--- a/notebooks/tfx_pipelines/pipeline/solutions/pipeline_vertex/config.py
+++ b/notebooks/tfx_pipelines/pipeline/solutions/pipeline_vertex/config.py
@@ -39,6 +39,7 @@ class Config:
         f"--temp_location={os.path.join(PIPELINE_ROOT, 'beam')}",
         f"--region={REGION}",
         "--runner=DataflowRunner",
+        "--experiments=use_runner_v2"
     ]
 
     ENABLE_CACHE = bool(os.getenv("ENABLE_CACHE", "False"))

--- a/notebooks/tfx_pipelines/pipeline/solutions/pipeline_vertex/config.py
+++ b/notebooks/tfx_pipelines/pipeline/solutions/pipeline_vertex/config.py
@@ -39,7 +39,7 @@ class Config:
         f"--temp_location={os.path.join(PIPELINE_ROOT, 'beam')}",
         f"--region={REGION}",
         "--runner=DataflowRunner",
-        "--experiments=use_runner_v2"
+        "--experiments=use_runner_v2",
     ]
 
     ENABLE_CACHE = bool(os.getenv("ENABLE_CACHE", "False"))


### PR DESCRIPTION
Adding an argument to `BEAM_DIRECT_PIPELINE_ARGS` in the `config.py` to explicitly use Dataflow runner v2 fixes the failing model evaluator component.