### PR TITLE
Training config fixes for the Time-series lab

### DIFF
--- a/notebooks/time_series_prediction/solutions/4_modeling_keras.ipynb
+++ b/notebooks/time_series_prediction/solutions/4_modeling_keras.ipynb
@@ -515,7 +515,7 @@
     ")\n",
     "\n",
     "model.compile(\n",
-    "    optimizer=Adam(lr=0.001),\n",
+    "    optimizer=Adam(learning_rate=0.001),\n",
     "    loss=\"categorical_crossentropy\",\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
@@ -523,10 +523,9 @@
     "history = model.fit(\n",
     "    x=Xtrain.values,\n",
     "    y=ytrain_categorical,\n",
-    "    batch_size=Xtrain.shape[0],\n",
+    "    batch_size=1000,\n",
     "    validation_data=(Xvalid.values, yvalid_categorical),\n",
-    "    epochs=30,\n",
-    "    verbose=0,\n",
+    "    epochs=5,\n",
     ")"
    ]
   },
@@ -604,7 +603,7 @@
     ")\n",
     "\n",
     "model.compile(\n",
-    "    optimizer=Adam(lr=0.001),\n",
+    "    optimizer=Adam(learning_rate=0.001),\n",
     "    loss=\"categorical_crossentropy\",\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
@@ -612,10 +611,9 @@
     "history = model.fit(\n",
     "    x=Xtrain.values,\n",
     "    y=ytrain_categorical,\n",
-    "    batch_size=Xtrain.shape[0],\n",
+    "    batch_size=1000,\n",
     "    validation_data=(Xvalid.values, yvalid_categorical),\n",
-    "    epochs=10,\n",
-    "    verbose=0,\n",
+    "    epochs=5,\n",
     ")"
    ]
   },
@@ -697,7 +695,7 @@
     ")\n",
     "\n",
     "model.compile(\n",
-    "    optimizer=Adam(lr=0.01),\n",
+    "    optimizer=Adam(learning_rate=0.01),\n",
     "    loss=\"categorical_crossentropy\",\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
@@ -705,10 +703,9 @@
     "history = model.fit(\n",
     "    x=Xtrain.values,\n",
     "    y=ytrain_categorical,\n",
-    "    batch_size=Xtrain.shape[0],\n",
+    "    batch_size=1000,\n",
     "    validation_data=(Xvalid.values, yvalid_categorical),\n",
-    "    epochs=10,\n",
-    "    verbose=0,\n",
+    "    epochs=5,\n",
     ")"
    ]
   },
@@ -763,7 +760,7 @@
     "\n",
     "# Reshape inputs to pass through RNN layer.\n",
     "model.add(Reshape(target_shape=[N_TIME_STEPS, 1]))\n",
-    "model.add(LSTM(N_TIME_STEPS // 8, activation=\"relu\", return_sequences=False))\n",
+    "model.add(LSTM(N_TIME_STEPS // 8))\n",
     "\n",
     "model.add(\n",
     "    Dense(\n",
@@ -775,7 +772,7 @@
     "\n",
     "# Create the model.\n",
     "model.compile(\n",
-    "    optimizer=Adam(lr=0.001),\n",
+    "    optimizer=Adam(learning_rate=0.001),\n",
     "    loss=\"categorical_crossentropy\",\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
@@ -783,10 +780,9 @@
     "history = model.fit(\n",
     "    x=Xtrain.values,\n",
     "    y=ytrain_categorical,\n",
-    "    batch_size=Xtrain.shape[0],\n",
+    "    batch_size=1000,\n",
     "    validation_data=(Xvalid.values, yvalid_categorical),\n",
-    "    epochs=40,\n",
-    "    verbose=0,\n",
+    "    epochs=5,\n",
     ")"
    ]
   },
@@ -845,9 +841,9 @@
     "model.add(Reshape(target_shape=[N_TIME_STEPS, 1]))\n",
     "\n",
     "for layer in rnn_hidden_units[:-1]:\n",
-    "    model.add(GRU(units=layer, activation=\"relu\", return_sequences=True))\n",
+    "    model.add(GRU(units=layer, return_sequences=True))\n",
     "\n",
-    "model.add(GRU(units=rnn_hidden_units[-1], return_sequences=False))\n",
+    "model.add(GRU(units=rnn_hidden_units[-1]))\n",
     "model.add(\n",
     "    Dense(\n",
     "        units=N_LABELS,\n",
@@ -857,7 +853,7 @@
     ")\n",
     "\n",
     "model.compile(\n",
-    "    optimizer=Adam(lr=0.001),\n",
+    "    optimizer=Adam(learning_rate=0.001),\n",
     "    loss=\"categorical_crossentropy\",\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
@@ -865,10 +861,9 @@
     "history = model.fit(\n",
     "    x=Xtrain.values,\n",
     "    y=ytrain_categorical,\n",
-    "    batch_size=Xtrain.shape[0],\n",
+    "    batch_size=1000,\n",
     "    validation_data=(Xvalid.values, yvalid_categorical),\n",
-    "    epochs=50,\n",
-    "    verbose=0,\n",
+    "    epochs=5,\n",
     ")"
    ]
   },
@@ -945,7 +940,7 @@
     "model.add(Dense(units=N_LABELS, activation=\"softmax\"))\n",
     "\n",
     "model.compile(\n",
-    "    optimizer=Adam(lr=0.001),\n",
+    "    optimizer=Adam(learning_rate=0.001),\n",
     "    loss=\"categorical_crossentropy\",\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
@@ -953,10 +948,9 @@
     "history = model.fit(\n",
     "    x=Xtrain.values,\n",
     "    y=ytrain_categorical,\n",
-    "    batch_size=Xtrain.shape[0],\n",
+    "    batch_size=1000,\n",
     "    validation_data=(Xvalid.values, yvalid_categorical),\n",
-    "    epochs=30,\n",
-    "    verbose=0,\n",
+    "    epochs=5,\n",
     ")"
    ]
   },
@@ -1023,7 +1017,6 @@
     "model.add(\n",
     "    Dense(\n",
     "        units=N_TIME_STEPS // 32,\n",
-    "        activation=\"relu\",\n",
     "        kernel_regularizer=tf.keras.regularizers.l1(l=0.1),\n",
     "    )\n",
     ")\n",
@@ -1036,7 +1029,7 @@
     ")\n",
     "\n",
     "model.compile(\n",
-    "    optimizer=Adam(lr=0.001),\n",
+    "    optimizer=Adam(learning_rate=0.001),\n",
     "    loss=\"categorical_crossentropy\",\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
@@ -1044,10 +1037,9 @@
     "history = model.fit(\n",
     "    x=Xtrain.values,\n",
     "    y=ytrain_categorical,\n",
-    "    batch_size=Xtrain.shape[0],\n",
+    "    batch_size=1000,\n",
     "    validation_data=(Xvalid.values, yvalid_categorical),\n",
-    "    epochs=80,\n",
-    "    verbose=0,\n",
+    "    epochs=5,\n",
     ")"
    ]
   },
@@ -1103,12 +1095,13 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-3.m78",
+   "kernel": "python3",
+   "name": "tf2-gpu.2-8.m103",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m78"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m103"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1122,7 +1115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The current training setting uses full batch Adam resulting into an out-of-memory error. This PR reduces the batch size to a default of 1000, along with removing a few warning due to deprecated argument names. The verbose mode is also re-enabled now, so that the metrics per epoch are output during training.