### PR TITLE
FIX: updated isort version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     -   id: nbqa-isort
         args: [--profile=black, -l80]
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
     -   id: isort
         args: ["--profile", "black", "-l80"]


### PR DESCRIPTION
Updated isort version due to a dependency issue of pre-commit.

In the current version, pre-commit fails to build due to a known bug.
Build Error sample: https://results.pre-commit.ci/run/github/271800973/1675182387.Wfce44-jSxyoPolBR3sONw

Updating isort version can fix the problem, but the latest 5.12.0 requires Python 3.8, I updated it to the [hotfix vetsion 5.11.5](https://github.com/PyCQA/isort/releases/tag/5.11.5).

Reference: https://stackoverflow.com/questions/75269700/pre-commit-fails-to-install-isort-5-11-4-with-error-runtimeerror-the-poetry-co

