### PR TITLE
Updating keras_for_text_classification notebook with preprocessing layers

### DIFF
--- a/notebooks/text_models/solutions/keras_for_text_classification.ipynb
+++ b/notebooks/text_models/solutions/keras_for_text_classification.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,9 +40,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The google.cloud.bigquery extension is already loaded. To reload it, use:\n",
+      "  %reload_ext google.cloud.bigquery\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext google.cloud.bigquery"
    ]
@@ -56,9 +65,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: PROJECT=sanjana-sandbox-306423\n",
+      "env: BUCKET=sanjana-sandbox-306423\n",
+      "env: REGION=\"us-central1\"\n"
+     ]
+    }
+   ],
    "source": [
     "PROJECT = !(gcloud config get-value core/project)\n",
     "PROJECT = PROJECT[0]\n",
@@ -81,9 +100,139 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Query complete after 0.01s: 100%|██████████| 2/2 [00:00<00:00, 316.85query/s]                         \n",
+      "Downloading: 100%|██████████| 10/10 [00:01<00:00,  9.38rows/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>url</th>\n",
+       "      <th>title</th>\n",
+       "      <th>score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>http://www.dumpert.nl/mediabase/6560049/3eb18e...</td>\n",
+       "      <td>Calling the NSA: \"I accidentally deleted an e-...</td>\n",
+       "      <td>258</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>http://blog.liip.ch/archive/2013/10/28/hhvm-an...</td>\n",
+       "      <td>Amazing performance with HHVM and PHP with a S...</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>http://www.gamedev.net/page/resources/_/techni...</td>\n",
+       "      <td>A Journey Through the CPU Pipeline</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>http://jfarcand.wordpress.com/2011/02/25/atmos...</td>\n",
+       "      <td>Atmosphere Framework 0.7 released: GWT, Wicket...</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>http://tech.gilt.com/post/90578399884/immutabl...</td>\n",
+       "      <td>Immutable Infrastructure with Docker and EC2 [...</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>http://thechangelog.com/post/501053444/episode...</td>\n",
+       "      <td>Changelog 0.2.0 - node.js w/Felix Geisendorfer</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>http://openangelforum.com/2010/09/09/second-bo...</td>\n",
+       "      <td>Second Open Angel Forum in Boston Oct 13th--fr...</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>http://bredele.github.io/async</td>\n",
+       "      <td>A collection of JavaScript asynchronous patterns</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>http://www.smashingmagazine.com/2007/08/25/20-...</td>\n",
+       "      <td>20 Free and Fresh Icon Sets</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>http://www.cio.com/article/147801/Study_Finds_...</td>\n",
+       "      <td>Study: Only 1 in 5 Workers is \"Engaged\" in The...</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                 url  \\\n",
+       "0  http://www.dumpert.nl/mediabase/6560049/3eb18e...   \n",
+       "1  http://blog.liip.ch/archive/2013/10/28/hhvm-an...   \n",
+       "2  http://www.gamedev.net/page/resources/_/techni...   \n",
+       "3  http://jfarcand.wordpress.com/2011/02/25/atmos...   \n",
+       "4  http://tech.gilt.com/post/90578399884/immutabl...   \n",
+       "5  http://thechangelog.com/post/501053444/episode...   \n",
+       "6  http://openangelforum.com/2010/09/09/second-bo...   \n",
+       "7                     http://bredele.github.io/async   \n",
+       "8  http://www.smashingmagazine.com/2007/08/25/20-...   \n",
+       "9  http://www.cio.com/article/147801/Study_Finds_...   \n",
+       "\n",
+       "                                               title  score  \n",
+       "0  Calling the NSA: \"I accidentally deleted an e-...    258  \n",
+       "1  Amazing performance with HHVM and PHP with a S...     11  \n",
+       "2                 A Journey Through the CPU Pipeline     11  \n",
+       "3  Atmosphere Framework 0.7 released: GWT, Wicket...     11  \n",
+       "4  Immutable Infrastructure with Docker and EC2 [...     11  \n",
+       "5     Changelog 0.2.0 - node.js w/Felix Geisendorfer     11  \n",
+       "6  Second Open Angel Forum in Boston Oct 13th--fr...     11  \n",
+       "7   A collection of JavaScript asynchronous patterns     11  \n",
+       "8                        20 Free and Fresh Icon Sets     11  \n",
+       "9  Study: Only 1 in 5 Workers is \"Engaged\" in The...     11  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%bigquery --project $PROJECT\n",
     "\n",
@@ -107,9 +256,125 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Query complete after 0.00s: 100%|██████████| 3/3 [00:00<00:00, 1318.13query/s]                        \n",
+      "Downloading: 100%|██████████| 100/100 [00:01<00:00, 87.94rows/s] \n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>source</th>\n",
+       "      <th>num_articles</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>blogspot</td>\n",
+       "      <td>41386</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>github</td>\n",
+       "      <td>36525</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>techcrunch</td>\n",
+       "      <td>30891</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>youtube</td>\n",
+       "      <td>30848</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>nytimes</td>\n",
+       "      <td>28787</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>f5</td>\n",
+       "      <td>1254</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>gamasutra</td>\n",
+       "      <td>1249</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>cnbc</td>\n",
+       "      <td>1229</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>indiatimes</td>\n",
+       "      <td>1223</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>computerworlduk</td>\n",
+       "      <td>1166</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             source  num_articles\n",
+       "0          blogspot         41386\n",
+       "1            github         36525\n",
+       "2        techcrunch         30891\n",
+       "3           youtube         30848\n",
+       "4           nytimes         28787\n",
+       "..              ...           ...\n",
+       "95               f5          1254\n",
+       "96        gamasutra          1249\n",
+       "97             cnbc          1229\n",
+       "98       indiatimes          1223\n",
+       "99  computerworlduk          1166\n",
+       "\n",
+       "[100 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%bigquery --project $PROJECT\n",
     "\n",
@@ -136,9 +401,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "SELECT \n",
+      "    LOWER(REGEXP_REPLACE(title, '[^a-zA-Z0-9 $.-]', ' ')) AS title,\n",
+      "    source\n",
+      "FROM\n",
+      "  (\n",
+      "SELECT\n",
+      "    title,\n",
+      "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[OFFSET(1)] AS source\n",
+      "    \n",
+      "FROM\n",
+      "    `bigquery-public-data.hacker_news.stories`\n",
+      "WHERE\n",
+      "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
+      "    AND LENGTH(title) > 10\n",
+      ")\n",
+      "WHERE (source = 'github' OR source = 'nytimes' OR source = 'techcrunch')\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "regex = \".*://(.[^/]+)/\"\n",
     "\n",
@@ -176,15 +466,84 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For ML training, we usually need to split our dataset into training and evaluation datasets (and perhaps an independent test dataset if we are going to do model or feature selection based on the evaluation dataset). AutoML however figures out on its own how to create these splits, so we won't need to do that here. \n",
+    "For ML training, we usually need to split our dataset into training and evaluation datasets (and perhaps an independent test dataset if we are going to do model or feature selection based on the evaluation dataset).\n",
     "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>title</th>\n",
+       "      <th>source</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>feminist-software-foundation complains about r...</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>expose sps as web services on the fly.</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>show hn  scrwl   shorthand code reading and wr...</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>geoip module on nodejs now is a c   addon</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>show hn  linuxexplorer</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               title  source\n",
+       "0  feminist-software-foundation complains about r...  github\n",
+       "1             expose sps as web services on the fly.  github\n",
+       "2  show hn  scrwl   shorthand code reading and wr...  github\n",
+       "3          geoip module on nodejs now is a c   addon  github\n",
+       "4                             show hn  linuxexplorer  github"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "bq = bigquery.Client(project=PROJECT)\n",
     "title_dataset = bq.query(query).to_dataframe()\n",
@@ -192,22 +551,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "AutoML for text classification requires that\n",
-    "* the dataset be in csv form with \n",
-    "* the first column being the texts to classify or a GCS path to the text \n",
-    "* the last colum to be the text labels\n",
-    "\n",
-    "The dataset we pulled from BiqQuery satisfies these requirements."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The full dataset contains 96203 titles\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"The full dataset contains {len(title_dataset)} titles\")"
    ]
@@ -221,9 +576,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "github        36525\n",
+       "techcrunch    30891\n",
+       "nytimes       28787\n",
+       "Name: source, dtype: int64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "title_dataset.source.value_counts()"
    ]
@@ -234,14 +603,12 @@
    "source": [
     "Finally we will save our data, which is currently in-memory, to disk.\n",
     "\n",
-    "We will create a csv file containing the full dataset and another containing only 1000 articles for development.\n",
-    "\n",
-    "**Note:** It may take a long time to train AutoML on the full dataset, so we recommend to use the sample dataset for the purpose of learning the tool. \n"
+    "We will create a csv file containing the full dataset and store it the `data` folder."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,60 +639,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's sample 1000 articles from the full dataset and make sure we have enough examples for each label in our sample dataset (see [here](https://cloud.google.com/natural-language/automl/docs/beginners-guide) for further details on how to prepare data for AutoML)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sample_title_dataset = title_dataset.sample(n=1000)\n",
-    "sample_title_dataset.source.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's write the sample datatset to disk."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SAMPLE_DATASET_NAME = \"titles_sample.csv\"\n",
-    "SAMPLE_DATASET_PATH = os.path.join(DATADIR, SAMPLE_DATASET_NAME)\n",
+    "## Text Classification\n",
     "\n",
-    "sample_title_dataset.to_csv(\n",
-    "    SAMPLE_DATASET_PATH, header=False, index=False, encoding=\"utf-8\"\n",
-    ")"
+    "Now that we have the data as a csv file let's start by "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "sample_title_dataset.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.8.1\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import shutil\n",
     "\n",
     "import pandas as pd\n",
     "import tensorflow as tf\n",
+    "from keras import Input\n",
+    "from keras.layers import TextVectorization\n",
     "from tensorflow.keras.callbacks import EarlyStopping, TensorBoard\n",
     "from tensorflow.keras.layers import (\n",
     "    GRU,\n",
@@ -345,7 +684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,9 +724,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>title</th>\n",
+       "      <th>source</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>gocircuit  simple language-agnostic cluster pr...</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>the best questions we got while raising ventur...</td>\n",
+       "      <td>techcrunch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>andreessen horowitz brings on londoner benedic...</td>\n",
+       "      <td>techcrunch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>a open source minimalist hn reader</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>zurb launches foundation 3 to take on twitter ...</td>\n",
+       "      <td>techcrunch</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               title      source\n",
+       "0  gocircuit  simple language-agnostic cluster pr...      github\n",
+       "1  the best questions we got while raising ventur...  techcrunch\n",
+       "2  andreessen horowitz brings on londoner benedic...  techcrunch\n",
+       "3                 a open source minimalist hn reader      github\n",
+       "4  zurb launches foundation 3 to take on twitter ...  techcrunch"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "DATASET_NAME = \"titles_full.csv\"\n",
     "TITLE_SAMPLE_PATH = os.path.join(DATA_DIR, DATASET_NAME)\n",
@@ -398,108 +806,25 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Integerize the texts"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The first thing we need to do is to find how many words we have in our dataset (`VOCAB_SIZE`), how many titles we have (`DATASET_SIZE`), and what the maximum length of the titles we have (`MAX_LEN`) is. Keras offers the `Tokenizer` class in its `keras.preprocessing.text` module to help us with that:"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "tokenizer = Tokenizer()\n",
-    "tokenizer.fit_on_texts(titles_df.title)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "integerized_titles = tokenizer.texts_to_sequences(titles_df.title)\n",
-    "integerized_titles[:3]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "VOCAB_SIZE = len(tokenizer.index_word)\n",
-    "VOCAB_SIZE"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DATASET_SIZE = tokenizer.document_count\n",
-    "DATASET_SIZE"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MAX_LEN = max(len(sequence) for sequence in integerized_titles)\n",
-    "MAX_LEN"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's now implement a function `create_sequence` that will \n",
-    "* take as input our titles as well as the maximum sentence length and \n",
-    "* returns a list of the integers corresponding to our tokens padded to the sentence maximum length\n",
-    "\n",
-    "Keras has the helper functions `pad_sequence` for that on the top of the tokenizer methods."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO 1\n",
-    "def create_sequences(texts, max_len=MAX_LEN):\n",
-    "    sequences = tokenizer.texts_to_sequences(texts)\n",
-    "    padded_sequences = pad_sequences(sequences, max_len, padding=\"post\")\n",
-    "    return padded_sequences"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sequences = create_sequences(titles_df.title[:3])\n",
-    "sequences"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0        github\n",
+       "1    techcrunch\n",
+       "2    techcrunch\n",
+       "3        github\n",
+       "Name: source, dtype: object"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "titles_df.source[:4]"
    ]
@@ -517,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -527,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,9 +865,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[1., 0., 0.],\n",
+       "       [0., 0., 1.],\n",
+       "       [0., 0., 1.],\n",
+       "       [1., 0., 0.]], dtype=float32)"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "encode_labels(titles_df.source[:4])"
    ]
@@ -563,10 +902,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
+    "DATASET_SIZE = titles_df.shape[0]\n",
     "N_TRAIN = int(DATASET_SIZE * 0.80)\n",
     "\n",
     "titles_train, sources_train = (\n",
@@ -593,18 +933,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "github        29138\n",
+       "techcrunch    24776\n",
+       "nytimes       23048\n",
+       "Name: source, dtype: int64"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sources_train.value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "github        7387\n",
+       "techcrunch    6115\n",
+       "nytimes       5739\n",
+       "Name: source, dtype: int64"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sources_valid.value_counts()"
    ]
