### PR TITLE
UPDATE: added --user option to pip install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ clean:
 
 .PHONY: install
 install:
-	@pip install -U pip
-	@pip install -r requirements.txt
+	@pip install --user -U pip
+	@pip install --user -r requirements.txt
 	@pre-commit install
 
 .PHONY: precommit


### PR DESCRIPTION
Added `--user` option to `pip install` to avoid permission issue in the latest Vertex AI Workbench instance.

Due to this change, before running  `make` command, `export PATH=/home/jupyter/.local/bin:$PATH` have to be run. This instruction will be added in README in a following PR.