### PR TITLE
FIX: fixed the object_detectio kernel command

### DIFF
--- a/kernels/object_detection.sh
+++ b/kernels/object_detection.sh
@@ -34,4 +34,8 @@ python -m ipykernel install --user --name=$ENVNAME
 pip install -q -U pip
 pip install -q .
 
+# Add the missing builer.py file due to the breaking change.
+# https://stackoverflow.com/questions/71759248/importerror-cannot-import-name-builder-from-google-protobuf-internal
+wget https://raw.githubusercontent.com/protocolbuffers/protobuf/main/python/google/protobuf/internal/builder.py -O ./$ENVNAME/lib/python3.7/site-packages/google/protobuf/internal/builder.py
+
 deactivate


### PR DESCRIPTION
fixed the object_detectio kernel command due to the protobuf breaking change.

https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.0

<img width="1084" alt="Screenshot 2023-01-31 at 17 48 05" src="https://user-images.githubusercontent.com/6895245/215855533-ef1131ea-c014-4164-a425-ed9898e2727c.png">

This is not a beautiful solution, but this is the quickest workaround so far.

Reference:
https://stackoverflow.com/questions/71759248/importerror-cannot-import-name-builder-from-google-protobuf-internal