@@ -613,39 +981,246 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using `create_sequence` and `encode_labels`, we can now prepare the\n",
-    "training and validation data to feed our models.\n",
-    "\n",
-    "The features will be\n",
-    "padded list of integers and the labels will be one-hot-encoded 3D vectors."
+    "Using `encode_labels` function, we can now prepare the\n",
+    "training and validation data to feed our models. The labels will be one-hot-encoded 3D vectors."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train, Y_train = create_sequences(titles_train), encode_labels(sources_train)\n",
-    "X_valid, Y_valid = create_sequences(titles_valid), encode_labels(sources_valid)"
+    "Y_train = encode_labels(sources_train)\n",
+    "Y_valid = encode_labels(sources_valid)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "X_train[:3]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[1., 0., 0.],\n",
+       "       [0., 0., 1.],\n",
+       "       [0., 0., 1.]], dtype=float32)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Y_train[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Keras Text Preprocessing Layer\n",
+    "\n",
+    "Before we start passing data to the model, we need to preprocess the text. Using Keras preprocessing layers we can now include this in the model directly.\n",
+    "\n",
+    "The preprocessing that we will be doing:\n",
+    "- Tokenizing the text\n",
+    "- Integerizing the tokens"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At instanciation, we can specify the maximum length of the sequence output as well as the maximum number of tokens to be considered"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAX_LEN = 26\n",
+    "MAX_TOKENS = 20000\n",
+    "VOCAB_SIZE = 47271\n",
+    "preprocessing_layer = TextVectorization(\n",
+    "    output_sequence_length=MAX_LEN, max_tokens=MAX_TOKENS\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before using this layer in our model, we need to adapt it to our data so that it generates a token-to-integer mapping. Remeber our dataset looks like the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>title</th>\n",
+       "      <th>source</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>gocircuit  simple language-agnostic cluster pr...</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>the best questions we got while raising ventur...</td>\n",
+       "      <td>techcrunch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>andreessen horowitz brings on londoner benedic...</td>\n",
+       "      <td>techcrunch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>a open source minimalist hn reader</td>\n",
+       "      <td>github</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>zurb launches foundation 3 to take on twitter ...</td>\n",
+       "      <td>techcrunch</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               title      source\n",
+       "0  gocircuit  simple language-agnostic cluster pr...      github\n",
+       "1  the best questions we got while raising ventur...  techcrunch\n",
+       "2  andreessen horowitz brings on londoner benedic...  techcrunch\n",
+       "3                 a open source minimalist hn reader      github\n",
+       "4  zurb launches foundation 3 to take on twitter ...  techcrunch"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "titles_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can directly use the Pandas Series corresponding to the titles in our dataset to adapt the data using the `adapt` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preprocessing_layer.adapt(titles_df.title)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, the preprocessing layer can create the integer representation of our input text if we simply apply the layer to it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    gocircuit  simple language-agnostic cluster pr...\n",
+       "1    the best questions we got while raising ventur...\n",
+       "2    andreessen horowitz brings on londoner benedic...\n",
+       "3                   a open source minimalist hn reader\n",
+       "4    zurb launches foundation 3 to take on twitter ...\n",
+       "Name: title, dtype: object"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_train, X_valid = titles_train, titles_valid\n",
+    "X_train[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(5, 26), dtype=int64, numpy=\n",
+       "array([[    1,    47, 13066,  1518,   163,     0,     0,     0,     0,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "       [    2,   233,   513,    98,   603,   926,   834,   355,   396,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "       [  842,  1183,   296,    10,     1, 13886,     1,     0,     0,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "       [    4,    42,    61,  1532,    13,   517,     0,     0,     0,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "       [10451,    45,  1372,   194,     3,   205,    10,    35,     9,\n",
+       "          335,    76,     0,     0,     0,     0,     0,     0,     0,\n",
+       "            0,     0,     0,     0,     0,     0,     0,     0]])>"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "integers = preprocessing_layer(X_train[:5])\n",
+    "integers"
    ]
   },
   {
@@ -667,7 +1242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,6 +1250,8 @@
     "\n",
     "    model = Sequential(\n",
     "        [\n",
+    "            Input(shape=(1,), dtype=tf.string),\n",
+    "            preprocessing_layer,\n",
     "            Embedding(\n",
     "                VOCAB_SIZE + 1, embed_dim, input_shape=[MAX_LEN]\n",
     "            ),  # TODO 3\n",
@@ -698,9 +1275,114 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/100\n",
+      "257/257 [==============================] - 4s 13ms/step - loss: 1.0489 - accuracy: 0.4293 - val_loss: 0.9808 - val_accuracy: 0.5647\n",
+      "Epoch 2/100\n",
+      "257/257 [==============================] - 3s 12ms/step - loss: 0.8954 - accuracy: 0.6694 - val_loss: 0.8143 - val_accuracy: 0.7317\n",
+      "Epoch 3/100\n",
+      "257/257 [==============================] - 3s 12ms/step - loss: 0.7470 - accuracy: 0.7658 - val_loss: 0.6947 - val_accuracy: 0.7686\n",
+      "Epoch 4/100\n",
+      "257/257 [==============================] - 3s 12ms/step - loss: 0.6416 - accuracy: 0.7961 - val_loss: 0.6088 - val_accuracy: 0.7989\n",
+      "Epoch 5/100\n",
+      "257/257 [==============================] - 3s 12ms/step - loss: 0.5638 - accuracy: 0.8157 - val_loss: 0.5469 - val_accuracy: 0.8112\n",
+      "Epoch 6/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.5066 - accuracy: 0.8287 - val_loss: 0.5024 - val_accuracy: 0.8199\n",
+      "Epoch 7/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.4641 - accuracy: 0.8393 - val_loss: 0.4697 - val_accuracy: 0.8256\n",
+      "Epoch 8/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.4317 - accuracy: 0.8478 - val_loss: 0.4452 - val_accuracy: 0.8334\n",
+      "Epoch 9/100\n",
+      "257/257 [==============================] - 3s 11ms/step - loss: 0.4060 - accuracy: 0.8552 - val_loss: 0.4266 - val_accuracy: 0.8386\n",
+      "Epoch 10/100\n",
+      "257/257 [==============================] - 3s 12ms/step - loss: 0.3851 - accuracy: 0.8607 - val_loss: 0.4117 - val_accuracy: 0.8408\n",
+      "Epoch 11/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.3676 - accuracy: 0.8656 - val_loss: 0.4001 - val_accuracy: 0.8442\n",
+      "Epoch 12/100\n",
+      "257/257 [==============================] - 3s 14ms/step - loss: 0.3525 - accuracy: 0.8706 - val_loss: 0.3910 - val_accuracy: 0.8451\n",
+      "Epoch 13/100\n",
+      "257/257 [==============================] - 3s 12ms/step - loss: 0.3394 - accuracy: 0.8749 - val_loss: 0.3829 - val_accuracy: 0.8479\n",
+      "Epoch 14/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.3279 - accuracy: 0.8790 - val_loss: 0.3768 - val_accuracy: 0.8498\n",
+      "Epoch 15/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.3175 - accuracy: 0.8828 - val_loss: 0.3717 - val_accuracy: 0.8507\n",
+      "Epoch 16/100\n",
+      "257/257 [==============================] - 4s 14ms/step - loss: 0.3081 - accuracy: 0.8856 - val_loss: 0.3675 - val_accuracy: 0.8532\n",
+      "Epoch 17/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.2995 - accuracy: 0.8892 - val_loss: 0.3642 - val_accuracy: 0.8527\n",
+      "Epoch 18/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.2914 - accuracy: 0.8918 - val_loss: 0.3620 - val_accuracy: 0.8531\n",
+      "Epoch 19/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.2841 - accuracy: 0.8943 - val_loss: 0.3594 - val_accuracy: 0.8540\n",
+      "Epoch 20/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.2771 - accuracy: 0.8974 - val_loss: 0.3579 - val_accuracy: 0.8544\n",
+      "Epoch 21/100\n",
+      "257/257 [==============================] - 4s 15ms/step - loss: 0.2708 - accuracy: 0.8991 - val_loss: 0.3579 - val_accuracy: 0.8545\n",
+      "Epoch 22/100\n",
+      "257/257 [==============================] - 4s 14ms/step - loss: 0.2648 - accuracy: 0.9015 - val_loss: 0.3565 - val_accuracy: 0.8546\n",
+      "Epoch 23/100\n",
+      "257/257 [==============================] - 4s 14ms/step - loss: 0.2591 - accuracy: 0.9032 - val_loss: 0.3567 - val_accuracy: 0.8537\n",
+      "Epoch 24/100\n",
+      "257/257 [==============================] - 4s 14ms/step - loss: 0.2536 - accuracy: 0.9049 - val_loss: 0.3566 - val_accuracy: 0.8550\n",
+      "Epoch 25/100\n",
+      "257/257 [==============================] - 4s 14ms/step - loss: 0.2486 - accuracy: 0.9071 - val_loss: 0.3574 - val_accuracy: 0.8531\n",
+      "Epoch 26/100\n",
+      "257/257 [==============================] - 3s 13ms/step - loss: 0.2438 - accuracy: 0.9089 - val_loss: 0.3580 - val_accuracy: 0.8550\n",
+      "Epoch 27/100\n",
+      "257/257 [==============================] - 4s 14ms/step - loss: 0.2393 - accuracy: 0.9108 - val_loss: 0.3590 - val_accuracy: 0.8542\n",
+      "Model: \"sequential_5\"\n",
+      "_________________________________________________________________\n",
+      " Layer (type)                Output Shape              Param #   \n",
+      "=================================================================\n",
+      " text_vectorization_2 (TextV  (None, 26)               0         \n",
+      " ectorization)                                                   \n",
+      "                                                                 \n",
+      " embedding_5 (Embedding)     (None, 26, 10)            472720    \n",
+      "                                                                 \n",
+      " lambda_5 (Lambda)           (None, 10)                0         \n",
+      "                                                                 \n",
+      " dense_5 (Dense)             (None, 3)                 33        \n",
+      "                                                                 \n",
+      "=================================================================\n",
+      "Total params: 472,753\n",
+      "Trainable params: 472,753\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n",
+      "CPU times: user 3min, sys: 2min 44s, total: 5min 45s\n",
+      "Wall time: 1min 31s\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAwQUlEQVR4nO3deXxU9b3/8ddnJvseyEpCSAJhDQgaQFQiKiDYVtyqoHXBVsq12uVWq2311rZ629vetrf96a2XWrcWBepuXcBaLeIGAcIS1piwZCEbZN+T7++PM4QkZBlgkslMPs/HYx4z53vOTD6HefDOyfd8z/eIMQallFKez+buApRSSrmGBrpSSnkJDXSllPISGuhKKeUlNNCVUspL+LjrB0dFRZnk5GR3/XillPJIW7duLTfGRPe0zm2BnpycTFZWlrt+vFJKeSQROdzbOu1yUUopL6GBrpRSXkIDXSmlvITb+tCVUsNTS0sLBQUFNDY2uruUIS0gIIDExER8fX2dfo8GulJqUBUUFBAaGkpycjIi4u5yhiRjDBUVFRQUFJCSkuL0+7TLRSk1qBobGxk5cqSGeR9EhJEjR57xXzEa6EqpQadh3r+z+TfyuEA/WFLDz/++h6bWNneXopRSQ4rHBXrBiQb+vCmfT7+ocHcpSikPFRIS4u4SBoTHBfqcsSMJ9rOzYU+Ju0tRSqkhxeMCPcDXzrwJMby3p4T2dr3bklLq7BljuP/++0lPT2fq1KmsXbsWgOLiYjIzM5k+fTrp6el89NFHtLW1cccdd3Rs+7vf/c7N1Z/OI4ctLpwSy1u7iskuqOT8pEh3l6OUOks/fTOHPUXVLv3MyaPC+MlXpji17SuvvEJ2djY7duygvLycmTNnkpmZyQsvvMCVV17Jj3/8Y9ra2qivryc7O5vCwkJ2794NQGVlpUvrdgWPO0IHmDchBh+bsCFHu12UUmdv06ZNLFu2DLvdTmxsLJdeeilbtmxh5syZPPPMMzzyyCPs2rWL0NBQUlNTycvL49577+Xdd98lLCzM3eWfxiOP0MMDfZkzdiQb9hzjwcUT3V2OUuosOXskPVCM6bnbNjMzk40bN/LWW29x6623cv/993PbbbexY8cO1q9fzxNPPMG6det4+umnB7nivnnkETrAwsmx5JXVkVta6+5SlFIeKjMzk7Vr19LW1kZZWRkbN25k1qxZHD58mJiYGO666y6+/vWvs23bNsrLy2lvb+f666/n5z//Odu2bXN3+afxyCN0gPmTY3n49Rw27DnGuJhx7i5HKeWBrr32Wj799FPOO+88RIRf/epXxMXF8dxzz/HrX/8aX19fQkJCeP755yksLGT58uW0t7cD8Itf/MLN1Z9OevuTY6BlZGSYc73BxZLHNyEivPati11UlVJqoO3du5dJkya5uwyP0NO/lYhsNcZk9LR9v10uIvK0iJSKyO5e1ouI/EFEckVkp4icf1aVn4WFU+LIPlpJSbXO2qaUUs70oT8LLOpj/WIgzfFYAfzx3MtyzsLJsQC8pxcZKaVU/4FujNkIHO9jkyXA88byGRAhIvGuKrAv42JCSIkK1qtGlVIK14xySQCOdloucLSdRkRWiEiWiGSVlZWd8w8WERZOjuXTL8qpbmw5589TSilP5opA72mOxx7PtBpjVhljMowxGdHR0S740dZVoy1thg/3n/svCKWU8mSuCPQCYHSn5USgyAWf65TpoyOJCvFnQ86xwfqRSik1JLki0N8AbnOMdrkQqDLGFLvgc3vnGAcKYLcJCybH8OH+Mp0jXSk1rDkzbPFF4FNggogUiMjXRWSliKx0bPI2kAfkAn8C7h6wagH2vQX/nQY1p06ELpwcR21Tq86RrpRyub7mTj906BDp6emDWE3f+r1S1BizrJ/1BviWyyrqT/hoqC+H3H/AjFuArnOkz5sQM2ilKKXUUOJ5l/7HTYWQOMh9ryPQT86R/o89JTy6JB2bTe9XqJRHeOdBOLbLtZ8ZNxUW/7LX1Q888ABjxozh7rutzoRHHnkEEWHjxo2cOHGClpYWHn30UZYsWXJGP7axsZF/+7d/IysrCx8fH377299y2WWXkZOTw/Lly2lubqa9vZ2XX36ZUaNGceONN1JQUEBbWxsPP/wwN9100zntNnji5FwikDYfcv8Jba0dzQsmx1Ja08SOgkr31aaUGvKWLl3acSMLgHXr1rF8+XJeffVVtm3bxgcffMD3v//9Xmdi7M0TTzwBwK5du3jxxRe5/fbbaWxs5Mknn+Q73/kO2dnZZGVlkZiYyLvvvsuoUaPYsWMHu3fvZtGivq7ddJ7nHaEDpC2E7X+Fgs0w5iIALjs5R/qeEmboTS+U8gx9HEkPlBkzZlBaWkpRURFlZWVERkYSHx/P9773PTZu3IjNZqOwsJCSkhLi4uKc/txNmzZx7733AjBx4kTGjBnDgQMHmDNnDo899hgFBQVcd911pKWlMXXqVO677z4eeOABvvzlLzN37lyX7JvnHaEDpM4Dmw8c3NDRFB7ky4WpI3X4olKqXzfccAMvvfQSa9euZenSpaxevZqysjK2bt1KdnY2sbGxNDae2RxRvR3R33zzzbzxxhsEBgZy5ZVX8s9//pPx48ezdetWpk6dyg9/+EN+9rOfuWK3PDTQA8IhaQ4cfK9L88IpsXyhc6QrpfqxdOlS1qxZw0svvcQNN9xAVVUVMTEx+Pr68sEHH3D48OEz/szMzExWr14NwIEDBzhy5AgTJkwgLy+P1NRUvv3tb3P11Vezc+dOioqKCAoK4mtf+xr33Xefy+ZW98xABxg3H0p2Q/Wpa5jmT9LJupRS/ZsyZQo1NTUkJCQQHx/PLbfcQlZWFhkZGaxevZqJE8/8Tmh33303bW1tTJ06lZtuuolnn30Wf39/1q5dS3p6OtOnT2ffvn3cdttt7Nq1i1mzZjF9+nQee+wxHnroIZfsl+fOh16yB/44B77yB7jg9o7mqx/fhN0mvHq3zpGu1FCk86E7z+XzoQ9ZMZMgLLFLPzpYU+puP1JJqc6RrpQaZjw30EUgbQHkfQitzR3NC6dYZ6Xf26vdLkop19i1axfTp0/v8pg9e7a7yzqNZw5bPCltAWx9Bo5+BimZVlNMCMkjg9iQU8Its8e4uUClVE+MMYh4zgWAU6dOJTs7e1B/5tl0h3vuETpAyqVg8+3S7SIiLJwSxydflFOjc6QrNeQEBARQUVFxVoE1XBhjqKioICAg4Ize59lH6P4hkHyxNXxx4aMdzQsnx7JqYx4f7i/jK+eNcmOBSqnuEhMTKSgowBU3ufFmAQEBJCYmntF7PDvQAcYtgA0/hsojEJEEwIykSKJC/Niwp0QDXakhxtfXl5SUFHeX4ZU8u8sFrGkAoMtFRnabMH9SLB/sK9U50pVSw4bnB3pUGkSM6fGq0dqmVj7L6+v+1kop5T2cCnQRWSQi+0UkV0Qe7GF9pIi8KiI7RWSziAzejO8i1lF6/r+g5dTY84vGRhHkZ9e5XZRSw4YzdyyyA08Ai4HJwDIRmdxtsx8B2caYacBtwO9dXWif0hZASz0c/rijyZojPZr39pTQ3q5n05VS3s+ZI/RZQK4xJs8Y0wysAbrP/D4ZeB/AGLMPSBaRWJdW2pfkuWD3t+5i1MnCyXE6R7pSathwJtATgKOdlgscbZ3tAK4DEJFZwBjgzMbbnAu/IEiZe9o0AJ3nSFdKKW/nTKD3dDlX9z6MXwKRIpIN3AtsB1q7v0lEVohIlohkuXwMatpCqMiFii86mk7Okb5e+9GVUsOAM4FeAIzutJwIFHXewBhTbYxZboyZjtWHHg3kd/8gY8wqY0yGMSYjOjr67Kvuybj51nO3bpcrp8SSV1bHwZIa1/48pZQaYpwJ9C1AmoikiIgfsBR4o/MGIhLhWAfwDWCjMabataX2Y+RYGDG2h+GL1mRd7+zWo3SllHfrN9CNMa3APcB6YC+wzhiTIyIrRWSlY7NJQI6I7MMaDfOdgSq4T2kL4dBH0Fzf0RQbFsAFYyJ5VwNdKeXlnBqHbox52xgz3hgz1hjzmKPtSWPMk47Xnxpj0owxE40x1xljTgxk0b1KWwCtjXBoU5fmxelx7Cmu5khFfS9vVEopz+f5V4p2NuZi8A06bbTLlR3dLsXuqEoppQaFdwW6b4A1L3rue9Bpas7RI4JITwjjXR3topTyYt4V6GB1u5w4ZA1h7GRxejzbj1RSXNXgnrqUUmqAeV+gj1tgPXfrdlmUbnW7rNeTo0opL+V9gR45BqImnBboY6NDSIsJ0W4XpZTX8r5AB6vb5fAn0FTbpXlxehyb849TUdvkpsKUUmrgeGmgL4S2Zsjf2KV5UXo87Qad20Up5ZW8M9CT5oBfyGndLpPiQ0kaEaRXjSqlvJJ3BrqPH6TOs6YB6DR8UURYnB7HJ7nlVDW0uK8+pZQaAN4Z6GD1o1cXQNm+Ls2L0uNobTe8v1e7XZRS3sV7A72X4YvnJUYQFxag3S5KKa/jvYEengAxU06bfdFmExalx7HxQBl1TadN2a6UUh7LewMdrG6XI59CY1WX5kXpcTS1tvPhfhffZEMppdzIywN9IbS3Qt6HXZpnJo9gZLCfTtallPIq3h3oo2eBf/hp3S52m7BwSiwf7CulsaXNTcUppZRreXeg231h7GVw4F1o6zpMcVF6PHXNbWw6WO6m4pRSyrWcCnQRWSQi+0UkV0Qe7GF9uIi8KSI7RCRHRJa7vtSzNP1mqCuD/W93aZ6TOpKwAB8d7aKU8hr9BrqI2IEnsG4tNxlYJiKTu232LWCPMeY8YB7wm073GHWvcfMhLBGynunS7OdjY/6kWP6xt4SWtnY3FaeUUq7jzBH6LCDXGJNnjGkG1gBLum1jgFARESAEOA4MjTGBNjucfxvkfQDH87usWpQeR1VDC5/lVbipOKWUch1nAj0BONppucDR1tnjWDeKLgJ2Ad8xxpx22CsiK0QkS0SyysoGccjg+beC2GDbc12aM8dHE+Rn124XpZRXcCbQpYc20235SiAbGAVMBx4XkbDT3mTMKmNMhjEmIzo6+gxLPQdho2D8Itj+V2ht7mgO8LVz2YQYNuQco629+y4ppZRncSbQC4DRnZYTsY7EO1sOvGIsuUA+MNE1JbrIBct7PDm6KD2O8tpmth4+4abClFLKNZwJ9C1AmoikOE50LgXe6LbNEeAKABGJBSYAea4s9JyNuwLCR8PWridHL5sYg5+PTS8yUkp5vH4D3RjTCtwDrAf2AuuMMTkislJEVjo2+zlwkYjsAt4HHjDGDK0B3h0nRz+E46d+14T4+5CZFsX63ccwRrtdlFKey6lx6MaYt40x440xY40xjznanjTGPOl4XWSMWWiMmWqMSTfG/HUgiz5rM74GYoetXU+OLkqPp6iqkZ0FVb28USmlhj7vvlK0u5MnR7NXdzk5umBSLD420dEuSimPNrwCHSDj5MnRtzqawoN8mTN2JO/uLtZuF6WUxxp+gT72csfJ0We7NC9Kj+NQRT37jtW4py6llDpHwy/QbXY4/3br5GjFFx3NCyfHIQLvareLUspDDb9Ah1MnRztdORod6s/M5BEa6EopjzU8Az0sHiYshu1dT44umhLH/pIa8spq3VicUkqdneEZ6AAX3AH15bDv7x1Ni9LjAHh7l15kpJTyPMM30MdeDuFJXU6OjooI5MLUEbzw+RGdUlcp5XGGb6Db7HDBbZD/ry4nR1dkplJU1chbO/UoXSnlWYZvoANMP/3k6LzxMYyLCWHVxjwdk66U8ijDO9B7ODlqswkr5qayp7iaj3P1xhdKKc8xvAMdrGl1u50cXTJjFNGh/qz6aGhNGKmUUn3RQO84OXpqWl1/Hzt3XJTMxgNl7C2udmNxSinlPA10m81xcnRjl5OjX5s9hiA/O3/So3SllIfQQAeYcatjWt1nO5rCg3y5aeZo3sguoriqwX21KaWUk5wKdBFZJCL7RSRXRB7sYf39IpLteOwWkTYRGeH6cgdIaJx1cjR7NbQ2dTTfeXEKBnj240NuK00ppZzVb6CLiB14AlgMTAaWicjkztsYY35tjJlujJkO/BD4lzHm+ADUO3AylkN9RZeTo6NHBHHV1Hhe+PwINY0tbixOKaX658wR+iwg1xiTZ4xpBtYAS/rYfhnwoiuKG1Spl0NEEmR1vefoirmp1DS1smbzUTcVppRSznEm0BOAzmlW4Gg7jYgEAYuAl3tZv0JEskQkq6ys7ExrHVg2mzWt7qGPoDy3o3lqYjhzUkfy9Mf5Oh2AUmpIcybQpYe23i6h/ArwcW/dLcaYVcaYDGNMRnR0tLM1Dp4Zt4LNBzav6tK8IjOV4qpG/r6zyE2FKaVU/5wJ9AJgdKflRKC3ZFuKJ3a3nBQaC9NvgaynuwxhnDchmrSYEP7vXzodgFJq6HIm0LcAaSKSIiJ+WKH9RveNRCQcuBR43bUlDrLLfgx2P/jHTzqaRIS7MlPZd6yGTbnlbixOKaV612+gG2NagXuA9cBeYJ0xJkdEVorIyk6bXgtsMMbUDUypgyQ0Fi75Lux9Ew5/0tG8ZPooYkL9WbVRLzRSSg1NTo1DN8a8bYwZb4wZa4x5zNH2pDHmyU7bPGuMWTpQhQ6qOfdA6ChY/2Not06E+vvYuePiZD46WM6eIp0OQCk19OiVoj3xC4IrHoaibbD71ICdW2aPIdjPzlM6HYBSagjSQO/NtKUQNw3e/ym0WJf+hwf6ctPMJN7YUURRpU4HoJQaWjTQe2OzwZWPQdVR+OyPHc13XpJsTQfwySG3laaUUj3RQO9LSiaMXwwf/RZqrQuhEiOD+JJjOoBqnQ5AKTWEaKD3Z8HPoKUePvxFR9OKzFRqm1pZs/mIGwtTSqmuNND7Ez0eMu60ptYt2w9AekI4F40dydObDtHcqtMBKKWGBg10Z8x7EPyCYcPDHU13ZaZyrFqnA1BKDR0a6M4IjoK534eD6yHvQwDmjY9mQmwoqzbqdABKqaFBA91Zs1da9x5d/xC0tyEifGNuCvuO1bBhT4m7q1NKKQ10p/kGwPyfQMku2LEGgGtmJDAhNpSfvbmH+uZWNxeolBruNNDPRPr1kJAB//w5NNfha7fx6LXpFFY28Pv3D7q7OqXUMKeBfiZE4Mr/hJpi+ORxAGYmj+DGjET+/FE++4/VuLlApdRwpoF+ppJmw+Ql8PHvoeYYAA8unkRogA8PvbaL9nY9QaqUcg8N9LMx/xFoa4Z/PgrAiGA/fnjVJLYcOsFLWwvcW5tSatjSQD8bI1Jh9jdh+1/h2G4Abjg/kZnJkfzinb0cr2t2c4FKqeFIA/1sZd4HgRGw4SEwBptNePSaqdQ0tvLLd/a6uzql1DDkVKCLyCIR2S8iuSLyYC/bzBORbBHJEZF/ubbMISgwEi59API+6JgzfUJcKN+Ym8q6rAI25/d4n2yllBow/Qa6iNiBJ4DFwGRgmYhM7rZNBPC/wNXGmCnAV11f6hA08xsweja8+Z2OeV6+fcU4EiICeei1XbS06TwvSqnB48wR+iwg1xiTZ4xpBtYAS7ptczPwijHmCIAxptS1ZQ5Rdl/46rPgEwBrb4WmWoL8fPjp1VM4UFLLnzflu7tCpdQw4kygJwBHOy0XONo6Gw9EisiHIrJVRG7r6YNEZIWIZIlIVllZ2dlVPNSEjYIbnoaKg/Dmt8EY5k+OZeHkWP7nHwc4erze3RUqpYYJZwJdemjrPtjaB7gA+BJwJfCwiIw/7U3GrDLGZBhjMqKjo8+42CEr9VK4/GGrL33zKgB+cvUUbCL89M0cNxenlBounAn0AmB0p+VEoPucsQXAu8aYOmNMObAROM81JXqIi78LE66C9T+Co5tJiAjku/PT+MfeUjbkHHN3dUqpYcCZQN8CpIlIioj4AUuBN7pt8zowV0R8RCQImA0Mr7F7Nhtc80cIT4R1t0NtGcsvTmFiXCiPvJFDXZNO3qWUGlj9BroxphW4B1iPFdLrjDE5IrJSRFY6ttkLvAvsBDYDTxljdg9c2UNUYATc+BdoOA4v34mvGB67Np2iqkadvEspNeDEXTdnyMjIMFlZWW752QNu+2p4/W7rphhX/AcPvryTv20t4O/3XsKk+DB3V6eU8mAistUYk9HTOr1SdCDMuAXOvx0++g3sf4cHFk0kPNCXh17brZN3KaUGjAb6QFn8K4g/D175JpFNBfzoqklsPXyCdVlH+3+vUkqdBQ30geIbADc+b82hvvY2rp86gtkpI/jPt/dyqLzO3dUppbyQBvpAikyG6/4EJbuRt+/j19dPw24Tvv7cFqoaWtxdnVLKy2igD7TxC+HSH0D2apIOv8STX7uAI8frueeFbbTqXC9KKRfSQB8Mlz4AYy+Ht+9ndsARHrtmKh8dLOdnf9/j7sqUUl5EA30w2Oxw3VMQHA1rb+XGsa2syEzl+U8P8/ynh9xdnVLKS2igD5bgkbDsBWiug6cX8cCMNuZPiuWnb+5h4wEvmahMKeVWGuiDKf48WP4OiA37c1fxh0taSIsJ4VsvbCO3tNbd1SmlPJwG+mCLmQhfXw9BUQStuY6/zKvF38fG15/bwgm9F6lS6hxooLtDRBLc+S6MHEv0G7ex9pISiqsaWfnXrTS36sgXpdTZ0UB3l5AYuOMtSJzJ2A/vYe0F+/k8/zgPv7Ybd82vo5TybBro7hQQDl97GdIWMGPHT3h+/MeszTqqt65TSp0VDXR38wuCpS/A1K+SeeQJ/hT/Oo+9vYf395a4uzKllIfRQB8K7L5w7SqYeRcLTqzl/8Ke47svbmXfsWp3V6aU8iBOBbqILBKR/SKSKyIP9rB+nohUiUi24/Efri/Vy9lscNWvIfMHLGzawO/tv2flM59SXtvk7sqUUh7Cp78NRMQOPAEswLp36BYRecMY0/269Y+MMV8egBqHDxG4/McQGMnl63+If+PPuesp4ck7M4kNC3B3dUqpIc6ZI/RZQK4xJs8Y0wysAZYMbFnD3Jy74Zonuci2h/868e888PhfyS2tcXdVSqkhzplATwA635WhwNHW3RwR2SEi74jIlJ4+SERWiEiWiGSVlenl7n2avgy55W+kBDfxVPMPePd/72NLXqm7q1JKDWHOBLr00NZ9oPQ2YIwx5jzg/wGv9fRBxphVxpgMY0xGdHT0GRU6LI27At97Pqdp/NXcwxr8n1vExo8/dndVSqkhyplALwBGd1pOBIo6b2CMqTbG1Dpevw34ikiUy6oczoJGEHzzs9Re/RTJtjJmbVjC56t/Bu16RalSqitnAn0LkCYiKSLiBywF3ui8gYjEiYg4Xs9yfG6Fq4sdzkLO/yp+3/6c/cEZzD74Gw7/7jLaK/QCJKXUKf0GujGmFbgHWA/sBdYZY3JEZKWIrHRsdgOwW0R2AH8Alhq9ft3lAiJHkf79t3k16UdEVu+n+fE5tGx+GvSfWikFiLtyNyMjw2RlZbnlZ3s6YwyrN3xM8qYfcIk9h5aUK/C99nEIG+Xu0pRSA0xEthpjMnpap1eKeiAR4WtXXkLFdWt5pG05bfkf0f7EhbBznR6tKzWMaaB7sCUzRrPw9oe43vya3c1x8Mpd8OyX4fAn7i5NKeUGGuge7qJxUfz3yutY6fMoj5k7aSrZD88shuevgQLt0lJqONFA9wKT4sN46Vtz+TTqOs6r/BWvx9xNe/FOeOoKWH0jFGW7u0Sl1CDQQPcSoyICefXui/nmFen8e8FcLm/9PXnTvg9HP4dVl8KaW6Akx91lKqUGkAa6F/G12/jegvG8dvfF+AaGcfnmC3hk7Is0XfIA5G+EP14Mf1sOZQfcXapSagBooHuhqYnhvHnvJXzz0lSe23aCK7ZeyOYlH8Dcf4cD6+F/Z8Mr34SKL9xdqlLKhTTQvVSAr50fLp7ESyvn4GMTbnx+P4/UXU/D3dthzrdgz+vweAb89QbrdWuzu0tWSp0jvbBoGGhobuO/3t3Hs58cIiUqmP/+6jQuGNEMW56C7auhpgiCouC8pXD+bRA9wd0lK6V60deFRRrow8gnX5Rz/992UlzVwF2ZqXxv/ngC7EDu+7D9edj/DrS3QuIsK9inXAv+Ie4uWynViQa66lDT2MJ/vr2XFzcfZVxMCD++ahLzJkQjIlBbCjvWwPa/QPkB8AuB9Otgxm2QmGHdUUkp5VYa6Oo0H+wv5Sev53DkeD2zUkbw4OKJnJ8Uaa00Bo5uhm3PQ84r0FIP0RPhvGUw8csQNc69xSs1jGmgqx41t7azZssR/vD+Qcprm1k4OZYfLJrAuJjQUxs1Vluhvu0vUOj4vqLGw8QvwYQvQcIF1g2ulVKDQgNd9amuqZU/b8pn1cY86ptbueGCRL47fzyjIgK7blh5xOpn3/cWHNoEpg1CYmHCYivcUzLBV29mrdRA0kBXTqmobeKJD77gr58dBoE7Lkrm7nljiQjyO33jhhNw8D0r3HP/Ac214BsM466wjt7TFkLQiMHfCaW8nAa6OiNHj9fzu38c4NXthYT4+/Bv88ay/KIUAv3sPb+htQnyP4J9f7eO4GuPgdgh4XwYcxGMuQSSZkNA+ODuiFJe6JwDXUQWAb8H7MBTxphf9rLdTOAz4CZjzEt9faYG+tC371g1v353P+/vKyU2zJ9vXTaOGy5IJMjPp/c3tbdD0XbY/7bVLVO4FdpbQGwQmw5jLobkiyHpIggeOXg7o5SXOKdAFxE7cABYgHXD6C3AMmPMnh62ew9oBJ7WQPceWw4d57/e2UfW4ROEBfiwbHYSt81JJqF7H3tPmuutk6mHP7ECvmALtDZa66InOo7gL7ae9Y5LSvXrXAN9DvCIMeZKx/IPAYwxv+i23XeBFmAm8HcNdO9ijGHr4RM88/Eh3tldjIiwaEocd16SzPlJkYizY9Rbm60j+MObrJA/8jk011jrgmMgfhrETYO4qRB/HkSm6CgapTrpK9D7+Nu5QwJwtNNyATC72w9IAK4FLscK9N4KWQGsAEhKSnLiR6uhQkTISB5BRvIICisbeP7TQ7z4+RHe2lXMtMRw7rw4haumxuPn00/4+vhZ/elJs2Hu96GtFUp2wZHPoHgnHNsJeR9aV6yCdXFTbPqpoI+fZh3Z+/gP+D4r5WmcOUL/KnClMeYbjuVbgVnGmHs7bfM34DfGmM9E5Fn0CH1YqG9u5eVthTzzcT55ZXXEhPpz64VjuHl2EiNDziFwW5ugdK8V7sd2WUFfstsaSQNg87Xmm4meCDETIWay9ToyGWy9nLhVyksMeJeLiOQDJ//mjgLqgRXGmNd6+1wNdO/R3m7YeLCMpz8+xMYDZfj52Lhm+ihumT2GaYnhznfH9P1D4EQ+FO+wgr4kB0r3QdWRU9v4BFgXPcVMtoI+epL1HJ6k3TbKa5xroPtgnRS9AijEOil6szGmx9vf6BH68JZbWsMzHx/ilW2FNLS0MTY6mOvOT+SaGQnOnUQ9U001ULbfOqIv2wele6ygryk6tY1vMIxIhcgxEJHU7TEGAsJcX5dSA8QVwxavAv4Ha9ji08aYx0RkJYAx5slu2z6LBvqwV9XQwju7inlleyGb848DcGHqCK6bkcjiqXGEBvgObAENlVbQl+21wv54vnWla+URaKnrum1ARNeAj0iyRtyEJUBYvHU1rHblqCFCLyxSbnX0eD2vbi/k1e2F5JfX4e9jY+GUOK47P4G546LwsQ9id4gxUH8cKg87Av7wqaDvCPz6ru8RuxXqYfFW0IeOcrxOgNB46xESDf5hOiOlGnAa6GpIMMaw/Wglr24r5M2dRVTWtxAV4s+S6aO4dkYCU0aFuaa//dyKhPoKqC6E6mLruaa42+siaKo+/b12fwiOhuAoCIk59To4pmt70EgIjATfAeiCUl5PA10NOU2tbXywr4xXtxfwz32ltLQZkkYEsXByLAunxHHBmEjstiF8tNtU6wj3Qqg5BnVl1qO27NTrk4+2Xm7vZ/e3gr3jEXHqdUDEqWX/UPALBt8gaxinX5C17BcC9gHuulJDjga6GtJO1DXzzu5jbNhzjE9yK2hua2dksB/zJ8WycEosF4+LIsDXQ/uwjbGO5juCvtTq8mk4YT0aKx2vKx0PR3v3fv7e2HxPhfvJoPcPtbp//EIcrzs/whzPjnV+IdaYfp+AU892P+06cjVjoL3N+uXe3uL43oLO6qM00JXHqGls4V8HytiQU8IH+0qpaWolyM/OvAnRLJwcx2UTYggPGgZHpa3Np8K+uRaa605/tPTQ1lxr/fXQVGNdgdvkeJy8UMtZnQO+87M4frF2BL70sSzWLwcfv1O/KHwCrGW7v+Nz/U+9tvuCabfCD3PqtWl3LJuuyx36qqHTsmmz/h06Hs4stzne51hn2ju1tXZd39YMbS3Wo72l2+tuf6Vd8j2Y/8iZfScn90YDXXmi5tZ2Ps2rYEPOMd7bU0JpTRM+NuHC1JEsmBxL5vhokkcGub/ffagzxpo/p6nW+mvhZMifDP+2Jmt9az/PLY1dw7QjO3pbbrcCrbXJerQ1dXvdbH2uaRu8fwuxgc2n08Pe87KcbLc5Xndut3f6HPupNruf9UvJ7msdgfe47GM9J1wASRee3S5ooCtP195u2FFQyYY9JazPOUZemdUlkRgZyNy0KOamRXPx2KjhcfTubdrbrJBvbwHECsuTR/gnX4ut23K3X+LGiV8yYveKC8w00JXXOVxRx0cHy/noYBmf5FZQ09SKTWBaYgSZaVHMHR/N9NER+A7mkEilBoEGuvJqrW3t7CioZOMBK+Czj1bSbiDE34c5Y0eSmRbFnLFRjI0O1u4Z5fE00NWwUtXQwqdflLPxYDkbD5RRcKIBgJHBfsxKGdHxmBgXNrSHRirVg3OdPlcpjxIe6Mui9HgWpcdjjOFwRT2f5VWwOf84mw8d553dxwAI9fchIzmSWSkjmZUygqkJ4f1P/6vUEKaBrryaiJAcFUxyVDBLZ1lz8BdWNrAl/zif5x9nc34FH+wvAyDA18aM0ZHMShnB+WMimZ4YoSdZlUfRLhc17JXXNpF16GTAH2dPcXXH4IjU6GBmjI5kRlIE00dHMDEudHDnnlGqG+1DV+oM1DS2sLOgiu1HTpB9tJLtRyqpqLMuDAn0tTM1IZwZSRGOkI8kLjzAzRWr4UQDXalzYIyh4EQD2zoF/J6iaprb2gGICwsgPSGc9IQw0keFk54QTmyYv46oUQNCT4oqdQ5EhNEjghg9Iogl0xMAa3KxPUXVZB+tJPtoJTlF1by/r6SjqyYqxI8po7qGfGJkoIa8GlBOBbqILAJ+j3WDi6eMMb/stn4J8HOgHWgFvmuM2eTiWpUaMvx97MxIimRGUmRHW31zK3uLq9ldWM3uwip2F1Xzf//Ko7XdSvmwAB/SE8KZHB/GpPgwJsaHMi4mBH8fD514TA05ztyCzo51C7oFQAHWLeiWGWP2dNomBKgzxhgRmQasM8ZM7OtztctFDQeNLW0cKKmxQr6oit2FVew/VkNTq9VdY7cJY6ODmRhnBfwkx3NcWIAezasenWuXyywg1xiT5/iwNcASoCPQjTG1nbYPputUaEoNWwG+dqYlRjAtMaKjra3dkF9ex75j1ewrrmHfsWq2Hj7BGztO3Qc1PNCXiXGhTIoPY3xsKONjQ0iLDSU8UIdRqt45E+gJwNFOywXA7O4bici1wC+AGOBLPX2QiKwAVgAkJSWdaa1KeQW7TRgXE8K4mBC+PO1Ue1VDCwdKathXXM3eY9bzuqyj1Defmo0wNsyf8bFWV03noA8b6Hu0Ko/gTKD39HffaUfgxphXgVdFJBOrP31+D9usAlaB1eVyZqUq5d3CA32ZmTyCmckjOtra2w2FlQ0cLK3hQEktB0pqyC2tZc3mozS0nAr6uLAA0mJDSIsJZWxMMKlRIYyNDiY6VEfbDCfOBHoBMLrTciJQ1Mu2GGM2ishYEYkyxpSfa4FKDWc226kRNpdPjO1oPxn0B0qsoD9YUsPB0lpe2HyYxpb2ju1C/X1IiQ4mNSqYsdEhpEaHkBodTEpUsOfeBUr1yplA3wKkiUgKUAgsBW7uvIGIjAO+cJwUPR/wAypcXaxSytI56K+Y1DXoi6sbySurJa+sjryyWr4oq2Nz/nFeyz51HCYCo8IDO8I9eWQwKdHBpIwMJjEyUK+G9VD9BroxplVE7gHWYw1bfNoYkyMiKx3rnwSuB24TkRagAbjJuOuKJaWGMZtNSIgIJCEikLlp0V3W1Te3kl9e5wj6Or4oqyW/vI5XtxVS03TqFnU+jl8WHUEfFURylBX88eGBOkPlEKZXiio1zBljqKhrJr+8jvzyOg45nvPL6zhUUdelC8fXLiRGWn8ZJI0IJGlEEEkjgkiMDCJpZJCenB0EeqWoUqpXIkJUiD9RIf5dTsiC1YVTUtPoCPp6jhyv5+hx63nH0UqqGlq6bB8R5EuSoytodGQQo0dYfy0kRgaRGBmo/fYDTANdKdUrm02IDw8kPjyQi8aevr6qvoWjJ06F/MlHTmEVG3KO0dLWtQcgKsSfhMhAEk8+OoV9QmQgQX4aSedC//WUUmctPMiX8CBrrpru2toNpTWNFJxooPBEAwUn6q3XlQ3sKarmvZySjgnOTooM8mWU4xzAqAgr9DsvR4X46TDMPmigK6UGhL3T0f3M5NPXt7cbymubONop7Isqrcehijo+zi2nrtNFVQB+PraOk76jIgKID7eeR0UEdrwezkf5w3fPlVJuZbMJMWEBxIQFcMGYyNPWG2OobmiloLKeospGCk/UU1TVaB3tVzbw4f4yymqb6D6uIzzQOsofFR5AvCPsR4UHEhsWQFx4AHFhAQT6eWdfvga6UmpIEpGOLp0po07v0gFobm2npLqRosoGiqsaKaxsoLiqgeJK63XW4ROnnbgFa+bLuPAAK+QdQd/99chgP2weNkRTA10p5bH8fGwdF1j1pq6pleKqBo5VNXGsupESx+NYlfV8oKSGspom2rsd6dttQlSIH7FhAcSE+hMdGkBsmD8xnZ5jwvwZGew3ZC7E0kBXSnm1YH8fxsWEMi4mtNdtWtvaKa9t5pgj6EtrGimtbqKkupHSmiYKTjR0uRVhZzaBkSH+RIf4Ex3a6RHiT0xY1/YQf58BPamrga6UGvZ87Darfz08oOvMVd00t7ZTXttEaU0TpdWNlNQ0UeYI/bKaJspqmzqO+Fu7H/IDAb42okP9uX1OMt+Ym+r6/XD5JyqllJfy87FZJ1kjAvvcrr3dUNXQ0inoG61nxyM61H9A6tNAV0opF7PZhMhgPyKD/ZgQ13tXj8t/7qD9JKWUUgNKA10ppbyEBrpSSnkJDXSllPISTgW6iCwSkf0ikisiD/aw/hYR2el4fCIi57m+VKWUUn3pN9BFxA48ASwGJgPLRGRyt83ygUuNMdOwbhC9ytWFKqWU6pszR+izgFxjTJ4xphlYAyzpvIEx5hNjzAnH4mdYN5JWSik1iJwJ9ATgaKflAkdbb74OvHMuRSmllDpzzlxY1NPEAz3eiFRELsMK9Et6Wb8CWOFYrBWR/c4U2YMooPws3+tphsu+Dpf9BN1XbzSY+zmmtxXOBHoBXWc3SASKum8kItOAp4DFxpiKnj7IGLMKF/Svi0hWbzdJ9TbDZV+Hy36C7qs3Gir76UyXyxYgTURSRMQPWAq80XkDEUkCXgFuNcYccH2ZSiml+tPvEboxplVE7gHWA3bgaWNMjoisdKx/EvgPYCTwv46pIVuHwm8rpZQaTpyanMsY8zbwdre2Jzu9/gbwDdeW1qfhNCxyuOzrcNlP0H31RkNiP8V0vyGfUkopj6SX/iullJfQQFdKKS/hcYHe37wy3kREDonILhHJFpEsd9fjKiLytIiUisjuTm0jROQ9ETnoeI50Z42u0su+PiIihY7vNVtErnJnja4gIqNF5AMR2SsiOSLyHUe7V32vfeznkPhOPaoP3TGvzAFgAdb4+C3AMmPMHrcWNkBE5BCQYYzxqgszRCQTqAWeN8akO9p+BRw3xvzS8Ys60hjzgDvrdIVe9vURoNYY89/urM2VRCQeiDfGbBORUGArcA1wB170vfaxnzcyBL5TTztC73deGTX0GWM2Ase7NS8BnnO8fg7rP4nH62VfvY4xptgYs83xugbYizVFiFd9r33s55DgaYF+pvPKeDoDbBCRrY5pE7xZrDGmGKz/NECMm+sZaPc4ppt+2tO7IboTkWRgBvA5Xvy9dttPGALfqacFutPzyniJi40x52NNXfwtx5/vyvP9ERgLTAeKgd+4tRoXEpEQ4GXgu8aYanfXM1B62M8h8Z16WqA7Na+MtzDGFDmeS4FXsbqcvFWJo3/yZD9lqZvrGTDGmBJjTJsxph34E17yvYqIL1bIrTbGvOJo9rrvtaf9HCrfqacFer/zyngLEQl2nHRBRIKBhcDuvt/l0d4Abne8vh143Y21DKiTAedwLV7wvYo158efgb3GmN92WuVV32tv+zlUvlOPGuUC4BgO9D+cmlfmMfdWNDBEJBXrqBysKRpe8JZ9FZEXgXlYU46WAD8BXgPWAUnAEeCrxhiPP5nYy77Ow/rT3ACHgG+e7Gf2VCJyCfARsAtodzT/CKt/2Wu+1z72cxlD4Dv1uEBXSinVM0/rclFKKdULDXSllPISGuhKKeUlNNCVUspLaKArpZSX0EBXSikvoYGulFJe4v8DH6yaatC0EaMAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAp+ElEQVR4nO3deXib1YHv8e/xKu+748ROSAjZEwzEJG0ZICSFpgwUaFlCOwxQIJdO6bDc3kIpFHrb28szpdNhBgoNU6BMoUzLMlAuLVuAMBRoEghL4iSErLYTW/G+yJIlnfvHK+927AQ7sl79Ps+jR++mV+e1kp+Pj857jrHWIiIisS8h2gUQEZGxoUAXEXEJBbqIiEso0EVEXEKBLiLiEknReuPCwkI7ffr0aL29iEhM2rhx40FrbdFQ+6IW6NOnT2fDhg3RensRkZhkjNkz3D41uYiIuIQCXUTEJRToIiIuoUAXEXEJBbqIiEso0EVEXEKBLiLiElHrhy4i4lZdoTDNvi6aOrpo9nXR4uuKrAdo9gU56ZhcTp015L1Bn4kCXURkgHDY0hYI0uLrosUXpKXTCeWWzsi2zv7bmwc8OgKhQ57/2tNnKtBFRA5XKGxp8wdp6gjQ0N77aOwI0NDeRWN7gIaOQL/nJl8XI839k5WaRHZaMlmeJLI9yUzNT2dhWjI5acnkpiWTk+4sZ3evp/WuJyeOT2v3qALdGLMSuAdIBP7dWnvXgP15wEPATKAT+Ka19uMxLquIxJnumnJrd804UktujdSMWzuDtPmDPdta+z07y+2HqC0nJxryM1LIS08hPyOFeZOzyU9PIS/dCd7stGSyPclkpzmhnRNZz/QkkZhgjuJPYnRGDHRjTCJwH3AmUAWsN8Y8Z63d0uewW4FN1toLjDFzI8evGI8Ci0hs8gdDNLQHqG8LUN8eoL7N76xHlhs7+jdrtHZ20eoPjlhTTklKINuTRJbHqS1neZIozvJElnu3dYd2XkYK+ekp5GemkJGSiDETL5iP1Ghq6EuAHdbanQDGmCeA84C+gT4f+L8A1tqtxpjpxphJ1trasS6wiESHtZb2QKhfTbilM0hbn9pw3+eWzq6ewG5oC9DqDw553r615Oy0ZEpz05hXkhWpHTuh3F1D7l7uG9SpSYlH+ScxcY0m0EuBfX3Wq4ClA475APgq8N/GmCXAMUAZ0C/QjTGrgdUA06ZNO8Iii8hYC4bCeNv87G/u5ED3o6Uzsu7jQEsntc1+AqHwIc+TYOgTtskUZKRQlpdOfkYKhZkp5GekUpCZQkFGCgWZqeRnpJDtSXJVLTmaRhPoQ/2kB/4RdBdwjzFmE/AR8D4w6NextXYNsAagoqJihD+kROSzsNbS6g9ysNXPwbYAB9v8zqPVjzeyXtfq50CzD2+rn/CA/5GpSQlMzvFQkuOh4ph8JmV7yM9I7hfYWZ4kslJ7l9Nd1oQRa0YT6FXA1D7rZUBN3wOstS3AlQDG+TR3RR4iMoastbR0BnuC+WBbAG9rZ7/A9rYFIvv8+IODa9TGQEFGCoWZqRRlpTK7uCgS3Gk9AV6S7SE3PVnhHGNGE+jrgVnGmBlANbAK+HrfA4wxuUCHtTYAXA2si4S8iIxSOGzxtvmpauygqtEXeXRQ1xKpWbcF8Lb5CQwR0gkG8jNSKcxMoSgrlZmFGRRmOeuFmam9jyznC8Gkceo2J9E1YqBba4PGmOuAF3G6LT5krd1sjLk2sv8BYB7wqDEmhPNl6VXjWGaRmNQVCnOwzU9NU+eg0K5q9FHd6BvURl2QkUJxtofCzBRmFmdS1CeYu2vYhZmp5KWnTMhudHJ0GTtSn6BxUlFRYTUFnbiBPxjC2+qntsWPt7WTulY/dS1+alsiy63O9vr2wKAueIWZKZTmpVOWlxZ5OMtT89KYkptGeoru/ZP+jDEbrbUVQ+3TvxaREVhrOdgWYG9DO3sbOthT38Hehg72Rp7rWv2DXpOYYCjMTGFStofSXA8nTM1lUnYqxVkeSnJSmZqXTmmeAlvGlv41ieB026tp6mR3fTu769vZW9/BnoYO9jU4oT1wbI7JOR6m5qdz+uwiyvLSmZSdyqRsD0VZqRRnp1KQkaomEDnqFOgSN7pDe1d9O3vq29l1sJ099R3sPtjOvsYOukK97SGe5ASm5aczLT+dL8wsZFp+GscUZDA132kS8STrZhaZeBTo4irWWupa/ez0trPzYBu7vO3sPNg+ZGinpyRyTEEGc0qy+NLCEmYUZHBMQTrTCzMozkpVlz2JOQp0iUlt/mAkrNvY6XVq290B3ncwptSkBGYUDg7tGYUZFCm0xWUU6DKh+YMhPq1rZ1ttC1sPtLIt8tjf3NlzjDFQmpvGjMIMKiryObYogxmFGRxblMnkbA8JasuWOKFAlwkhHLZUN/kiod0b3rsOthOM3JOenGiYWZTJkhn5zJ6UxbGR0D6mIF1t2iIo0OUos9ZS2+Jne21rz2NbbRs7alv7NZWU5aUxtySLM+dPYk5JFnNLsplRmEFKku5wFBmOAl3GzcE2P9sP9Ib2J5EAb+nsHbetMDOFWcVZXLi4jDkl2cwpyWL2pEyyPMlRLLlIbFKgy2dmrWVfg4/NNc18XNPMx9UtbK5p5mBboOeY3PRkZhdncW75FOaUZDGr2AnugszUKJZcxF0U6HJYQmHLroPtTnhX94Z3d607KcEwe1IWZ8wpZt7kbGZPcoJbPUpExp8CXQ6p3R9k/e4G/vJpPe/vbWRzTUvPXZMpSQnMK3Fq3QtLc1g4JYfZJZmaQWYishZCXRDshKC/9zkUgHAQbAjCIWe55zkINty7HA45x1nrPLDO/oHLNjzEPttbjr7r9DkXBpJSIcnT59kzxLbIsw1BoL3/o6t98LZAO3R1QEoGeHIhLTfynNdnOfKclDL459blg84m8DWBr7F3uTOy7muCcBckpg5f1iSPc+7ubbnHQP6MMf+YFejSjz8YYtPeJt76tJ63Pz3I+3ubCIYtKYkJLCrL4eKKqSyYks3C0hyOK84ct9nLY1KoC9oPQnsdtHuhzes893201TlhmpAMCYmQkNT7SEzqv96939o+4RoJ1Z6ADfcGcPf2YGBwcAc7GTwvTRwwCZCS6QRplw8CrYc+PjnDCffkdPC3OIEdChziBQY8OZCYAiF/n5/1CE65Ac780WFcyOgo0ONcKGzZXNPMXz6t560dB1m/u4HOrjAJBhaV5nD1qcdyynEFVByTT1qKi2re1kKgbZhaV1MkCAeGon/ooAy0O2Hd2TT0eyWmQmYxZBRB1mRIThtcEw4HnV8IXb7+NeJQlxNKCYlgEiEhwQl5k9i7LSkVEtIj25IOUUscogaZmNz/l4hJGPwLpee9I88mwen8byK/zHuWzYB9xlke9pne12OcX06hwKF/1j3LPqdsyRlOzTsl3QnulAwnjLuXk1L7v1eoCzqbB9ewB9bAuzogNbt/DT4tb3ANPzXb+UwG/tsa6q+hvs/Zk4/s3+0IFOhx6EBzJ2u31vHG9jre/rS+p/17VnEmq06exhdmFrD02AJy0mKsp4m/DdpqofUAtB2A1tre5476wcEdHnrS4h4mAZLSDh2QnhwnoDOKnEdm5DmjGDIKnSBPyewfKhI9icnO55JROH7vYUykeSVl5GPHmAI9DoTClg+qmlhbWcfarXVs2e9MJlWam8aXF07mC8cV8PmZBRRneaJTwEA7tOx3akXD1si623wjtbfOlgGhfcCpcQ+UmAKZk5z/wJ5cyJ06RPvpEG2pyelOE4hIDNG/WJdq9nXx5ide1m6t4/VtXhraAyQmGBZPy+OWL89l+dxiZhVnjn/PE2ud2nHTXmjeB81V0LTPWe7e5ms8/PMmpztBnVUCkxbCcV90ljNLIGtS5LnECWvVjiVOKNBdZKe3jVcr63h1ay0bdjcSDFty05NZNruIM+YWc/rsInLTP+OfgdY6XxZ1NICvAToaI88NkWaNht59LTVOeAd9/c+RnOHUlHOmQuliZzm7NNLmeYheDT3tvqmD2y1FRIEe65o6Avzxgxqe3FjFB1XNAMwtyeKa045lxdxiTpiae2QTAne2QO1mqP3YeRz42KlR+xoO0fYc+cY/PR/S8qFoDhx3Zm9455RB7jTVmkXGiQI9BgVDYd785CBPbqzi5S21BEJh5pZkcdvfzmPlwhLK8tJHf7JwGBp39YZ27Wao/cgJ726eXChZBHO+DOkFvYE98Dkt1+kJISJRoUCPIdtrW3lqYxVPv1+Nt9VPXnoyX186jQsXl7FgSvbo2sODftj7Dny6Fva8BbVbnJsxwOnVUXAclFbA4iuctulJCyF7imrUIjFAgT7BNXUEeC7SpPJhVTNJCYYz5hZz4eIyzphTPPLog9aCd5sT4N0h3tXh9OEtrYCTLoNJC5zgLp7ndMETkZikQJ+gPqpq5sE3d/Lnjw8QCIWZNzmb28+Zz3knTKFwpAGt2uth52vw6WtOiLfWONsLZsGJl8HM5TD9FEjNGv8LEZGjRoE+gYTDlje2e/nVuk95Z2cDWalJfH3pNC6qKGPBlJyhX2St0/WvZhNUb4Sdr8P+DwDrtH0fu8wJ8JlnOF9IiohrKdAnAH8wxLObanhw3U4+qWtjco6HH5w9j1VLpvYfF7xveO/fBDXvO8u+Bmd/QhKULYEzfuCE+JQT9CWlSBxRoEdRc0cXj/11D4+8tZu6Vj9zS7L4xSXlnHP8FGfQq9Za2PluJLw3Oc8d9c6LE5KgaB7MPRumnAiTT3TawpOjdLeniESdAj0Kqho7eOi/d/Of6/fSHghx6qxC7r6onFOPK8B4K+Gt38G2PzlNKOAMiFQ83+k2OPkEmHKSwltEBlGgH0W7Drbzi5e38/8+2o8Bzi2fwtWnlLEg8DFsuxteeKG3/3fpYlh+G8xYBiUL1ftEREakQD8KwmHLb9/dw09fqCTRGP5haT7fnPQpeVVPwn+8Av5m55b2Y8+AU78Ls7/kjEMiInIYFOjjbH+zj+89+SF//aSG7075mMsz3iZl0zvOZAQZRTD/KzDnbKc3Ssph3OEpIjKAAn2cWGv5r03V/Nuzb3KRfYkHs1/D09AIZhaccr0T4qWLNciUiIwZBfo4qG/z8+ATf2Dunsd4KfFdEk0YM30lfO5amHG6bqMXkXExqkA3xqwE7gESgX+31t41YH8O8FtgWuScd1trHx7jsk58oS4+fPk/sO/czy1sJ5CSQULFNZglq6FgZrRLJyIuN2KgG2MSgfuAM4EqYL0x5jlr7ZY+h30b2GKtPdcYUwRsM8Y8Zq091Oyq7tHRgP/dX+N761ccH/RSkzCZ2s//iEmnfhM82dEunYjEidHU0JcAO6y1OwGMMU8A5wF9A90CWcYZ7i8TaABGmLDRBfyt8NJthDf9jtSQn/XhhdTOv4Vzv3YFKclqzRKRo2s0qVMK7OuzXgUsHXDMvcBzQA2QBVxirQ0PPJExZjWwGmDatBgfV6TLR/jxVbDnbZ4InsbLWRdw3aqv8LVj8qJdMhGJU6MJ9KG+wbMD1r8EbAKWAzOBl40xb1prW/q9yNo1wBqAioqKgeeIHaEu7O8vhz1vcUPgH8hZ8nXuO3su6SmqlYtI9Iymz1wVMLXPehlOTbyvK4GnrWMHsAuYOzZFnGDCIezTqzGfvMhtXd9k7lnf5MfnL1SYi0jUjSbQ1wOzjDEzjDEpwCqc5pW+9gIrAIwxk4A5wM6xLOiEYC32jzdgNj/NT7suJefU1fzDsuOiXSoREWAUTS7W2qAx5jrgRZxuiw9ZazcbY66N7H8A+DHwiDHmI5wmmputtQfHsdxHn7Xw0m2Y9x/l34Ln4zv5Ov73l+ZEu1QiIj1G1U5grX0BeGHAtgf6LNcAZ41t0SaYN/4J3r6Xh4NfYufCG/j5VxaMbg5PEZGjRA2/o/H2L+H1n/KH4Gm8Peu7/PKichISFOYiMrEo0Efy3n/Ai9/nT6ElPHfMLTz49cUkJWr8FRGZeBToh/Lx09g//iNvhst5qOQHPPL3S/Eka0o3EZmYFOjD2f4S9qlr2Biezc/zbuPRK08hI1U/LhGZuJRQQ9n934T/8+/YaqdyZ+YPefjq08lJTx75dSIiUaRAH6h6I+HHLmZ3qIjvpvyQB69ZTlFWarRLJSIyIgV6X83VhH57IQe6Mvl24u3cd81ZlOZqLk8RiQ3qrtEtGMD+4XL8Ph/f4vv8/KqzObYoM9qlEhEZNQV6t5duw1St538GVnPxyuXMn6JxzEUktijQAT56Ev76Kz4o+wZ/Ci/li/MmRbtEIiKHTW3odVvhuX+EqZ/jrsClLJgCJTmeaJdKROSwxXcN3d8Kv78MUtJpPudB3t3bwoq5xdEulYjIEYnfGrq1Ts28fgf8/XO8vj+RsIUzFOgiEqPit4b+7q9g89Ow4ocw41RerayjICOF8rLcaJdMROSIxGeg730XXvoBzDkbTrmBYCjMG9u9nDG3WKMoikjMir9Ab/PCH66AnDI4/34whvf2NtHs61L7uYjEtPhqQw+H4KmrwNcAV70MabkAvLq1luREw9/MKoxu+UREPoP4CvTXfgq73oDz7oPJx/dsXltZx5IZ+WR5NACXiMSu+Gly2fZnePNuOPEyOPHvejbva+jgk7o2ls/VzUQiEtviI9Abd8Mzq6HkeDj7Z/12rd1aB8BytZ+LSIxzf6B3dcJ/XuYsX/woJPcfPfHVrXUcW5jBjMKMKBRORGTsuD/Q37wbDnwIF6yB/Bn9drX7g7zzab1q5yLiCu4P9N1vwdTPwZyVg3a9teMggVCY5fMU6CIS+9wd6NZC3RaYNH/I3Wu31pGVmsTJ0/OPcsFERMaeuwO99QB0NkHRvEG7rLWs3VrHabOLSE50949BROKDu5OsbovzXDw40DfXtFDX6lf7uYi4hrsD3bvVeR4i0F+trMMYWDan6CgXSkRkfLg70Ou2QEYxZAy+pX/t1lpOmJpLQWZqFAomIjL2XB7olVA8d/Dm1k4+qGrWYFwi4iruDfRw2JlernhwD5fXt3kBdLu/iLiKewO9eR90tQ/Zfr62so7JOR7mTc6KQsFERMaHewO9rtJ5HlBD9wdDvPmJM5mFMZrMQkTcY1SBboxZaYzZZozZYYy5ZYj9/8sYsyny+NgYEzLGRPdune4ui0Vz+m3+664G2gMhtZ+LiOuMGOjGmETgPuDLwHzgUmNMv2qvtfZn1toTrLUnAN8H3rDWNoxDeUevrhKyy8CT02/z2q11pCYl8IWZmsxCRNxlNDX0JcAOa+1Oa20AeAI47xDHXwr8biwK95l4Kwe1n1trebWyji/MLCAtJTFKBRMRGR+jCfRSYF+f9arItkGMMenASuCpYfavNsZsMMZs8Hq9h1vW0QsFwbt9UJfFT73t7G3oYPk89W4REfcZTaAP9c2hHebYc4G3hmtusdausdZWWGsriorG8Q7Nxl0Q8g/6QnTt1lpAk1mIiDuNJtCrgKl91suAmmGOXcVEaG4ZZgyXtVvrmFuSRWlu2hAvEhGJbaMJ9PXALGPMDGNMCk5oPzfwIGNMDnA68OzYFvEI1G0FDBT29nBp9nWxfnejauci4lpJIx1grQ0aY64DXgQSgYestZuNMddG9j8QOfQC4CVrbfu4lXa06rZA3nRISe/ZtG67l1DYskKTWYiIS40Y6ADW2heAFwZse2DA+iPAI2NVsM+krnKI9vM68tKTOWFqXpQKJSIyvtx3p2jQD/U7+rWfh8KW17fVccacYhITdHeoiLiT+wK9fgfYUL9A37SvkcaOLs5Q+7mIuJj7Ar1nDJfeQH+1so7EBMNpszWZhYi4lwsDfQskJEHBrJ5Na7fWcfL0PHLSkqNYMBGR8eXCQK+EguMgKQWA6iYfWw+0qruiiLieOwO9T3PL2q11gCazEBH3c1egB9qhcTcU9Qb6+l0NTMnxMLMoI3rlEhE5CtwV6N5tgO1XQ69q7OCYggxNZiEirueuQB9ilqKapk6maOwWEYkD7gp0byUkpkL+DAC6QmFqWzspzVOgi4j7uSvQ6yqhaDYkOJNXHGjuxFoozfVEuWAiIuPPfYHep7mluskHQGlu+nCvEBFxDfcEuq8JWqr7fSFa3egE+hTV0EUkDrgn0L3bnOc+XRZrmroDXW3oIuJ+7gn0IWYpqmn2UZiZgidZE0KLiPu5KNArISUTcnpny6tq9Kl2LiJxw0WBvgWK5kJC7yXVNPk0f6iIxA33BLp3KxTP7Vm11lLdpBq6iMQPdwR6mxfavf26LDZ2dNHZFVagi0jccEegewdPalHT0wddgS4i8cEdgT7EGC5VjQp0EYkv7gl0Ty5k9o553lND1zguIhIn3BPoxfOhzxC51U0+PMkJ5KVr2jkRiQ+xH+jWDpqlCJwa+pTcNI2DLiJxI/YDvXU/+JuHDHS1n4tIPIn9QB/iln9wmlwU6CIST1wQ6JEeLn0G5ersCnGwLaBAF5G44o5Az5wEGQU9mzTKoojEI3cEetHcfptqmjoBBbqIxJfYDvRwODKGy/x+m7tr6GXqgy4icSS2A71pD3R1DPpCtKrJhzEwKVszFYlI/IjtQB/iln9wauiTsjykJMX25YmIHI5RJZ4xZqUxZpsxZocx5pZhjllmjNlkjNlsjHljbIs5jO5BuYrm9Nvs3FSk2rmIxJekkQ4wxiQC9wFnAlXAemPMc9baLX2OyQV+Cay01u41xhSPU3n7q6t0ZijyZPfbXN3kY1FpzlEpgojIRDGaGvoSYIe1dqe1NgA8AZw34JivA09ba/cCWGvrxraYwxjilv9w2LK/qVODcolI3BlNoJcC+/qsV0W29TUbyDPGvG6M2WiM+fuhTmSMWW2M2WCM2eD1eo+sxN1CQTi4fVCgH2zzEwiFdVORiMSd0QT6UKNb2QHrScBi4G+BLwG3G2NmD3qRtWustRXW2oqioqLDLmw/DTshFOh3hyg4zS2gcdBFJP6M2IaOUyOf2me9DKgZ4piD1tp2oN0Ysw4oB7aPSSmHMswYLrqpSETi1Whq6OuBWcaYGcaYFGAV8NyAY54FTjXGJBlj0oGlQOXYFnWAukrADOrhUt3UAWhiCxGJPyPW0K21QWPMdcCLQCLwkLV2szHm2sj+B6y1lcaYPwMfAmHg3621H49nwanbAvkzILl/cNc0dZKVmkS2RxNbiEh8GU2TC9baF4AXBmx7YMD6z4CfjV3RRjDELf/gzCWq5hYRiUexeStlVyfUfzqo/RwiE1uouUVE4lBsBnr9J2BDQwd6s+4SFZH4FJuBPsSkFgDt/iBNHV2U5qZHoVAiItEVu4GekAQFx/Xb3DuxhWroIhJ/YjfQC2ZBUkq/zVW6qUhE4liMBvqWYb8QBfVBF5H4FHuB7m9zJrYYJtCTEgzFWWpyEZH4E3uBfnCb8zxEoFc3+ijJ8ZCYMNTwMyIi7haDgb7DeR7ipqKapk7dVCQicWtUd4pOKOWXwMzlkF4waFd1k48lM/KjUCgRkeiLvUAHyBw89G4wFOZAS6d6uIhI3Iq9Jpdh1LX6CYWtmlxEJG65JtCr1WVRROKcawK9pw+67hIVkTjlmkCvauy+7V81dBGJT64J9JomH3npyaSnxOb3vCIin5WrAl21cxGJZ64J9Oomn7osikhcc0WgW2up1tRzIhLnXBHoLb4g7YGQaugiEtdcEejqgy4i4pJA752pSIEuIvHLFYFerZmKRETcEeg1TT5SkhIoyEgZ+WAREZdyRaBXNfmYkuMhQRNbiEgcc0Wg1zT59IWoiMQ91wT6lBwFuojEt5gP9EAwTF2rXzV0EYl7MR/oB5o7sVZdFkVEYj7Qq5o6AHVZFBGJ+UCvaeoEFOgiIi4IdOemopIczVQkIvFtVIFujFlpjNlmjNlhjLlliP3LjDHNxphNkccPx76oQ6tu9FGUlYonOfFovaWIyIQ04vQ+xphE4D7gTKAKWG+Mec5au2XAoW9aa88ZhzIeUk2zhs0VEYHR1dCXADustTuttQHgCeC88S3W6FU3+ihToIuIjFxDB0qBfX3Wq4ClQxz3eWPMB0AN8F1r7eaBBxhjVgOrAaZNm3b4pR3AWkt1k48V84o/87lE4l1XVxdVVVV0dnZGuygCeDweysrKSE5OHvVrRhPoQw2QYgesvwccY61tM8acDfwXMGvQi6xdA6wBqKioGHiOw9bQHsAfDKvJRWQMVFVVkZWVxfTp0zFG4yJFk7WW+vp6qqqqmDFjxqhfN5omlypgap/1MpxaeN83b7HWtkWWXwCSjTGFoy7FEdKwuSJjp7Ozk4KCAoX5BGCMoaCg4LD/WhpNoK8HZhljZhhjUoBVwHMD3rzERP4VGGOWRM5bf1glOQKa2EJkbCnMJ44j+SxGbHKx1gaNMdcBLwKJwEPW2s3GmGsj+x8ALgS+ZYwJAj5glbX2MzepjKSq0Qn0Mo3jIiIyqjb07maUFwZse6DP8r3AvWNbtJHVNHWSnpJITtrovzQQEXGrmL5TtKbJ6YOuPxNF5HAEg8FoF2FcjKqGPlFVN/n0hajIOPjRHzezpaZlTM85f0o2d5y7YMTjzj//fPbt20dnZyfXX389q1ev5s9//jO33noroVCIwsJCXn31Vdra2vjOd77Dhg0bMMZwxx138LWvfY3MzEza2toAePLJJ3n++ed55JFHuOKKK8jPz+f999/npJNO4pJLLuGGG27A5/ORlpbGww8/zJw5cwiFQtx88828+OKLGGO45pprmD9/Pvfeey/PPPMMAC+//DL3338/Tz/99Jj+jD6rmA70miYfC0tzol0MERlDDz30EPn5+fh8Pk4++WTOO+88rrnmGtatW8eMGTNoaGgA4Mc//jE5OTl89NFHADQ2No547u3bt/PKK6+QmJhIS0sL69atIykpiVdeeYVbb72Vp556ijVr1rBr1y7ef/99kpKSaGhoIC8vj29/+9t4vV6Kiop4+OGHufLKK8f153AkYjbQfYEQ9e0BfSEqMg5GU5MeL//6r//aUxPet28fa9as4bTTTuvpj52fnw/AK6+8whNPPNHzury8vBHPfdFFF5GY6Iz71NzczOWXX84nn3yCMYaurq6e81577bUkJSX1e7/LLruM3/72t1x55ZW8/fbbPProo2N0xWMnZgO9prm7y6JGWRRxi9dff51XXnmFt99+m/T0dJYtW0Z5eTnbtm0bdKy1dsjvz/puG9iPOyMjo2f59ttv54wzzuCZZ55h9+7dLFu27JDnvfLKKzn33HPxeDxcdNFFPYE/kcTsl6I9fdA1l6iIazQ3N5OXl0d6ejpbt27lnXfewe/388Ybb7Br1y6AniaXs846i3vv7e1c193kMmnSJCorKwmHwz01/eHeq7S0FIBHHnmkZ/tZZ53FAw880PPFaff7TZkyhSlTpvCTn/yEK664YsyueSzFbKBXR/qgay5REfdYuXIlwWCQ448/nttvv53Pfe5zFBUVsWbNGr761a9SXl7OJZdcAsBtt91GY2MjCxcupLy8nNdeew2Au+66i3POOYfly5czefLkYd/re9/7Ht///vc55ZRTCIVCPduvvvpqpk2bxvHHH095eTmPP/54z75vfOMbTJ06lfnz54/TT+CzMUfh/p8hVVRU2A0bNhzx6//5pW3c+9oOtv3kyyQnxuzvJZEJo7Kyknnz5kW7GBPaddddx4knnshVV111VN5vqM/EGLPRWlsx1PETrxFolKqbOinJ9ijMReSoWLx4MRkZGfz85z+PdlGGFcOB3qExXETkqNm4cWO0izCimK3e1jR1KtBFRPqIyUAPhy37m336QlREpI+YDHRvm5+ukFUNXUSkj5gM9O6JLTSXqIhIr9gM9EZNbCEiMlBMBnrvTEW67V8kXmVmZka7CBNOTHZbrG7yke1JIsujiS1ExsWfboEDH43tOUsWwZfvGttzTgDBYHDCjOsSszV0NbeIuMvNN9/ML3/5y571O++8kx/96EesWLGCk046iUWLFvHss8+O6lxtbW3Dvu7RRx/tua3/sssuA6C2tpYLLriA8vJyysvL+ctf/sLu3btZuHBhz+vuvvtu7rzzTgCWLVvGrbfeyumnn84999zDH//4R5YuXcqJJ57IF7/4RWpra3vKceWVV7Jo0SKOP/54nnrqKX79619z44039pz3wQcf5Kabbjrin1s/1tqoPBYvXmyP1Mp/WWeveuSvR/x6ERlsy5YtUX3/9957z5522mk96/PmzbN79uyxzc3N1lprvV6vnTlzpg2Hw9ZaazMyMoY9V1dX15Cv+/jjj+3s2bOt1+u11lpbX19vrbX24osvtr/4xS+stdYGg0Hb1NRkd+3aZRcsWNBzzp/97Gf2jjvusNZae/rpp9tvfetbPfsaGhp6yvXggw/am266yVpr7fe+9z17/fXX9zuura3NHnvssTYQCFhrrf385z9vP/zwwyGvY6jPBNhgh8nVifF3wmGqbuzg5Okjj30sIrHjxBNPpK6ujpqaGrxeL3l5eUyePJkbb7yRdevWkZCQQHV1NbW1tZSUlBzyXNZabr311kGvW7t2LRdeeCGFhYVA71jna9eu7RnfPDExkZycnBEnzOgeJAygqqqKSy65hP379xMIBHrGbh9uzPbly5fz/PPPM2/ePLq6uli0aNFh/rSGFnOB3trZRUtnUE0uIi504YUX8uSTT3LgwAFWrVrFY489htfrZePGjSQnJzN9+vRBY5wPZbjX2WHGOh9KUlIS4XC4Z/1QY6t/5zvf4aabbuIrX/kKr7/+ek/TzHDvd/XVV/PTn/6UuXPnjunMRzHXhl7T5PxQNZeoiPusWrWKJ554gieffJILL7yQ5uZmiouLSU5O5rXXXmPPnj2jOs9wr1uxYgW///3vqa+vB3rHOl+xYgX3338/AKFQiJaWFiZNmkRdXR319fX4/X6ef/75Q75f99jqv/nNb3q2Dzdm+9KlS9m3bx+PP/44l1566Wh/PCOKwUBXH3QRt1qwYAGtra2UlpYyefJkvvGNb7BhwwYqKip47LHHmDt37qjOM9zrFixYwA9+8ANOP/10ysvLe76MvOeee3jttddYtGgRixcvZvPmzSQnJ/PDH/6QpUuXcs455xzyve+8804uuugiTj311J7mHBh+zHaAiy++mFNOOWVUU+eNVsyNh75hdwMPvrmTn5y/iKKs1HEomUh80njoR9c555zDjTfeyIoVK4Y9xvXjoVdMz6dien60iyEickSamppYsmQJ5eXlhwzzIxFzgS4i0u2jjz7q6UveLTU1lXfffTdKJRpZbm4u27dvH5dzK9BFpMfh9AKZCBYtWsSmTZuiXYxxcSTN4TH3paiIjA+Px0N9ff0RBYmMLWst9fX1eDyHN16VaugiAkBZWRlVVVV4vd5oF0VwfsGWlZUd1msU6CICQHJycs8djhKb1OQiIuISCnQREZdQoIuIuETU7hQ1xniB0Q3MMFghcHAMizORxcu1xst1gq7VjY7mdR5jrS0aakfUAv2zMMZsGO7WV7eJl2uNl+sEXasbTZTrVJOLiIhLKNBFRFwiVgN9TbQLcBTFy7XGy3WCrtWNJsR1xmQbuoiIDBarNXQRERlAgS4i4hIxF+jGmJXGmG3GmB3GmFuiXZ7xZIzZbYz5yBizyRhz+NM7TVDGmIeMMXXGmI/7bMs3xrxsjPkk8jx283JF0TDXeqcxpjryuW4yxpwdzTKOBWPMVGPMa8aYSmPMZmPM9ZHtrvpcD3GdE+Izjak2dGNMIrAdOBOoAtYDl1prt0S1YOPEGLMbqLDWuurGDGPMaUAb8Ki1dmFk2z8BDdbauyK/qPOstTdHs5xjYZhrvRNos9beHc2yjSVjzGRgsrX2PWNMFrAROB+4Ahd9roe4zouZAJ9prNXQlwA7rLU7rbUB4AngvCiXSQ6TtXYd0DBg83lA93Tpv8H5TxLzhrlW17HW7rfWvhdZbgUqgVJc9rke4jonhFgL9FJgX5/1KibQD3McWOAlY8xGY8zqaBdmnE2y1u4H5z8NUBzl8oy364wxH0aaZGK6GWIgY8x04ETgXVz8uQ64TpgAn2msBfpQc2PFTpvR4TvFWnsS8GXg25E/3yX23Q/MBE4A9gM/j2ppxpAxJhN4CrjBWtsS7fKMlyGuc0J8prEW6FXA1D7rZUBNlMoy7qy1NZHnOuAZnCYnt6qNtE92t1PWRbk848ZaW2utDVlrw8CDuORzNcYk44TcY9bapyObXfe5DnWdE+UzjbVAXw/MMsbMMMakAKuA56JcpnFhjMmIfOmCMSYDOAv4+NCvimnPAZdHli8Hno1iWcZVd8BFXIALPlfjzCz9a6DSWvvPfXa56nMd7jonymcaU71cACLdgf4FSAQestb+n+iWaHwYY47FqZWDM1Xg4265VmPM74BlOEOO1gJ3AP8F/B6YBuwFLrLWxvyXicNc6zKcP80tsBv4H93tzLHKGPM3wJvAR0A4svlWnPZl13yuh7jOS5kAn2nMBbqIiAwt1ppcRERkGAp0ERGXUKCLiLiEAl1ExCUU6CIiLqFAFxFxCQW6iIhL/H8fnnBcTN+2SgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%time\n",
     "\n",
@@ -735,6 +1417,50 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can have the model directly predict on the input since we are using keras preprocessing layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_predictions(model):\n",
+    "    prediction = model.predict(X_train[:5])\n",
+    "    for predict in prediction:\n",
+    "        print(\n",
+    "            \"Github:{:.2%} , NYTimes:{:.2%}, TechCrunch:{:.2%}\".format(\n",
+    "                float(predict[0]), float(predict[1]), float(predict[2])\n",
+    "            )\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Github:99.86% , NYTimes:0.02%, TechCrunch:0.12%\n",
+      "Github:0.00% , NYTimes:8.47%, TechCrunch:91.53%\n",
+      "Github:0.44% , NYTimes:21.43%, TechCrunch:78.13%\n",
+      "Github:99.97% , NYTimes:0.01%, TechCrunch:0.02%\n",
+      "Github:14.51% , NYTimes:0.10%, TechCrunch:85.39%\n"
+     ]
+    }
+   ],
+   "source": [
+    "get_predictions(dnn_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Building a RNN model"
    ]
   },
