### PR TITLE
adding a new kernel for the BERT lab: `bert_lab`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,7 @@ object_detection_kernel:
 .PHONY: pytorch_kfp_kernel
 pytorch_kfp_kernel:
 	./kernels/pytorch_kfp.sh
+
+.PHONY: bert_kernel
+bert_kernel:
+	./kernels/bert_kernel.sh

--- a/kernels/bert_kernel.sh
+++ b/kernels/bert_kernel.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# To build the kernel:  ./kernels/uncertainty_aware_models.sh
+# To remove the kernel: ./kernels/uncertainty_aware_models.sh remove
+#
+# This scripts will create a ipython kernel named $MODULE
+# populated with the reqs in ./notebooks/$MODULE/requirements.txt
+
+
+MODULE=text_models
+ENVNAME=bert_kernel
+REPO_ROOT_DIR="$(dirname $(cd $(dirname $BASH_SOURCE) && pwd))"
+
+# Cleaning up the kernel and exiting if first arg is 'remove'
+if [ "$1" == "remove" ]; then
+  echo Removing kernel $ENVNAME
+  jupyter kernelspec remove $ENVNAME
+  rm -r "$REPO_ROOT_DIR/notebooks/$MODULE/$ENVNAME"
+  exit 0
+fi
+
+cd $REPO_ROOT_DIR/notebooks/$MODULE
+
+# Setup virtual env and kernel
+echo creating $ENVNAME at $(pwd)
+python3 -m venv $ENVNAME
+
+# Registering the venv as an ipython kernel
+source $ENVNAME/bin/activate
+pip install -U pip
+pip install ipykernel
+python -m ipykernel install --user --name=$ENVNAME
+
+# Install Object Detection API and its dependencies
+test -f requirements.txt && pip install -r requirements.txt
+
+deactivate

--- a/notebooks/text_models/labs/classify_text_with_bert.ipynb
+++ b/notebooks/text_models/labs/classify_text_with_bert.ipynb
@@ -46,6 +46,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Select the `bert_kernel` for this Jupyter notebook from the kernel menu in the top-right corner.\n",
+    "\n",
+    "If the `bert_kernel` is unavailable, run the following cell to create it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cd ~/asl-ml-immersion && make bert_kernel"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -875,12 +893,12 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-8.m100",
+   "name": "tf2-gpu.2-8.m106",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m100"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m106"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/text_models/requirements.txt
+++ b/notebooks/text_models/requirements.txt
@@ -1,0 +1,3 @@
+tensorflow==2.8.4
+tensorflow_text==2.8.2
+tf-models-official==2.8.0

--- a/notebooks/text_models/solutions/classify_text_with_bert.ipynb
+++ b/notebooks/text_models/solutions/classify_text_with_bert.ipynb
@@ -46,6 +46,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Select the `bert_kernel` for this Jupyter notebook from the kernel menu in the top-right corner.\n",
+    "\n",
+    "If the `bert_kernel` is unavailable, run the following cell to create it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cd ~/asl-ml-immersion && make bert_kernel"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -870,15 +888,15 @@
    "toc_visible": true
   },
   "environment": {
-   "kernel": "python3",
-   "name": "tf2-gpu.2-8.m94",
+   "kernel": "bert_kernel",
+   "name": "tf2-gpu.2-8.m106",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m94"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m106"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "bert_kernel",
    "language": "python",
-   "name": "python3"
+   "name": "bert_kernel"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
The BERT lab uses `tf-models-official==2.8.0` which inadvertently updates the TF version. To prevent this, a new kernel has been created for the lab to run in.