### PR TITLE
[bug] fix the URL for dataset download in load_text lab

### DIFF
--- a/notebooks/text_models/labs/load_text.ipynb
+++ b/notebooks/text_models/labs/load_text.ipynb
@@ -78,7 +78,7 @@
    },
    "outputs": [],
    "source": [
-    "data_url = \"gs://asl-public/text/data/stack_overflow_16k.tar.gz\"\n",
+    "data_url = \"https://storage.googleapis.com/asl-public/text/data/stack_overflow_16k.tar.gz\"\n",
     "\n",
     "dataset_dir = utils.get_file(\n",
     "    origin=data_url, untar=True, cache_dir=\"stack_overflow\", cache_subdir=\"\"\n",
@@ -880,7 +880,7 @@
    },
    "outputs": [],
    "source": [
-    "DIRECTORY_URL = \"gs://asl-public/text/data/illiad\"\n",
+    "DIRECTORY_URL = \"https://storage.googleapis.com/asl-public/text/data/illiad/\"\n",
     "FILE_NAMES = [\"cowper.txt\", \"derby.txt\", \"butler.txt\"]\n",
     "\n",
     "for name in FILE_NAMES:\n",
@@ -1477,9 +1477,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-8.m94",
+   "name": "tf2-gpu.2-8.m100",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m94"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m100"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/notebooks/text_models/solutions/load_text.ipynb
+++ b/notebooks/text_models/solutions/load_text.ipynb
@@ -78,7 +78,7 @@
    },
    "outputs": [],
    "source": [
-    "data_url = \"gs://asl-public/text/data/stack_overflow_16k.tar.gz\"\n",
+    "data_url = \"https://storage.googleapis.com/asl-public/text/data/stack_overflow_16k.tar.gz\"\n",
     "\n",
     "dataset_dir = utils.get_file(\n",
     "    origin=data_url, untar=True, cache_dir=\"stack_overflow\", cache_subdir=\"\"\n",
@@ -889,7 +889,7 @@
    },
    "outputs": [],
    "source": [
-    "DIRECTORY_URL = \"gs://asl-public/text/data/illiad\"\n",
+    "DIRECTORY_URL = \"https://storage.googleapis.com/asl-public/text/data/illiad/\"\n",
     "FILE_NAMES = [\"cowper.txt\", \"derby.txt\", \"butler.txt\"]\n",
     "\n",
     "for name in FILE_NAMES:\n",
@@ -1481,9 +1481,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-8.m94",
+   "name": "tf2-gpu.2-8.m100",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m94"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m100"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ cloudml-hypertune
 # Requirments for the SNGP labs (commented out for now because it upgrades to TF 2.8)
 # which will conflicts with the MLOPs labs targeted to TF 2.6
 # tf-models-official==2.8.0
+
+# Requirements for NLP labs
+tensorflow_text==2.8.2


### PR DESCRIPTION
In the lab, the download url is listed as a path to a GCS using `gs://` but this does not work with `utils.get_file`. Changed the path to an authenticated url.