@@ -759,6 +1485,8 @@
     "\n",
     "    model = Sequential(\n",
     "        [\n",
+    "            Input(shape=(1,), dtype=tf.string),\n",
+    "            preprocessing_layer,\n",
     "            Embedding(\n",
     "                VOCAB_SIZE + 1, embed_dim, input_shape=[MAX_LEN], mask_zero=True\n",
     "            ),  # TODO 3\n",
@@ -821,6 +1549,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_predictions(rnn_model)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -848,6 +1585,8 @@
     "\n",
     "    model = Sequential(\n",
     "        [\n",
+    "            Input(shape=(1,), dtype=tf.string),\n",
+    "            preprocessing_layer,\n",
     "            Embedding(\n",
     "                VOCAB_SIZE + 1, embed_dim, input_shape=[MAX_LEN], mask_zero=True\n",
     "            ),  # TODO 3\n",
@@ -925,222 +1664,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## (Optional) Using the Keras Text Preprocessing Layer"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Thanks to the new Keras preprocessing layer, we can also include the preprocessing of the text (i.e., the tokenization followed by the integer representation of the tokens) within the model itself as a standard Keras layer. Let us first import this text preprocessing layer:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from keras.layers import TextVectorization"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "At instanciation, we can specify the maximum length of the sequence output as well as the maximum number of tokens to be considered:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MAX_LEN = 26\n",
-    "MAX_TOKENS = 20000\n",
-    "preprocessing_layer = TextVectorization(\n",
-    "    output_sequence_length=MAX_LEN, max_tokens=MAX_TOKENS\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Before using this layer in our model, we need to adapt it to our data so that it generates a token-to-integer mapping. Remeber our dataset looks like the following:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "titles_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can directly use the Pandas Series corresponding to the titles in our dataset to adapt the data using the `adapt` method:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "preprocessing_layer.adapt(titles_df.title)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "At this point, the preprocessing layer can create the integer representation of our input text if we simply apply the layer to it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X_train, X_valid = titles_train, titles_valid\n",
-    "X_train[:5]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "integers = preprocessing_layer(X_train[:5])\n",
-    "integers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Exercise:** In the following cell, implement a function\n",
-    "`build_model_with_text_preprocessing(embed_dim, units)` that returns a text model with the following sequential structure:\n",
-    "\n",
-    "1. the `preprocessing_layer` we defined above folowed by\n",
-    "1. an embedding layer with `embed_dim` dimension for the output vectors followed by\n",
-    "1. a GRU layer with `units` number of neurons followed by\n",
-    "1. a final dense layer for classification"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def build_model_with_text_preprocessing(embed_dim, units):\n",
-    "\n",
-    "    model = Sequential(\n",
-    "        [\n",
-    "            preprocessing_layer,\n",
-    "            Embedding(\n",
-    "                VOCAB_SIZE + 1, embed_dim, input_shape=[MAX_LEN], mask_zero=True\n",
-    "            ),  # TODO 3\n",
-    "            GRU(units),\n",
-    "            Dense(N_CLASSES, activation=\"softmax\"),\n",
-    "        ]\n",
-    "    )\n",
-    "\n",
-    "    model.compile(\n",
-    "        optimizer=tf.keras.optimizers.Adam(learning_rate=0.0001),\n",
-    "        loss=\"categorical_crossentropy\",\n",
-    "        metrics=[\"accuracy\"],\n",
-    "    )\n",
-    "    return model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Our model is now able to cosume text directly as input! Again, consider the following text sample:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X_train[:5]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then we can have our model directly predict on this input:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = build_model_with_text_preprocessing(embed_dim=EMBED_DIM, units=UNITS)\n",
-    "model.predict(X_train[:5])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Of course the model above has not yet been trained, so its prediction are meaningless so far. \n",
-    "Let us train it now on our dataset as before: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "tf.random.set_seed(33)\n",
-    "\n",
-    "MODEL_DIR = os.path.join(LOGDIR, \"rnn\")\n",
-    "shutil.rmtree(MODEL_DIR, ignore_errors=True)\n",
-    "\n",
-    "EPOCHS = 100\n",
-    "BATCH_SIZE = 300\n",
-    "EMBED_DIM = 10\n",
-    "UNITS = 16\n",
-    "PATIENCE = 2\n",
-    "\n",
-    "model = build_model_with_text_preprocessing(embed_dim=EMBED_DIM, units=UNITS)\n",
-    "\n",
-    "history = model.fit(\n",
-    "    X_train,\n",
-    "    Y_train,\n",
-    "    epochs=EPOCHS,\n",
-    "    batch_size=BATCH_SIZE,\n",
-    "    validation_data=(X_valid, Y_valid),\n",
-    "    callbacks=[EarlyStopping(patience=PATIENCE), TensorBoard(MODEL_DIR)],\n",
-    ")\n",
-    "\n",
-    "pd.DataFrame(history.history)[[\"loss\", \"val_loss\"]].plot()\n",
-    "pd.DataFrame(history.history)[[\"accuracy\", \"val_accuracy\"]].plot()\n",
-    "\n",
-    "model.summary()"
+    "get_predictions(cnn_model)"
    ]
   },
   {
@@ -1154,9 +1683,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-6.m82",
+   "name": "tf2-gpu.2-8.m94",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-6:m82"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m94"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -1173,7 +1702,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/text_models/solutions/keras_for_text_classification_feature_columns.ipynb
+++ b/notebooks/text_models/solutions/keras_for_text_classification_feature_columns.ipynb
@@ -1,0 +1,1181 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Keras for Text Classification\n",
+    "\n",
+    "**Learning Objectives**\n",
+    "1. Learn how to create a text classification datasets using BigQuery\n",
+    "1. Learn how to tokenize and integerize a corpus of text for training in Keras\n",
+    "1. Learn how to do one-hot-encodings in Keras\n",
+    "1. Learn how to use embedding layers to represent words in Keras\n",
+    "1. Learn about the bag-of-word representation for sentences\n",
+    "1. Learn how to use DNN/CNN/RNN model to classify text in keras\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "\n",
+    "In this notebook, we will implement text models to recognize the probable source (GitHub, TechCrunch, or The New York Times) of the titles we have in the title dataset we constructed in the first task of the lab.\n",
+    "\n",
+    "In the next step, we will load and pre-process the texts and labels so that they are suitable to be fed to a Keras model. For the texts of the titles we will learn how to split them into a list of tokens, and then how to map each token to an integer using the Keras Tokenizer class. What will be fed to our Keras models will be batches of padded list of integers representing the text. For the labels, we will learn how to one-hot-encode each of the 3 classes into a 3 dimensional basis vector.\n",
+    "\n",
+    "Then we will explore a few possible models to do the title classification. All models will be fed padded list of integers, and all models will start with a Keras Embedding layer that transforms the integer representing the words into dense vectors.\n",
+    "\n",
+    "The first model will be a simple bag-of-word DNN model that averages up the word vectors and feeds the tensor that results to further dense layers. Doing so means that we forget the word order (and hence that we consider sentences as a “bag-of-words”). In the second and in the third model we will keep the information about the word order using a simple RNN and a simple CNN allowing us to achieve the same performance as with the DNN model but in much fewer epochs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import pandas as pd\n",
+    "from google.cloud import bigquery"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext google.cloud.bigquery"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Replace the variable values in the cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROJECT = !(gcloud config get-value core/project)\n",
+    "PROJECT = PROJECT[0]\n",
+    "%env PROJECT = {PROJECT}\n",
+    "%env BUCKET = {PROJECT}\n",
+    "%env REGION = \"us-central1\"\n",
+    "SEED = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a Dataset from BigQuery \n",
+    "\n",
+    "Hacker news headlines are available as a BigQuery public dataset. The [dataset](https://bigquery.cloud.google.com/table/bigquery-public-data:hacker_news.stories?tab=details) contains all headlines from the sites inception in October 2006 until October 2015. \n",
+    "\n",
+    "Here is a sample of the dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bigquery --project $PROJECT\n",
+    "\n",
+    "SELECT\n",
+    "    url, title, score\n",
+    "FROM\n",
+    "    `bigquery-public-data.hacker_news.stories`\n",
+    "WHERE\n",
+    "    LENGTH(title) > 10\n",
+    "    AND score > 10\n",
+    "    AND LENGTH(url) > 0\n",
+    "LIMIT 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's do some regular expression parsing in BigQuery to get the source of the newspaper article from the URL. For example, if the url is http://mobile.nytimes.com/...., I want to be left with <i>nytimes</i>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bigquery --project $PROJECT\n",
+    "\n",
+    "SELECT\n",
+    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[OFFSET(1)] AS source,\n",
+    "    COUNT(title) AS num_articles\n",
+    "FROM\n",
+    "    `bigquery-public-data.hacker_news.stories`\n",
+    "WHERE\n",
+    "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
+    "    AND LENGTH(title) > 10\n",
+    "GROUP BY\n",
+    "    source\n",
+    "ORDER BY num_articles DESC\n",
+    "  LIMIT 100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have good parsing of the URL to get the source, let's put together a dataset of source and titles. This will be our labeled dataset for machine learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regex = \".*://(.[^/]+)/\"\n",
+    "\n",
+    "\n",
+    "sub_query = \"\"\"\n",
+    "SELECT\n",
+    "    title,\n",
+    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '{0}'), '.'))[OFFSET(1)] AS source\n",
+    "    \n",
+    "FROM\n",
+    "    `bigquery-public-data.hacker_news.stories`\n",
+    "WHERE\n",
+    "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '{0}'), '.com$')\n",
+    "    AND LENGTH(title) > 10\n",
+    "\"\"\".format(\n",
+    "    regex\n",
+    ")\n",
+    "\n",
+    "\n",
+    "query = \"\"\"\n",
+    "SELECT \n",
+    "    LOWER(REGEXP_REPLACE(title, '[^a-zA-Z0-9 $.-]', ' ')) AS title,\n",
+    "    source\n",
+    "FROM\n",
+    "  ({sub_query})\n",
+    "WHERE (source = 'github' OR source = 'nytimes' OR source = 'techcrunch')\n",
+    "\"\"\".format(\n",
+    "    sub_query=sub_query\n",
+    ")\n",
+    "\n",
+    "print(query)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For ML training, we usually need to split our dataset into training and evaluation datasets (and perhaps an independent test dataset if we are going to do model or feature selection based on the evaluation dataset). AutoML however figures out on its own how to create these splits, so we won't need to do that here. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bq = bigquery.Client(project=PROJECT)\n",
+    "title_dataset = bq.query(query).to_dataframe()\n",
+    "title_dataset.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "AutoML for text classification requires that\n",
+    "* the dataset be in csv form with \n",
+    "* the first column being the texts to classify or a GCS path to the text \n",
+    "* the last colum to be the text labels\n",
+    "\n",
+    "The dataset we pulled from BiqQuery satisfies these requirements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"The full dataset contains {len(title_dataset)} titles\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's make sure we have roughly the same number of labels for each of our three labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "title_dataset.source.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we will save our data, which is currently in-memory, to disk.\n",
+    "\n",
+    "We will create a csv file containing the full dataset and another containing only 1000 articles for development.\n",
+    "\n",
+    "**Note:** It may take a long time to train AutoML on the full dataset, so we recommend to use the sample dataset for the purpose of learning the tool. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATADIR = \"./data/\"\n",
+    "\n",
+    "if not os.path.exists(DATADIR):\n",
+    "    os.makedirs(DATADIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FULL_DATASET_NAME = \"titles_full.csv\"\n",
+    "FULL_DATASET_PATH = os.path.join(DATADIR, FULL_DATASET_NAME)\n",
+    "\n",
+    "# Let's shuffle the data before writing it to disk.\n",
+    "title_dataset = title_dataset.sample(n=len(title_dataset))\n",
+    "\n",
+    "title_dataset.to_csv(\n",
+    "    FULL_DATASET_PATH, header=False, index=False, encoding=\"utf-8\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's sample 1000 articles from the full dataset and make sure we have enough examples for each label in our sample dataset (see [here](https://cloud.google.com/natural-language/automl/docs/beginners-guide) for further details on how to prepare data for AutoML)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_title_dataset = title_dataset.sample(n=1000)\n",
+    "sample_title_dataset.source.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's write the sample datatset to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SAMPLE_DATASET_NAME = \"titles_sample.csv\"\n",
+    "SAMPLE_DATASET_PATH = os.path.join(DATADIR, SAMPLE_DATASET_NAME)\n",
+    "\n",
+    "sample_title_dataset.to_csv(\n",
+    "    SAMPLE_DATASET_PATH, header=False, index=False, encoding=\"utf-8\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_title_dataset.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "import pandas as pd\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.keras.callbacks import EarlyStopping, TensorBoard\n",
+    "from tensorflow.keras.layers import (\n",
+    "    GRU,\n",
+    "    Conv1D,\n",
+    "    Dense,\n",
+    "    Embedding,\n",
+    "    Flatten,\n",
+    "    Lambda,\n",
+    ")\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.preprocessing.sequence import pad_sequences\n",
+    "from tensorflow.keras.preprocessing.text import Tokenizer\n",
+    "from tensorflow.keras.utils import to_categorical\n",
+    "\n",
+    "print(tf.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's start by specifying where the information about the trained models will be saved as well as where our dataset is located:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LOGDIR = \"./text_models\"\n",
+    "DATA_DIR = \"./data\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our dataset consists of titles of articles along with the label indicating from which source these articles have been taken from (GitHub, TechCrunch, or The New York Times)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATASET_NAME = \"titles_full.csv\"\n",
+    "TITLE_SAMPLE_PATH = os.path.join(DATA_DIR, DATASET_NAME)\n",
+    "COLUMNS = [\"title\", \"source\"]\n",
+    "\n",
+    "titles_df = pd.read_csv(TITLE_SAMPLE_PATH, header=None, names=COLUMNS)\n",
+    "titles_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integerize the texts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first thing we need to do is to find how many words we have in our dataset (`VOCAB_SIZE`), how many titles we have (`DATASET_SIZE`), and what the maximum length of the titles we have (`MAX_LEN`) is. Keras offers the `Tokenizer` class in its `keras.preprocessing.text` module to help us with that:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokenizer = Tokenizer()\n",
+    "tokenizer.fit_on_texts(titles_df.title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "integerized_titles = tokenizer.texts_to_sequences(titles_df.title)\n",
+    "integerized_titles[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "VOCAB_SIZE = len(tokenizer.index_word)\n",
+    "VOCAB_SIZE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATASET_SIZE = tokenizer.document_count\n",
+    "DATASET_SIZE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAX_LEN = max(len(sequence) for sequence in integerized_titles)\n",
+    "MAX_LEN"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's now implement a function `create_sequence` that will \n",
+    "* take as input our titles as well as the maximum sentence length and \n",
+    "* returns a list of the integers corresponding to our tokens padded to the sentence maximum length\n",
+    "\n",
+    "Keras has the helper functions `pad_sequence` for that on the top of the tokenizer methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO 1\n",
+    "def create_sequences(texts, max_len=MAX_LEN):\n",
+    "    sequences = tokenizer.texts_to_sequences(texts)\n",
+    "    padded_sequences = pad_sequences(sequences, max_len, padding=\"post\")\n",
+    "    return padded_sequences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sequences = create_sequences(titles_df.title[:3])\n",
+    "sequences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "titles_df.source[:4]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now need to write a function that \n",
+    "* takes a title source and\n",
+    "* returns the corresponding one-hot encoded vector\n",
+    "\n",
+    "Keras `to_categorical` is handy for that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CLASSES = {\"github\": 0, \"nytimes\": 1, \"techcrunch\": 2}\n",
+    "N_CLASSES = len(CLASSES)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO 2\n",
+    "def encode_labels(sources):\n",
+    "    classes = [CLASSES[source] for source in sources]\n",
+    "    one_hots = to_categorical(classes)\n",
+    "    return one_hots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "encode_labels(titles_df.source[:4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preparing the train/test splits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's split our data into train and test splits:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_TRAIN = int(DATASET_SIZE * 0.80)\n",
+    "\n",
+    "titles_train, sources_train = (\n",
+    "    titles_df.title[:N_TRAIN],\n",
+    "    titles_df.source[:N_TRAIN],\n",
+    ")\n",
+    "\n",
+    "titles_valid, sources_valid = (\n",
+    "    titles_df.title[N_TRAIN:],\n",
+    "    titles_df.source[N_TRAIN:],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To be on the safe side, we verify that the train and test splits\n",
+    "have roughly the same number of examples per classes.\n",
+    "\n",
+    "Since it is the case, accuracy will be a good metric to use to measure\n",
+    "the performance of our models.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_train.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_valid.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using `create_sequence` and `encode_labels`, we can now prepare the\n",
+    "training and validation data to feed our models.\n",
+    "\n",
+    "The features will be\n",
+    "padded list of integers and the labels will be one-hot-encoded 3D vectors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train, Y_train = create_sequences(titles_train), encode_labels(sources_train)\n",
+    "X_valid, Y_valid = create_sequences(titles_valid), encode_labels(sources_valid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Y_train[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building a DNN model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The build_dnn_model function below returns a compiled Keras model that implements a simple embedding layer transforming the word integers into dense vectors, followed by a Dense softmax layer that returns the probabilities for each class.\n",
+    "\n",
+    "\n",
+    "Note that we need to put a custom Keras Lambda layer in between the Embedding layer and the Dense softmax layer to do an average of the word vectors returned by the embedding layer. This is the average that's fed to the dense softmax layer. By doing so, we create a model that is simple but that loses information about the word order, creating a model that sees sentences as \"bag-of-words\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_dnn_model(embed_dim):\n",
+    "\n",
+    "    model = Sequential(\n",
+    "        [\n",
+    "            Embedding(\n",
+    "                VOCAB_SIZE + 1, embed_dim, input_shape=[MAX_LEN]\n",
+    "            ),  # TODO 3\n",
+    "            Lambda(lambda x: tf.reduce_mean(x, axis=1)),  # TODO 4\n",
+    "            Dense(N_CLASSES, activation=\"softmax\"),  # TODO 5\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    model.compile(\n",
+    "        optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
+    "    )\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below we train the model on 100 epochs but adding an `EarlyStopping` callback that will stop the training as soon as the validation loss has not improved after a number of steps specified by `PATIENCE` . Note that we also give the `model.fit` method a Tensorboard callback so that we can later compare all the models using TensorBoard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "tf.random.set_seed(33)\n",
+    "\n",
+    "MODEL_DIR = os.path.join(LOGDIR, \"dnn\")\n",
+    "shutil.rmtree(MODEL_DIR, ignore_errors=True)\n",
+    "\n",
+    "BATCH_SIZE = 300\n",
+    "EPOCHS = 100\n",
+    "EMBED_DIM = 10\n",
+    "PATIENCE = 5\n",
+    "\n",
+    "dnn_model = build_dnn_model(embed_dim=EMBED_DIM)\n",
+    "\n",
+    "dnn_history = dnn_model.fit(\n",
+    "    X_train,\n",
+    "    Y_train,\n",
+    "    epochs=EPOCHS,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    validation_data=(X_valid, Y_valid),\n",
+    "    callbacks=[EarlyStopping(patience=PATIENCE), TensorBoard(MODEL_DIR)],\n",
+    ")\n",
+    "\n",
+    "pd.DataFrame(dnn_history.history)[[\"loss\", \"val_loss\"]].plot()\n",
+    "pd.DataFrame(dnn_history.history)[[\"accuracy\", \"val_accuracy\"]].plot()\n",
+    "\n",
+    "dnn_model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building a RNN model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `build_dnn_model` function below returns a compiled Keras model that implements a simple RNN model with a single `GRU` layer, which now takes into account the word order in the sentence.\n",
+    "\n",
+    "The first and last layers are the same as for the simple DNN model.\n",
+    "\n",
+    "Note that we set `mask_zero=True` in the `Embedding` layer so that the padded words (represented by a zero) are ignored by this and the subsequent layers.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_rnn_model(embed_dim, units):\n",
+    "\n",
+    "    model = Sequential(\n",
+    "        [\n",
+    "            Embedding(\n",
+    "                VOCAB_SIZE + 1, embed_dim, input_shape=[MAX_LEN], mask_zero=True\n",
+    "            ),  # TODO 3\n",
+    "            GRU(units),  # TODO 5\n",
+    "            Dense(N_CLASSES, activation=\"softmax\"),\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    model.compile(\n",
+    "        optimizer=tf.keras.optimizers.Adam(learning_rate=0.0001),\n",
+    "        loss=\"categorical_crossentropy\",\n",
+    "        metrics=[\"accuracy\"],\n",
+    "    )\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's train the model with early stoping as above. \n",
+    "\n",
+    "Observe that we obtain the same type of accuracy as with the DNN model, but in less epochs (~3 v.s. ~20 epochs):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "tf.random.set_seed(33)\n",
+    "\n",
+    "MODEL_DIR = os.path.join(LOGDIR, \"rnn\")\n",
+    "shutil.rmtree(MODEL_DIR, ignore_errors=True)\n",
+    "\n",
+    "EPOCHS = 100\n",
+    "BATCH_SIZE = 300\n",
+    "EMBED_DIM = 10\n",
+    "UNITS = 16\n",
+    "PATIENCE = 2\n",
+    "\n",
+    "rnn_model = build_rnn_model(embed_dim=EMBED_DIM, units=UNITS)\n",
+    "\n",
+    "history = rnn_model.fit(\n",
+    "    X_train,\n",
+    "    Y_train,\n",
+    "    epochs=EPOCHS,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    validation_data=(X_valid, Y_valid),\n",
+    "    callbacks=[EarlyStopping(patience=PATIENCE), TensorBoard(MODEL_DIR)],\n",
+    ")\n",
+    "\n",
+    "pd.DataFrame(history.history)[[\"loss\", \"val_loss\"]].plot()\n",
+    "pd.DataFrame(history.history)[[\"accuracy\", \"val_accuracy\"]].plot()\n",
+    "\n",
+    "rnn_model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build a CNN model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `build_dnn_model` function below returns a compiled Keras model that implements a simple CNN model with a single `Conv1D` layer, which now takes into account the word order in the sentence.\n",
+    "\n",
+    "The first and last layers are the same as for the simple DNN model, but we need to add a `Flatten` layer betwen the convolution and the softmax layer.\n",
+    "\n",
+    "Note that we set `mask_zero=True` in the `Embedding` layer so that the padded words (represented by a zero) are ignored by this and the subsequent layers.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_cnn_model(embed_dim, filters, ksize, strides):\n",
+    "\n",
+    "    model = Sequential(\n",
+    "        [\n",
+    "            Embedding(\n",
+    "                VOCAB_SIZE + 1, embed_dim, input_shape=[MAX_LEN], mask_zero=True\n",
+    "            ),  # TODO 3\n",
+    "            Conv1D(  # TODO 5\n",
+    "                filters=filters,\n",
+    "                kernel_size=ksize,\n",
+    "                strides=strides,\n",
+    "                activation=\"relu\",\n",
+    "            ),\n",
+    "            Flatten(),  # TODO 5\n",
+    "            Dense(N_CLASSES, activation=\"softmax\"),\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    model.compile(\n",
+    "        optimizer=tf.keras.optimizers.Adam(learning_rate=0.0001),\n",
+    "        loss=\"categorical_crossentropy\",\n",
+    "        metrics=[\"accuracy\"],\n",
+    "    )\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's train the model. \n",
+    "\n",
+    "Again we observe that we get the same kind of accuracy as with the DNN model but in many fewer steps.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "tf.random.set_seed(33)\n",
+    "\n",
+    "MODEL_DIR = os.path.join(LOGDIR, \"cnn\")\n",
+    "shutil.rmtree(MODEL_DIR, ignore_errors=True)\n",
+    "\n",
+    "EPOCHS = 100\n",
+    "BATCH_SIZE = 300\n",
+    "EMBED_DIM = 5\n",
+    "FILTERS = 200\n",
+    "STRIDES = 2\n",
+    "KSIZE = 3\n",
+    "PATIENCE = 2\n",
+    "\n",
+    "\n",
+    "cnn_model = build_cnn_model(\n",
+    "    embed_dim=EMBED_DIM,\n",
+    "    filters=FILTERS,\n",
+    "    strides=STRIDES,\n",
+    "    ksize=KSIZE,\n",
+    ")\n",
+    "\n",
+    "cnn_history = cnn_model.fit(\n",
+    "    X_train,\n",
+    "    Y_train,\n",
+    "    epochs=EPOCHS,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    validation_data=(X_valid, Y_valid),\n",
+    "    callbacks=[EarlyStopping(patience=PATIENCE), TensorBoard(MODEL_DIR)],\n",
+    ")\n",
+    "\n",
+    "pd.DataFrame(cnn_history.history)[[\"loss\", \"val_loss\"]].plot()\n",
+    "pd.DataFrame(cnn_history.history)[[\"accuracy\", \"val_accuracy\"]].plot()\n",
+    "\n",
+    "cnn_model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (Optional) Using the Keras Text Preprocessing Layer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Thanks to the new Keras preprocessing layer, we can also include the preprocessing of the text (i.e., the tokenization followed by the integer representation of the tokens) within the model itself as a standard Keras layer. Let us first import this text preprocessing layer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from keras.layers import TextVectorization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At instanciation, we can specify the maximum length of the sequence output as well as the maximum number of tokens to be considered:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAX_LEN = 26\n",
+    "MAX_TOKENS = 20000\n",
+    "preprocessing_layer = TextVectorization(\n",
+    "    output_sequence_length=MAX_LEN, max_tokens=MAX_TOKENS\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before using this layer in our model, we need to adapt it to our data so that it generates a token-to-integer mapping. Remeber our dataset looks like the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "titles_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can directly use the Pandas Series corresponding to the titles in our dataset to adapt the data using the `adapt` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preprocessing_layer.adapt(titles_df.title)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point, the preprocessing layer can create the integer representation of our input text if we simply apply the layer to it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train, X_valid = titles_train, titles_valid\n",
+    "X_train[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "integers = preprocessing_layer(X_train[:5])\n",
+    "integers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Exercise:** In the following cell, implement a function\n",
+    "`build_model_with_text_preprocessing(embed_dim, units)` that returns a text model with the following sequential structure:\n",
+    "\n",
+    "1. the `preprocessing_layer` we defined above folowed by\n",
+    "1. an embedding layer with `embed_dim` dimension for the output vectors followed by\n",
+    "1. a GRU layer with `units` number of neurons followed by\n",
+    "1. a final dense layer for classification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_model_with_text_preprocessing(embed_dim, units):\n",
+    "\n",
+    "    model = Sequential(\n",
+    "        [\n",
+    "            preprocessing_layer,\n",
+    "            Embedding(\n",
+    "                VOCAB_SIZE + 1, embed_dim, input_shape=[MAX_LEN], mask_zero=True\n",
+    "            ),  # TODO 3\n",
+    "            GRU(units),\n",
+    "            Dense(N_CLASSES, activation=\"softmax\"),\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    model.compile(\n",
+    "        optimizer=tf.keras.optimizers.Adam(learning_rate=0.0001),\n",
+    "        loss=\"categorical_crossentropy\",\n",
+    "        metrics=[\"accuracy\"],\n",
+    "    )\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our model is now able to cosume text directly as input! Again, consider the following text sample:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can have our model directly predict on this input:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = build_model_with_text_preprocessing(embed_dim=EMBED_DIM, units=UNITS)\n",
+    "model.predict(X_train[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of course the model above has not yet been trained, so its prediction are meaningless so far. \n",
+    "Let us train it now on our dataset as before: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "tf.random.set_seed(33)\n",
+    "\n",
+    "MODEL_DIR = os.path.join(LOGDIR, \"rnn\")\n",
+    "shutil.rmtree(MODEL_DIR, ignore_errors=True)\n",
+    "\n",
+    "EPOCHS = 100\n",
+    "BATCH_SIZE = 300\n",
+    "EMBED_DIM = 10\n",
+    "UNITS = 16\n",
+    "PATIENCE = 2\n",
+    "\n",
+    "model = build_model_with_text_preprocessing(embed_dim=EMBED_DIM, units=UNITS)\n",
+    "\n",
+    "history = model.fit(\n",
+    "    X_train,\n",
+    "    Y_train,\n",
+    "    epochs=EPOCHS,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    validation_data=(X_valid, Y_valid),\n",
+    "    callbacks=[EarlyStopping(patience=PATIENCE), TensorBoard(MODEL_DIR)],\n",
+    ")\n",
+    "\n",
+    "pd.DataFrame(history.history)[[\"loss\", \"val_loss\"]].plot()\n",
+    "pd.DataFrame(history.history)[[\"accuracy\", \"val_accuracy\"]].plot()\n",
+    "\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copyright 2022 Google Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "tf2-gpu.2-8.m94",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m94"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR does the following:
- adds the old feature column notebook under the name "keras_for_text_classification_feature_columns.ipnb"
- updates keras_for_text_classification notebook to use preprocessing layers in all the three models (DNN, CNN, RNN)
- removes references to AutoML in the documentation
- adds a get_prediction function to get predictions 


Test Environment 
- Use TF version 2.8.1