### PR TITLE
New setup to run the Kubernetes labs

### DIFF
--- a/notebooks/docker_and_kubernetes/labs/2_intro_k8s.ipynb
+++ b/notebooks/docker_and_kubernetes/labs/2_intro_k8s.ipynb
@@ -31,6 +31,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Setup\n",
+    "\n",
+    "To run this lab, you may need to run the following command:\n",
+    "\n",
+    "```bash\n",
+    "../../../scripts/setup_kubernetes_auth.sh\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create a GKE cluster\n",
     "\n",
     "A cluster consists of at least one cluster master machine and multiple worker machines called nodes. Nodes are Compute Engine virtual machine (VM) instances that run the Kubernetes processes necessary to make them part of the cluster.\n",
@@ -255,12 +268,13 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-1.m59",
+   "kernel": "python3",
+   "name": "tf2-gpu.2-8.m103",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-1:m59"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m103"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -274,7 +288,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/docker_and_kubernetes/labs/3_k8s_hello_node.ipynb
+++ b/notebooks/docker_and_kubernetes/labs/3_k8s_hello_node.ipynb
@@ -30,6 +30,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Setup\n",
+    "\n",
+    "To run this lab, you may need to run the following command:\n",
+    "\n",
+    "```bash\n",
+    "../../../scripts/setup_kubernetes_auth.sh\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create a Node.js server\n",
     "\n",
     "The file `./src/server.js` contains a simple Node.js server. Use `cat` to examine the contents of that file."
@@ -604,12 +617,13 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-1.m59",
+   "kernel": "python3",
+   "name": "tf2-gpu.2-8.m103",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-1:m59"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m103"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -623,7 +637,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/docker_and_kubernetes/solutions/2_intro_k8s.ipynb
+++ b/notebooks/docker_and_kubernetes/solutions/2_intro_k8s.ipynb
@@ -31,6 +31,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Setup\n",
+    "\n",
+    "To run this lab, you may need to run the following command:\n",
+    "\n",
+    "```bash\n",
+    "../../../scripts/setup_kubernetes_auth.sh\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create a GKE cluster\n",
     "\n",
     "A cluster consists of at least one cluster master machine and multiple worker machines called nodes. Nodes are Compute Engine virtual machine (VM) instances that run the Kubernetes processes necessary to make them part of the cluster.\n",
@@ -42,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,35 +93,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NAME         LOCATION       MASTER_VERSION   MASTER_IP       MACHINE_TYPE   NODE_VERSION     NUM_NODES  STATUS\n",
-      "asl-cluster  us-central1-a  1.16.13-gke.401  35.192.170.194  n1-standard-1  1.16.13-gke.401  3          RUNNING\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Updated property [compute/zone].\n",
-      "WARNING: Warning: basic authentication is deprecated, and will be removed in GKE control plane versions 1.19 and newer. For a list of recommended authentication methods, see: https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication\n",
-      "WARNING: Currently VPC-native is not the default mode during cluster creation. In the future, this will become the default mode and can be disabled using `--no-enable-ip-alias` flag. Use `--[no-]enable-ip-alias` flag to suppress this warning.\n",
-      "WARNING: Newly created clusters and node-pools will have node auto-upgrade enabled by default. This can be disabled using the `--no-enable-autoupgrade` flag.\n",
-      "WARNING: Starting with version 1.18, clusters will have shielded GKE nodes by default.\n",
-      "WARNING: Your Pod address range (`--cluster-ipv4-cidr`) can accommodate at most 1008 node(s). \n",
-      "Creating cluster asl-cluster in us-central1-a...\n",
-      "...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................done.\n",
-      "Created [https://container.googleapis.com/v1/projects/qwiklabs-gcp-01-3aff5ef1f764/zones/us-central1-a/clusters/asl-cluster].\n",
-      "To inspect the contents of your cluster, go to: https://console.cloud.google.com/kubernetes/workload_/gcloud/us-central1-a/asl-cluster?project=qwiklabs-gcp-01-3aff5ef1f764\n",
-      "kubeconfig entry generated for asl-cluster.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "gcloud config set compute/zone ${ZONE}\n",
@@ -124,18 +111,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NAME         LOCATION       MASTER_VERSION   MASTER_IP       MACHINE_TYPE   NODE_VERSION     NUM_NODES  STATUS\n",
-      "asl-cluster  us-central1-a  1.16.13-gke.401  35.192.170.194  n1-standard-1  1.16.13-gke.401  3          RUNNING\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!gcloud container clusters list"
    ]
