### PR TITLE
removed kernel from all goal in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-all: clean install kernels
+all: clean install
 
 kernels: \
  reinforcement_learning_kernel \


### PR DESCRIPTION
Removed `kernel` from `all` to avoid creating all the kernel when calling `make`.

In most cases, building all the kernel is a bit redundant.