### PR TITLE
Modified covertype dataset path

### DIFF
--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl_batch_predictions.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl_batch_predictions.ipynb
@@ -118,7 +118,7 @@
     "DATASET_LOCATION=US\n",
     "DATASET_ID=covertype_dataset\n",
     "TABLE_ID=covertype\n",
-    "DATA_SOURCE=gs://workshop-datasets/covertype/small/dataset.csv\n",
+    "DATA_SOURCE=gs://asl-public/data/covertype/dataset.csv\n",
     "SCHEMA=Elevation:INTEGER,\\\n",
     "Aspect:INTEGER,\\\n",
     "Slope:INTEGER,\\\n",

--- a/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough_vertex.ipynb
@@ -118,7 +118,7 @@
     "DATASET_LOCATION=US\n",
     "DATASET_ID=covertype_dataset\n",
     "TABLE_ID=covertype\n",
-    "DATA_SOURCE=gs://workshop-datasets/covertype/small/dataset.csv\n",
+    "DATA_SOURCE=gs://asl-public/data/covertype/dataset.csv\n",
     "SCHEMA=Elevation:INTEGER,\\\n",
     "Aspect:INTEGER,\\\n",
     "Slope:INTEGER,\\\n",

--- a/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb
@@ -118,7 +118,7 @@
     "DATASET_LOCATION=US\n",
     "DATASET_ID=covertype_dataset\n",
     "TABLE_ID=covertype\n",
-    "DATA_SOURCE=gs://workshop-datasets/covertype/small/dataset.csv\n",
+    "DATA_SOURCE=gs://asl-public/data/covertype/dataset.csv\n",
     "SCHEMA=Elevation:INTEGER,\\\n",
     "Aspect:INTEGER,\\\n",
     "Slope:INTEGER,\\\n",


### PR DESCRIPTION
Modified the covertype dataset path to `asl-public` because the previous bucket `workshop-datasets` was deleted.