@@ -151,18 +129,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Fetching cluster endpoint and auth data.\n",
-      "kubeconfig entry generated for asl-cluster.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "gcloud container clusters get-credentials ${CLUSTER_NAME}"
@@ -186,17 +155,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deployment.apps/hello-server created\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl create deployment hello-server --image=gcr.io/google-samples/hello-app:1.0"
    ]
@@ -214,17 +175,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "service/hello-server exposed\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl expose deployment hello-server --type=LoadBalancer --port 8080"
    ]
@@ -240,19 +193,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NAME           TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE\n",
-      "hello-server   LoadBalancer   10.3.241.199   35.192.87.8   8080:31625/TCP   68s\n",
-      "kubernetes     ClusterIP      10.3.240.1     <none>        443/TCP          5m44s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl get service"
    ]
@@ -305,12 +248,13 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-1.m59",
+   "kernel": "python3",
+   "name": "tf2-gpu.2-8.m103",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-1:m59"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m103"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -324,7 +268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/docker_and_kubernetes/solutions/3_k8s_hello_node.ipynb
+++ b/notebooks/docker_and_kubernetes/solutions/3_k8s_hello_node.ipynb
@@ -30,6 +30,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Setup\n",
+    "\n",
+    "To run this lab, you may need to run the following command:\n",
+    "\n",
+    "```bash\n",
+    "../../../scripts/setup_kubernetes_auth.sh\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create a Node.js server\n",
     "\n",
     "The file `./src/server.js` contains a simple Node.js server. Use `cat` to examine the contents of that file."
@@ -113,7 +126,7 @@
    "source": [
     "import os\n",
     "\n",
-    "PROJECT_ID = \"your-gcp-project-here\"  # REPLACE WITH YOUR PROJECT NAME\n",
+    "PROJECT_ID = \"qwiklabs-asl-02-3975462eb556\"  # REPLACE WITH YOUR PROJECT NAME\n",
     "os.environ[\"PROJECT_ID\"] = PROJECT_ID"
    ]
   },
@@ -195,7 +208,7 @@
    "outputs": [],
    "source": [
     "# your container id will be different\n",
-    "!docker stop b16e5ccb74dc"
+    "!docker stop 2760d59ec659"
    ]
   },
   {
@@ -381,7 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!curl http://34.122.72.240:8000"
+    "!curl http://35.223.2.76:8000"
    ]
   },
   {
@@ -539,18 +552,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deleting cluster hello-world...done.                                           \n",
-      "Deleted [https://container.googleapis.com/v1/projects/qwiklabs-gcp-01-3aff5ef1f764/zones/us-central1-a/clusters/hello-world].\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!gcloud container clusters --quiet delete hello-world"
    ]
@@ -565,12 +569,13 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-1.m59",
+   "kernel": "python3",
+   "name": "tf2-gpu.2-8.m103",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-1:m59"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m103"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -584,7 +589,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/scripts/setup_kubernetes_auth.sh
+++ b/scripts/setup_kubernetes_auth.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# For the new authentication of the GKE cluster. See reference:
+# https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+
+sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+echo export USE_GKE_GCLOUD_AUTH_PLUGIN=True >> ~/.bashrc || source ~/.bashrc
+sudo apt-get update && sudo apt-get --only-upgrade install kubectl google-cloud-sdk

--- a/scripts/setup_kubernetes_auth.sh
+++ b/scripts/setup_kubernetes_auth.sh
@@ -17,6 +17,6 @@
 # For the new authentication of the GKE cluster. See reference:
 # https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
 
-sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+yes | sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 echo export USE_GKE_GCLOUD_AUTH_PLUGIN=True >> ~/.bashrc || source ~/.bashrc
-sudo apt-get update && sudo apt-get --only-upgrade install kubectl google-cloud-sdk
+yes | sudo apt-get update && sudo apt-get --only-upgrade install kubectl google-cloud-sdk

--- a/scripts/setup_kubernetes_auth.sh
+++ b/scripts/setup_kubernetes_auth.sh
@@ -19,4 +19,5 @@
 
 yes | sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 echo export USE_GKE_GCLOUD_AUTH_PLUGIN=True >> ~/.bashrc || source ~/.bashrc
-yes | sudo apt-get update && sudo apt-get --only-upgrade install kubectl google-cloud-sdk
+sudo apt-get update
+yes | sudo apt-get --only-upgrade install kubectl google-cloud-sdk


### PR DESCRIPTION
The way `kubectl` authenticates to the GKE cluster has changed in the new release of Kubernetes as described [here](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke).

To fix this, this PR  adds 
* a new setup script `./scripts/setup_kubernetes_auth.sh` that needs to be ran on the JupyterLab instance
* instructions to run this scripts have also been added to each of the Kubernetes labs. 