### PR TITLE
Updated Infravalidator tf serving version

### DIFF
--- a/notebooks/tfx_pipelines/walkthrough/solutions/tfx_walkthrough_vertex.ipynb
+++ b/notebooks/tfx_pipelines/walkthrough/solutions/tfx_walkthrough_vertex.ipynb
@@ -1042,7 +1042,7 @@
     "    examples=example_gen.outputs[\"examples\"],\n",
     "    serving_spec=infra_validator_pb2.ServingSpec(\n",
     "        tensorflow_serving=infra_validator_pb2.TensorFlowServing(\n",
-    "            tags=[\"latest\"]\n",
+    "            tags=[\"2.6.2\"]\n",
     "        ),\n",
     "        local_docker=infra_validator_pb2.LocalDockerConfig(),\n",
     "    ),\n",


### PR DESCRIPTION
Added Infravalidator tf serving version to avoid #271 error.

## Result
InfraValidator is successfully executed.
```
...
INFO:absl:Model is successfully loaded.
INFO:absl:Stopping LocalDockerRunner(image: tensorflow/serving:2.6.2).
INFO:absl:Stopping container.
INFO:absl:Model passed infra validation.
INFO:absl:Running publisher for ModelInfraValidator
INFO:absl:MetadataStore with DB connection initialized
```