### PR TITLE
add code to deploy classification BERT model to Vertex for online predictions

### DIFF
--- a/notebooks/text_models/labs/classify_text_with_bert.ipynb
+++ b/notebooks/text_models/labs/classify_text_with_bert.ipynb
@@ -452,7 +452,7 @@
     "3. Encoder Layer\n",
     "4. From the BERT output map, use pooled_output\n",
     "5. Dropout layer\n",
-    "6. Dense layer "
+    "6. Dense layer with sigmoid activation"
    ]
   },
   {
@@ -481,7 +481,7 @@
     "dropout_rate = 0.15\n",
     "classifier_model = build_classifier_model(dropout_rate)\n",
     "bert_raw_result = classifier_model(tf.constant(text_test))\n",
-    "print(tf.sigmoid(bert_raw_result))"
+    "print(bert_raw_result)"
    ]
   },
   {
@@ -759,8 +759,11 @@
    "source": [
     "dataset_name = \"imdb\"\n",
     "saved_model_path = \"./{}_bert\".format(dataset_name.replace(\"/\", \"_\"))\n",
+    "TIMESTAMP = datetime.datetime.now().strftime(\"%Y%m%d%H%M%S\")\n",
     "\n",
-    "classifier_model.save(saved_model_path, include_optimizer=False)"
+    "EXPORT_PATH = os.path.join(saved_model_path, TIMESTAMP)\n",
+    "\n",
+    "classifier_model.save(EXPORT_PATH, include_optimizer=False)"
    ]
   },
   {
@@ -780,7 +783,7 @@
    },
    "outputs": [],
    "source": [
-    "reloaded_model = tf.saved_model.load(saved_model_path)"
+    "reloaded_model = tf.saved_model.load(EXPORT_PATH)"
    ]
   },
   {
@@ -817,13 +820,22 @@
     "    \"The movie was terrible...\",\n",
     "]\n",
     "\n",
-    "reloaded_results = tf.sigmoid(reloaded_model(tf.constant(examples)))\n",
-    "original_results = tf.sigmoid(classifier_model(tf.constant(examples)))\n",
+    "reloaded_results = reloaded_model(tf.constant(examples))\n",
+    "original_results = classifier_model(tf.constant(examples))\n",
     "\n",
     "print(\"Results from the saved model:\")\n",
     "print_my_examples(examples, reloaded_results)\n",
     "print(\"Results from the model in memory:\")\n",
     "print_my_examples(examples, original_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## (Optional) Deploy your model on Vertex AI to get online predictions"
    ]
   },
   {
@@ -850,6 +862,184 @@
     "serving_results = tf.sigmoid(serving_results[\"classifier\"])\n",
     "\n",
     "print_my_examples(examples, serving_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll export the model to a TensorFlow SavedModel format. Once we have a model in this format, we have lots of ways to \"serve\" the model, from a web application, from JavaScript, from mobile applications, etc.\n",
+    "\n",
+    "Next, print the signature of your saved model using the SavedModel Command Line Interface command saved_model_cli. You can read more about the command line interface and the show and run commands it supports in the [documentation here](https://www.tensorflow.org/guide/saved_model#overview_of_commands)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!saved_model_cli show \\\n",
+    "    --tag_set serve \\\n",
+    "    --signature_def serving_default \\\n",
+    "    --dir {EXPORT_PATH}\n",
+    "\n",
+    "!find {EXPORT_PATH}\n",
+    "os.environ['EXPORT_PATH'] = EXPORT_PATH"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TIMESTAMP = datetime.datetime.now().strftime(\"%Y%m%d%H%M%S\")\n",
+    "PROJECT = !gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "PROJECT = PROJECT[0]\n",
+    "BUCKET = PROJECT\n",
+    "REGION = \"us-central1\"\n",
+    "MODEL_DISPLAYNAME = f\"classification-bert-{TIMESTAMP}\"\n",
+    "\n",
+    "print(f\"MODEL_DISPLAYNAME: {MODEL_DISPLAYNAME}\")\n",
+    "\n",
+    "# from https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers\n",
+    "SERVING_CONTAINER_IMAGE_URI = (\n",
+    "    \"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-8:latest\"\n",
+    ")\n",
+    "\n",
+    "os.environ[\"BUCKET\"] = BUCKET\n",
+    "os.environ[\"REGION\"] = REGION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# Create GCS bucket if it doesn't exist already...\n",
+    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "\n",
+    "if [ -n \"$exists\" ]; then\n",
+    "    echo -e \"Bucket exists, let's not recreate it.\"\n",
+    "else\n",
+    "    echo \"Creating a new GCS bucket.\"\n",
+    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    echo \"\\nHere are your current buckets:\"\n",
+    "    gsutil ls\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gsutil cp -r $EXPORT_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uploaded_model = aiplatform.Model.upload(\n",
+    "    display_name=MODEL_DISPLAYNAME,\n",
+    "    artifact_uri=f\"gs://{BUCKET}/{MODEL_DISPLAYNAME}\",\n",
+    "    serving_container_image_uri=SERVING_CONTAINER_IMAGE_URI,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MACHINE_TYPE = \"n1-standard-4\"\n",
+    "\n",
+    "endpoint = uploaded_model.deploy(\n",
+    "    machine_type=MACHINE_TYPE,\n",
+    "    accelerator_type=None,\n",
+    "    accelerator_count=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the model has been uploaded to the endpoint, you can query the endpoint to get predictions from the model. The query has to be a list of instances. From the signature of the model we see that the key for the query has to be `text`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instances = [\n",
+    "    {\"text\": [\"I loved the movie and highly recomment it\"]},\n",
+    "    {\"text\": [\"It was an okay movie in my opinion\"]},\n",
+    "    {\"text\": [\"I hated the movie\"]},\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = endpoint.predict(instances=instances)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\" prediction:\", response.predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Cleanup\n",
+    "When deploying a model to an endpoint for online prediction, the minimum min-replica-count is 1, and it is charged per node hour. So let's delete the endpoint to reduce unnecessary charges. Before we can delete the endpoint, we first undeploy all attached models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint.undeploy_all()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "...then delete the endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint.delete()"
    ]
   },
   {

--- a/notebooks/text_models/requirements.txt
+++ b/notebooks/text_models/requirements.txt
@@ -1,3 +1,4 @@
+google-cloud-aiplatform==1.19.0
 tensorflow==2.8.4
 tensorflow_text==2.8.2
 tf-models-official==2.8.0

--- a/notebooks/text_models/solutions/classify_text_with_bert.ipynb
+++ b/notebooks/text_models/solutions/classify_text_with_bert.ipynb
@@ -56,22 +56,196 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "./kernels/bert_kernel.sh\n",
+      "creating bert_kernel at /home/jupyter/asl-ml-immersion/notebooks/text_models\n",
+      "Requirement already satisfied: pip in ./bert_kernel/lib/python3.7/site-packages (23.0.1)\n",
+      "Requirement already satisfied: ipykernel in ./bert_kernel/lib/python3.7/site-packages (6.16.2)\n",
+      "Requirement already satisfied: debugpy>=1.0 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (1.6.7)\n",
+      "Requirement already satisfied: matplotlib-inline>=0.1 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (0.1.6)\n",
+      "Requirement already satisfied: nest-asyncio in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (1.5.6)\n",
+      "Requirement already satisfied: packaging in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (23.0)\n",
+      "Requirement already satisfied: pyzmq>=17 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (25.0.2)\n",
+      "Requirement already satisfied: tornado>=6.1 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (6.2)\n",
+      "Requirement already satisfied: ipython>=7.23.1 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (7.34.0)\n",
+      "Requirement already satisfied: jupyter-client>=6.1.12 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (7.4.9)\n",
+      "Requirement already satisfied: psutil in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (5.9.4)\n",
+      "Requirement already satisfied: traitlets>=5.1.0 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (5.9.0)\n",
+      "Requirement already satisfied: setuptools>=18.5 in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (47.1.0)\n",
+      "Requirement already satisfied: pexpect>4.3 in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (4.8.0)\n",
+      "Requirement already satisfied: decorator in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (5.1.1)\n",
+      "Requirement already satisfied: pickleshare in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (0.7.5)\n",
+      "Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (3.0.38)\n",
+      "Requirement already satisfied: backcall in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (0.2.0)\n",
+      "Requirement already satisfied: pygments in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (2.14.0)\n",
+      "Requirement already satisfied: jedi>=0.16 in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (0.18.2)\n",
+      "Requirement already satisfied: jupyter-core>=4.9.2 in ./bert_kernel/lib/python3.7/site-packages (from jupyter-client>=6.1.12->ipykernel) (4.12.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in ./bert_kernel/lib/python3.7/site-packages (from jupyter-client>=6.1.12->ipykernel) (2.8.2)\n",
+      "Requirement already satisfied: entrypoints in ./bert_kernel/lib/python3.7/site-packages (from jupyter-client>=6.1.12->ipykernel) (0.4)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.0 in ./bert_kernel/lib/python3.7/site-packages (from jedi>=0.16->ipython>=7.23.1->ipykernel) (0.8.3)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in ./bert_kernel/lib/python3.7/site-packages (from pexpect>4.3->ipython>=7.23.1->ipykernel) (0.7.0)\n",
+      "Requirement already satisfied: wcwidth in ./bert_kernel/lib/python3.7/site-packages (from prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0->ipython>=7.23.1->ipykernel) (0.2.6)\n",
+      "Requirement already satisfied: six>=1.5 in ./bert_kernel/lib/python3.7/site-packages (from python-dateutil>=2.8.2->jupyter-client>=6.1.12->ipykernel) (1.16.0)\n",
+      "Installed kernelspec bert_kernel in /home/jupyter/.local/share/jupyter/kernels/bert_kernel\n",
+      "Collecting google-cloud-aiplatform==1.19.0\n",
+      "  Using cached google_cloud_aiplatform-1.19.0-py2.py3-none-any.whl (2.3 MB)\n",
+      "Requirement already satisfied: tensorflow==2.8.4 in ./bert_kernel/lib/python3.7/site-packages (from -r requirements.txt (line 2)) (2.8.4)\n",
+      "Requirement already satisfied: tensorflow_text==2.8.2 in ./bert_kernel/lib/python3.7/site-packages (from -r requirements.txt (line 3)) (2.8.2)\n",
+      "Requirement already satisfied: tf-models-official==2.8.0 in ./bert_kernel/lib/python3.7/site-packages (from -r requirements.txt (line 4)) (2.8.0)\n",
+      "Collecting google-cloud-resource-manager<3.0.0dev,>=1.3.3\n",
+      "  Downloading google_cloud_resource_manager-1.9.1-py2.py3-none-any.whl (276 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m276.8/276.8 kB\u001b[0m \u001b[31m10.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hCollecting google-cloud-storage<3.0.0dev,>=1.32.0\n",
+      "  Downloading google_cloud_storage-2.8.0-py2.py3-none-any.whl (113 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m113.6/113.6 kB\u001b[0m \u001b[31m20.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hCollecting google-cloud-bigquery<3.0.0dev,>=1.15.0\n",
+      "  Using cached google_cloud_bigquery-2.34.4-py2.py3-none-any.whl (206 kB)\n",
+      "Requirement already satisfied: protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5 in ./bert_kernel/lib/python3.7/site-packages (from google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (3.19.6)\n",
+      "Collecting proto-plus<2.0.0dev,>=1.22.0\n",
+      "  Downloading proto_plus-1.22.2-py3-none-any.whl (47 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m47.9/47.9 kB\u001b[0m \u001b[31m10.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hCollecting packaging<22.0.0dev,>=14.3\n",
+      "  Using cached packaging-21.3-py3-none-any.whl (40 kB)\n",
+      "Requirement already satisfied: google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0 in ./bert_kernel/lib/python3.7/site-packages (from google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (2.11.0)\n",
+      "Requirement already satisfied: astunparse>=1.6.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.6.3)\n",
+      "Requirement already satisfied: google-pasta>=0.1.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (0.2.0)\n",
+      "Requirement already satisfied: wrapt>=1.11.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.15.0)\n",
+      "Requirement already satisfied: opt-einsum>=2.3.2 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (3.3.0)\n",
+      "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.23.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (0.32.0)\n",
+      "Requirement already satisfied: tensorflow-estimator<2.9,>=2.8 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (2.8.0)\n",
+      "Requirement already satisfied: numpy>=1.20 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.21.6)\n",
+      "Requirement already satisfied: h5py>=2.9.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (3.8.0)\n",
+      "Requirement already satisfied: typing-extensions>=3.6.6 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (4.5.0)\n",
+      "Requirement already satisfied: absl-py>=0.4.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.4.0)\n",
+      "Requirement already satisfied: flatbuffers>=1.12 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (23.3.3)\n",
+      "Requirement already satisfied: tensorboard<2.9,>=2.8 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (2.8.0)\n",
+      "Requirement already satisfied: keras<2.9,>=2.8.0rc0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (2.8.0)\n",
+      "Requirement already satisfied: grpcio<2.0,>=1.24.3 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.53.0)\n",
+      "Requirement already satisfied: gast>=0.2.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (0.5.3)\n",
+      "Requirement already satisfied: termcolor>=1.1.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (2.2.0)\n",
+      "Requirement already satisfied: six>=1.12.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.16.0)\n",
+      "Requirement already satisfied: setuptools in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (47.1.0)\n",
+      "Requirement already satisfied: libclang>=9.0.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (16.0.0)\n",
+      "Requirement already satisfied: keras-preprocessing>=1.1.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.1.2)\n",
+      "Requirement already satisfied: tensorflow-hub>=0.8.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow_text==2.8.2->-r requirements.txt (line 3)) (0.13.0)\n",
+      "Requirement already satisfied: scipy>=0.19.1 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.7.3)\n",
+      "Requirement already satisfied: Pillow in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (9.5.0)\n",
+      "Requirement already satisfied: sentencepiece in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.1.97)\n",
+      "Requirement already satisfied: tensorflow-addons in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.19.0)\n",
+      "Requirement already satisfied: google-api-python-client>=1.6.7 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.84.0)\n",
+      "Requirement already satisfied: oauth2client in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.1.3)\n",
+      "Requirement already satisfied: kaggle>=1.3.9 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.5.13)\n",
+      "Requirement already satisfied: tf-slim>=1.1.0 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.1.0)\n",
+      "Requirement already satisfied: gin-config in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.5.0)\n",
+      "Requirement already satisfied: psutil>=5.4.3 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (5.9.4)\n",
+      "Requirement already satisfied: matplotlib in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (3.5.3)\n",
+      "Requirement already satisfied: sacrebleu in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.3.1)\n",
+      "Requirement already satisfied: pandas>=0.22.0 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.3.5)\n",
+      "Requirement already satisfied: tensorflow-model-optimization>=0.4.1 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.7.3)\n",
+      "Requirement already satisfied: opencv-python-headless in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.7.0.72)\n",
+      "Requirement already satisfied: pyyaml<6.0,>=5.1 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (5.4.1)\n",
+      "Requirement already satisfied: pycocotools in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.0.6)\n",
+      "Requirement already satisfied: seqeval in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.2.2)\n",
+      "Requirement already satisfied: tensorflow-datasets in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.8.2)\n",
+      "Requirement already satisfied: py-cpuinfo>=3.3.0 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (9.0.0)\n",
+      "Requirement already satisfied: Cython in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.29.34)\n",
+      "Requirement already satisfied: wheel<1.0,>=0.23.0 in ./bert_kernel/lib/python3.7/site-packages (from astunparse>=1.6.0->tensorflow==2.8.4->-r requirements.txt (line 2)) (0.40.0)\n",
+      "Requirement already satisfied: googleapis-common-protos<2.0dev,>=1.56.2 in ./bert_kernel/lib/python3.7/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (1.59.0)\n",
+      "Requirement already satisfied: requests<3.0.0dev,>=2.18.0 in ./bert_kernel/lib/python3.7/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (2.28.2)\n",
+      "Requirement already satisfied: google-auth<3.0dev,>=2.14.1 in ./bert_kernel/lib/python3.7/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (2.17.2)\n",
+      "Collecting grpcio-status<2.0dev,>=1.33.2\n",
+      "  Downloading grpcio_status-1.53.0-py3-none-any.whl (5.1 kB)\n",
+      "Requirement already satisfied: uritemplate<5,>=3.0.1 in ./bert_kernel/lib/python3.7/site-packages (from google-api-python-client>=1.6.7->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.1.1)\n",
+      "Requirement already satisfied: google-auth-httplib2>=0.1.0 in ./bert_kernel/lib/python3.7/site-packages (from google-api-python-client>=1.6.7->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.1.0)\n",
+      "Requirement already satisfied: httplib2<1dev,>=0.15.0 in ./bert_kernel/lib/python3.7/site-packages (from google-api-python-client>=1.6.7->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.22.0)\n",
+      "Collecting google-cloud-core<3.0.0dev,>=1.4.1\n",
+      "  Downloading google_cloud_core-2.3.2-py2.py3-none-any.whl (29 kB)\n",
+      "Collecting google-resumable-media<3.0dev,>=0.6.0\n",
+      "  Downloading google_resumable_media-2.4.1-py2.py3-none-any.whl (77 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m77.7/77.7 kB\u001b[0m \u001b[31m15.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: python-dateutil<3.0dev,>=2.7.2 in ./bert_kernel/lib/python3.7/site-packages (from google-cloud-bigquery<3.0.0dev,>=1.15.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (2.8.2)\n",
+      "Collecting grpc-google-iam-v1<1.0.0dev,>=0.12.4\n",
+      "  Downloading grpc_google_iam_v1-0.12.6-py2.py3-none-any.whl (26 kB)\n",
+      "Requirement already satisfied: certifi in ./bert_kernel/lib/python3.7/site-packages (from kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2022.12.7)\n",
+      "Requirement already satisfied: tqdm in ./bert_kernel/lib/python3.7/site-packages (from kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.65.0)\n",
+      "Requirement already satisfied: python-slugify in ./bert_kernel/lib/python3.7/site-packages (from kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (8.0.1)\n",
+      "Requirement already satisfied: urllib3 in ./bert_kernel/lib/python3.7/site-packages (from kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.26.15)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in ./bert_kernel/lib/python3.7/site-packages (from packaging<22.0.0dev,>=14.3->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (3.0.9)\n",
+      "Requirement already satisfied: pytz>=2017.3 in ./bert_kernel/lib/python3.7/site-packages (from pandas>=0.22.0->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2023.3)\n",
+      "Requirement already satisfied: werkzeug>=0.11.15 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (2.2.3)\n",
+      "Requirement already satisfied: markdown>=2.6.8 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (3.4.3)\n",
+      "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (0.6.1)\n",
+      "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (0.4.6)\n",
+      "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (1.8.1)\n",
+      "Requirement already satisfied: dm-tree~=0.1.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-model-optimization>=0.4.1->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.1.8)\n",
+      "Requirement already satisfied: cycler>=0.10 in ./bert_kernel/lib/python3.7/site-packages (from matplotlib->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.11.0)\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in ./bert_kernel/lib/python3.7/site-packages (from matplotlib->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.38.0)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in ./bert_kernel/lib/python3.7/site-packages (from matplotlib->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.4.4)\n",
+      "Requirement already satisfied: rsa>=3.1.4 in ./bert_kernel/lib/python3.7/site-packages (from oauth2client->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.9)\n",
+      "Requirement already satisfied: pyasn1>=0.1.7 in ./bert_kernel/lib/python3.7/site-packages (from oauth2client->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.4.8)\n",
+      "Requirement already satisfied: pyasn1-modules>=0.0.5 in ./bert_kernel/lib/python3.7/site-packages (from oauth2client->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.2.8)\n",
+      "Requirement already satisfied: portalocker in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.7.0)\n",
+      "Requirement already satisfied: colorama in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.4.6)\n",
+      "Requirement already satisfied: tabulate>=0.8.9 in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.9.0)\n",
+      "Requirement already satisfied: regex in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2022.10.31)\n",
+      "Requirement already satisfied: lxml in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.9.2)\n",
+      "Requirement already satisfied: scikit-learn>=0.21.3 in ./bert_kernel/lib/python3.7/site-packages (from seqeval->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.0.2)\n",
+      "Requirement already satisfied: typeguard>=2.7 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-addons->tf-models-official==2.8.0->-r requirements.txt (line 4)) (3.0.2)\n",
+      "Requirement already satisfied: tensorflow-metadata in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.12.0)\n",
+      "Requirement already satisfied: click in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (8.1.3)\n",
+      "Requirement already satisfied: toml in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.10.2)\n",
+      "Requirement already satisfied: promise in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.3)\n",
+      "Requirement already satisfied: importlib-resources in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (5.12.0)\n",
+      "Requirement already satisfied: etils[enp,epath]>=0.9.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.9.0)\n",
+      "Requirement already satisfied: dill in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.3.6)\n",
+      "Requirement already satisfied: zipp in ./bert_kernel/lib/python3.7/site-packages (from etils[enp,epath]>=0.9.0->tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (3.15.0)\n",
+      "Requirement already satisfied: cachetools<6.0,>=2.0.0 in ./bert_kernel/lib/python3.7/site-packages (from google-auth<3.0dev,>=2.14.1->google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (5.3.0)\n",
+      "Requirement already satisfied: requests-oauthlib>=0.7.0 in ./bert_kernel/lib/python3.7/site-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (1.3.1)\n",
+      "Collecting google-crc32c<2.0dev,>=1.0\n",
+      "  Downloading google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (32 kB)\n",
+      "Collecting grpcio-status<2.0dev,>=1.33.2\n",
+      "  Downloading grpcio_status-1.51.3-py3-none-any.whl (5.1 kB)\n",
+      "  Downloading grpcio_status-1.51.1-py3-none-any.whl (5.1 kB)\n",
+      "  Downloading grpcio_status-1.50.0-py3-none-any.whl (14 kB)\n",
+      "  Downloading grpcio_status-1.49.1-py3-none-any.whl (14 kB)\n",
+      "  Downloading grpcio_status-1.48.2-py3-none-any.whl (14 kB)\n",
+      "Requirement already satisfied: importlib-metadata>=4.4 in ./bert_kernel/lib/python3.7/site-packages (from markdown>=2.6.8->tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (6.1.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in ./bert_kernel/lib/python3.7/site-packages (from requests<3.0.0dev,>=2.18.0->google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (3.4)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in ./bert_kernel/lib/python3.7/site-packages (from requests<3.0.0dev,>=2.18.0->google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (3.1.0)\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in ./bert_kernel/lib/python3.7/site-packages (from scikit-learn>=0.21.3->seqeval->tf-models-official==2.8.0->-r requirements.txt (line 4)) (3.1.0)\n",
+      "Requirement already satisfied: joblib>=0.11 in ./bert_kernel/lib/python3.7/site-packages (from scikit-learn>=0.21.3->seqeval->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.2.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.1.1 in ./bert_kernel/lib/python3.7/site-packages (from werkzeug>=0.11.15->tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (2.1.2)\n",
+      "Requirement already satisfied: text-unidecode>=1.3 in ./bert_kernel/lib/python3.7/site-packages (from python-slugify->kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.3)\n",
+      "Requirement already satisfied: oauthlib>=3.0.0 in ./bert_kernel/lib/python3.7/site-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (3.2.2)\n",
+      "Installing collected packages: proto-plus, packaging, google-crc32c, grpcio-status, google-resumable-media, grpc-google-iam-v1, google-cloud-core, google-cloud-storage, google-cloud-resource-manager, google-cloud-bigquery, google-cloud-aiplatform\n",
+      "  Attempting uninstall: packaging\n",
+      "    Found existing installation: packaging 23.0\n",
+      "    Uninstalling packaging-23.0:\n",
+      "      Successfully uninstalled packaging-23.0\n",
+      "Successfully installed google-cloud-aiplatform-1.19.0 google-cloud-bigquery-2.34.4 google-cloud-core-2.3.2 google-cloud-resource-manager-1.9.1 google-cloud-storage-2.8.0 google-crc32c-1.5.0 google-resumable-media-2.4.1 grpc-google-iam-v1-0.12.6 grpcio-status-1.48.2 packaging-21.3 proto-plus-1.22.2\n"
+     ]
+    }
+   ],
    "source": [
     "!cd ~/asl-ml-immersion && make bert_kernel"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {
     "id": "_XgTpm9ZxoN9",
     "tags": []
    },
    "outputs": [],
    "source": [
+    "import datetime\n",
     "import os\n",
     "import shutil\n",
     "\n",
@@ -79,6 +253,7 @@
     "import tensorflow as tf\n",
     "import tensorflow_hub as hub\n",
     "import tensorflow_text as text\n",
+    "from google.cloud import aiplatform\n",
     "from official.nlp import optimization  # to create AdamW optmizer\n",
     "\n",
     "tf.get_logger().setLevel(\"ERROR\")"
@@ -93,9 +268,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num GPUs Available:  1\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Num GPUs Available: \", len(tf.config.list_physical_devices(\"GPU\")))"
    ]
@@ -126,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {
     "id": "pOdqCMoQDRJL",
     "tags": []
@@ -166,12 +349,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {
     "id": "6IwI_2bcIeX8",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 25000 files belonging to 2 classes.\n",
+      "Using 20000 files for training.\n",
+      "Found 25000 files belonging to 2 classes.\n",
+      "Using 5000 files for validation.\n",
+      "Found 25000 files belonging to 2 classes.\n"
+     ]
+    }
+   ],
    "source": [
     "AUTOTUNE = tf.data.AUTOTUNE\n",
     "batch_size = 32\n",
@@ -216,12 +411,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {
     "id": "JuxDkcvVIoev",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Review: b'\"Pandemonium\" is a horror movie spoof that comes off more stupid than funny. Believe me when I tell you, I love comedies. Especially comedy spoofs. \"Airplane\", \"The Naked Gun\" trilogy, \"Blazing Saddles\", \"High Anxiety\", and \"Spaceballs\" are some of my favorite comedies that spoof a particular genre. \"Pandemonium\" is not up there with those films. Most of the scenes in this movie had me sitting there in stunned silence because the movie wasn\\'t all that funny. There are a few laughs in the film, but when you watch a comedy, you expect to laugh a lot more than a few times and that\\'s all this film has going for it. Geez, \"Scream\" had more laughs than this film and that was more of a horror film. How bizarre is that?<br /><br />*1/2 (out of four)'\n",
+      "Label : 0 (neg)\n",
+      "Review: b\"David Mamet is a very interesting and a very un-equal director. His first movie 'House of Games' was the one I liked best, and it set a series of films with characters whose perspective of life changes as they get into complicated situations, and so does the perspective of the viewer.<br /><br />So is 'Homicide' which from the title tries to set the mind of the viewer to the usual crime drama. The principal characters are two cops, one Jewish and one Irish who deal with a racially charged area. The murder of an old Jewish shop owner who proves to be an ancient veteran of the Israeli Independence war triggers the Jewish identity in the mind and heart of the Jewish detective.<br /><br />This is were the flaws of the film are the more obvious. The process of awakening is theatrical and hard to believe, the group of Jewish militants is operatic, and the way the detective eventually walks to the final violent confrontation is pathetic. The end of the film itself is Mamet-like smart, but disappoints from a human emotional perspective.<br /><br />Joe Mantegna and William Macy give strong performances, but the flaws of the story are too evident to be easily compensated.\"\n",
+      "Label : 0 (neg)\n",
+      "Review: b'Great documentary about the lives of NY firefighters during the worst terrorist attack of all time.. That reason alone is why this should be a must see collectors item.. What shocked me was not only the attacks, but the\"High Fat Diet\" and physical appearance of some of these firefighters. I think a lot of Doctors would agree with me that,in the physical shape they were in, some of these firefighters would NOT of made it to the 79th floor carrying over 60 lbs of gear. Having said that i now have a greater respect for firefighters and i realize becoming a firefighter is a life altering job. The French have a history of making great documentary\\'s and that is what this is, a Great Documentary.....'\n",
+      "Label : 1 (pos)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-04-07 15:35:21.799976: W tensorflow/core/kernels/data/cache_dataset_ops.cc:768] The calling iterator did not fully read the dataset being cached. In order to avoid unexpected truncation of the dataset, the partially cached contents of the dataset  will be discarded. This can happen if you have an input pipeline similar to `dataset.cache().take(k).repeat()`. You should use `dataset.take(k).cache().repeat()` instead.\n"
+     ]
+    }
+   ],
    "source": [
     "for text_batch, label_batch in train_ds.take(1):\n",
     "    for i in range(3):\n",
@@ -256,13 +471,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {
     "cellView": "form",
     "id": "y8_ctG55-uTX",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BERT model selected           : https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-4_H-512_A-8/1\n",
+      "Preprocess model auto-selected: https://tfhub.dev/tensorflow/bert_en_uncased_preprocess/3\n"
+     ]
+    }
+   ],
    "source": [
     "# defining the URL of the smallBERT model to use\n",
     "tfhub_handle_encoder = (\n",
@@ -302,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,12 +551,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {
     "id": "r9-zCzJpnuwS",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Keys       : ['input_word_ids', 'input_type_ids', 'input_mask']\n",
+      "Shape      : (1, 128)\n",
+      "Word Ids   : [ 101 2023 2003 2107 2019 6429 3185  999  102    0    0    0]\n",
+      "Input Mask : [1 1 1 1 1 1 1 1 1 0 0 0]\n",
+      "Type Ids   : [0 0 0 0 0 0 0 0 0 0 0 0]\n"
+     ]
+    }
+   ],
    "source": [
     "text_test = [\"this is such an amazing movie!\"]\n",
     "text_preprocessed = bert_preprocess_model(text_test)\n",
@@ -379,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {
     "id": "tXxYpK8ixL34",
     "tags": []
@@ -391,12 +627,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {
     "id": "_OoF9mebuSZc",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded BERT: https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-4_H-512_A-8/1\n",
+      "Pooled Outputs Shape:(1, 512)\n",
+      "Pooled Outputs Values:[ 0.76262903  0.99280983 -0.18611847  0.3667386   0.15233745  0.6550445\n",
+      "  0.9681154  -0.94862705  0.00216164 -0.9877732   0.0684273  -0.97630596]\n",
+      "Sequence Outputs Shape:(1, 128, 512)\n",
+      "Sequence Outputs Values:[[-0.28946295  0.34321263  0.33231527 ...  0.2130087   0.71020836\n",
+      "  -0.05771071]\n",
+      " [-0.2874208   0.31981027 -0.23018518 ...  0.5845508  -0.21329744\n",
+      "   0.7269212 ]\n",
+      " [-0.66157013  0.6887687  -0.8743292  ...  0.10877226 -0.26173285\n",
+      "   0.47855547]\n",
+      " ...\n",
+      " [-0.22561097 -0.2892568  -0.07064426 ...  0.47566074  0.83277184\n",
+      "   0.40025318]\n",
+      " [-0.29824227 -0.27473107 -0.05450526 ...  0.488498    1.0955358\n",
+      "   0.18163362]\n",
+      " [-0.4437815   0.00930744  0.07223801 ...  0.17290124  1.1833242\n",
+      "   0.07898009]]\n"
+     ]
+    }
+   ],
    "source": [
     "bert_results = bert_model(text_preprocessed)\n",
     "\n",
@@ -450,12 +711,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {
     "id": "aksj743St9ga",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tf.Tensor([[0.59120435]], shape=(1, 1), dtype=float32)\n"
+     ]
+    }
+   ],
    "source": [
     "def build_classifier_model(dropout_rate=0.1):\n",
     "    text_input = tf.keras.layers.Input(shape=(), dtype=tf.string, name=\"text\")\n",
@@ -469,7 +738,7 @@
     "    outputs = encoder(encoder_inputs)\n",
     "    net = outputs[\"pooled_output\"]\n",
     "    net = tf.keras.layers.Dropout(dropout_rate)(net)\n",
-    "    net = tf.keras.layers.Dense(1, activation=None, name=\"classifier\")(net)\n",
+    "    net = tf.keras.layers.Dense(1, activation=\"sigmoid\", name=\"classifier\")(net)\n",
     "    return tf.keras.Model(text_input, net)\n",
     "\n",
     "\n",
@@ -477,7 +746,7 @@
     "dropout_rate = 0.15\n",
     "classifier_model = build_classifier_model(dropout_rate)\n",
     "bert_raw_result = classifier_model(tf.constant(text_test))\n",
-    "print(tf.sigmoid(bert_raw_result))"
+    "print(bert_raw_result)"
    ]
   },
   {
@@ -493,12 +762,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {
     "id": "0EmzyHZXKIpm",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You must install pydot (`pip install pydot`) and install graphviz (see instructions at https://graphviz.gitlab.io/download/) for plot_model/model_to_dot to work.\n"
+     ]
+    }
+   ],
    "source": [
     "tf.keras.utils.plot_model(classifier_model)"
    ]
@@ -534,7 +811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {
     "id": "OWPOZE-L3AgE",
     "tags": []
@@ -562,7 +839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {
     "id": "P9eP2y9dbw32",
     "tags": []
@@ -603,7 +880,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {
     "id": "-7GPDhR98jsD",
     "tags": []
@@ -631,11 +908,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {
     "id": "HtfDFAnN_Neu"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training model with https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-4_H-512_A-8/1\n",
+      "Epoch 1/5\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jupyter/asl-ml-immersion/notebooks/text_models/bert_kernel/lib/python3.7/site-packages/tensorflow/python/util/dispatch.py:1082: UserWarning: \"`binary_crossentropy` received `from_logits=True`, but the `output` argument was produced by a sigmoid or softmax activation and thus does not represent logits. Was this intended?\"\n",
+      "  return dispatch_target(*args, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "625/625 [==============================] - 162s 250ms/step - loss: 0.4973 - binary_accuracy: 0.7471 - val_loss: 0.3778 - val_binary_accuracy: 0.8380\n",
+      "Epoch 2/5\n",
+      "625/625 [==============================] - 155s 248ms/step - loss: 0.3372 - binary_accuracy: 0.8547 - val_loss: 0.3639 - val_binary_accuracy: 0.8502\n",
+      "Epoch 3/5\n",
+      "625/625 [==============================] - 155s 248ms/step - loss: 0.2582 - binary_accuracy: 0.8946 - val_loss: 0.3802 - val_binary_accuracy: 0.8518\n",
+      "Epoch 4/5\n",
+      "625/625 [==============================] - 155s 248ms/step - loss: 0.1959 - binary_accuracy: 0.9269 - val_loss: 0.4276 - val_binary_accuracy: 0.8504\n",
+      "Epoch 5/5\n",
+      "625/625 [==============================] - 155s 248ms/step - loss: 0.1599 - binary_accuracy: 0.9425 - val_loss: 0.4620 - val_binary_accuracy: 0.8528\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"Training model with {tfhub_handle_encoder}\")\n",
     "history = classifier_model.fit(\n",
@@ -656,11 +965,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {
     "id": "slqB-urBV9sP"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "782/782 [==============================] - 83s 106ms/step - loss: 0.4442 - binary_accuracy: 0.8608\n",
+      "Loss: 0.4441617429256439\n",
+      "Accuracy: 0.86080002784729\n"
+     ]
+    }
+   ],
    "source": [
     "loss, accuracy = classifier_model.evaluate(test_ds)\n",
     "\n",
@@ -681,11 +1000,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {
     "id": "fiythcODf0xo"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['loss', 'binary_accuracy', 'val_loss', 'val_binary_accuracy'])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7efe967c8190>"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1cAAAIjCAYAAADvBuGTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAA9hAAAPYQGoP6dpAACunklEQVR4nOzdeVwU9f8H8Ndy7YKcAnIogqCCJ954H4XhEaaWoh2CWpblFVlqXqAlpWaYmlbfPPIKzaMsNZU888wrNcULxQsQFRCQa5nfH/PbhZUFdmGXXeD1fDzmITs7O/OZYVRefD7z/kgEQRBAREREREREFWJi6AYQERERERFVBwxXREREREREOsBwRUREREREpAMMV0RERERERDrAcEVERERERKQDDFdEREREREQ6wHBFRERERESkAwxXREREREREOsBwRUREREREpAMMV0REVVxYWBi8vLzK9dmIiAhIJBLdNsjI3Lp1CxKJBKtXr67U4x44cAASiQQHDhxQrtP0e6WvNnt5eSEsLEyn+9TE6tWrIZFIcOvWrUo/NhFRZWK4IiLSE4lEotFS9Idvooo6evQoIiIikJqaauimEBHVOGaGbgARUXW1du1aldc//fQT9u7dW2x9kyZNKnScH374AQUFBeX67IwZMzB16tQKHZ80V5HvlaaOHj2KyMhIhIWFwd7eXuW9uLg4mJjw96pERPrCcEVEpCdvvvmmyuvjx49j7969xdY/LysrC1ZWVhofx9zcvFztAwAzMzOYmfG/gspSke+VLkilUoMen4iouuOvr4iIDKhnz55o3rw5Tp8+je7du8PKygqffvopAODXX39F//794e7uDqlUCh8fH8ydOxdyuVxlH88/x6N4XmfhwoX4/vvv4ePjA6lUivbt2+PUqVMqn1X3zJVEIsG4ceOwfft2NG/eHFKpFM2aNcPu3buLtf/AgQNo164dZDIZfHx88N1332n8HNfhw4cxZMgQ1K9fH1KpFB4eHvjwww/x7NmzYudnbW2Ne/fuYeDAgbC2toazszMmT55c7FqkpqYiLCwMdnZ2sLe3R2hoqEbD4/755x9IJBKsWbOm2Ht//vknJBIJfv/9dwDA7du38f7778PX1xeWlpZwdHTEkCFDNHqeSN0zV5q2+d9//0VYWBi8vb0hk8ng6uqKUaNG4dGjR8ptIiIi8PHHHwMAGjRooBx6qmibumeubt68iSFDhqB27dqwsrJCx44d8ccff6hso3h+bNOmTfj8889Rr149yGQyvPjii7h+/XqZ512Sb7/9Fs2aNYNUKoW7uzs++OCDYud+7do1vPrqq3B1dYVMJkO9evUwbNgwpKWlKbfZu3cvunbtCnt7e1hbW8PX11f594iIqDLx15VERAb26NEj9O3bF8OGDcObb74JFxcXAGIRAGtra4SHh8Pa2hp//fUXZs2ahfT0dCxYsKDM/W7YsAFPnz7Fu+++C4lEgvnz52Pw4MG4efNmmT0oR44cwdatW/H+++/DxsYG33zzDV599VUkJCTA0dERAHD27Fn06dMHbm5uiIyMhFwux5w5c+Ds7KzReW/evBlZWVkYO3YsHB0dcfLkSSxZsgR3797F5s2bVbaVy+UICgpCQEAAFi5ciH379uGrr76Cj48Pxo4dCwAQBAGvvPIKjhw5gvfeew9NmjTBtm3bEBoaWmZb2rVrB29vb2zatKnY9jExMXBwcEBQUBAA4NSpUzh69CiGDRuGevXq4datW1i+fDl69uyJ//77T6teR23avHfvXty8eRMjR46Eq6srLl26hO+//x6XLl3C8ePHIZFIMHjwYFy9ehUbN27E119/DScnJwAo8XuSlJSEzp07IysrCxMmTICjoyPWrFmDAQMG4JdffsGgQYNUtv/iiy9gYmKCyZMnIy0tDfPnz8cbb7yBEydOaHzOChEREYiMjERgYCDGjh2LuLg4LF++HKdOncLff/8Nc3Nz5ObmIigoCDk5ORg/fjxcXV1x7949/P7770hNTYWdnR0uXbqEl19+GS1btsScOXMglUpx/fp1/P3331q3iYiowgQiIqoUH3zwgfD8P7s9evQQAAgrVqwotn1WVlaxde+++65gZWUlZGdnK9eFhoYKnp6eytfx8fECAMHR0VF4/Pixcv2vv/4qABB27NihXDd79uxibQIgWFhYCNevX1euO3/+vABAWLJkiXJdcHCwYGVlJdy7d0+57tq1a4KZmVmxfaqj7vyioqIEiUQi3L59W+X8AAhz5sxR2bZ169ZC27Ztla+3b98uABDmz5+vXJefny9069ZNACCsWrWq1PZMmzZNMDc3V7lmOTk5gr29vTBq1KhS233s2DEBgPDTTz8p1+3fv18AIOzfv1/lXIp+r7Rps7rjbty4UQAgHDp0SLluwYIFAgAhPj6+2Paenp5CaGio8vWkSZMEAMLhw4eV654+fSo0aNBA8PLyEuRyucq5NGnSRMjJyVFuu3jxYgGAcOHChWLHKmrVqlUqbUpOThYsLCyEl156SXkMQRCEpUuXCgCElStXCoIgCGfPnhUACJs3by5x319//bUAQHj48GGpbSAiqgwcFkhEZGBSqRQjR44stt7S0lL59dOnT5GSkoJu3bohKysLV65cKXO/ISEhcHBwUL7u1q0bAHEYWFkCAwPh4+OjfN2yZUvY2toqPyuXy7Fv3z4MHDgQ7u7uyu0aNmyIvn37lrl/QPX8MjMzkZKSgs6dO0MQBJw9e7bY9u+9957K627duqmcy86dO2FmZqbsyQIAU1NTjB8/XqP2hISEIC8vD1u3blWu27NnD1JTUxESEqK23Xl5eXj06BEaNmwIe3t7nDlzRqNjlafNRY+bnZ2NlJQUdOzYEQC0Pm7R43fo0AFdu3ZVrrO2tsaYMWNw69Yt/Pfffyrbjxw5EhYWFsrX2txTRe3btw+5ubmYNGmSSoGNd955B7a2tsphiXZ2dgDEoZlZWVlq96Uo2vHrr7/qvVgIEVFZGK6IiAysbt26Kj+wKly6dAmDBg2CnZ0dbG1t4ezsrCyGUfR5k5LUr19f5bUiaD158kTrzyo+r/hscnIynj17hoYNGxbbTt06dRISEhAWFobatWsrn6Pq0aMHgOLnJ5PJig1tK9oeQHwWys3NDdbW1irb+fr6atQef39/+Pn5ISYmRrkuJiYGTk5OeOGFF5Trnj17hlmzZsHDwwNSqRROTk5wdnZGamqqRt+XorRp8+PHjzFx4kS4uLjA0tISzs7OaNCgAQDN7oeSjq/uWIoKlrdv31ZZX5F76vnjAsXP08LCAt7e3sr3GzRogPDwcPzvf/+Dk5MTgoKCsGzZMpXzDQkJQZcuXfD222/DxcUFw4YNw6ZNmxi0iMgg+MwVEZGBFe2RUEhNTUWPHj1ga2uLOXPmwMfHBzKZDGfOnMGUKVM0+sHR1NRU7XpBEPT6WU3I5XL07t0bjx8/xpQpU+Dn54datWrh3r17CAsLK3Z+JbVH10JCQvD5558jJSUFNjY2+O233zB8+HCViorjx4/HqlWrMGnSJHTq1Al2dnaQSCQYNmyYXn+gHzp0KI4ePYqPP/4YrVq1grW1NQoKCtCnT59KCxL6vi/U+eqrrxAWFoZff/0Ve/bswYQJExAVFYXjx4+jXr16sLS0xKFDh7B//3788ccf2L17N2JiYvDCCy9gz549lXbvEBEBDFdEREbpwIEDePToEbZu3Yru3bsr18fHxxuwVYXq1KkDmUymtlKcJtXjLly4gKtXr2LNmjUYMWKEcv3evXvL3SZPT0/ExsYiIyNDpScoLi5O432EhIQgMjISW7ZsgYuLC9LT0zFs2DCVbX755ReEhobiq6++Uq7Lzs4u16S9mrb5yZMniI2NRWRkJGbNmqVcf+3atWL71KRSY9Hjq7s+imGnnp6eGu9LG4r9xsXFwdvbW7k+NzcX8fHxCAwMVNm+RYsWaNGiBWbMmIGjR4+iS5cuWLFiBT777DMAgImJCV588UW8+OKLWLRoEebNm4fp06dj//79xfZFRKRPHBZIRGSEFL9tL9ojkJubi2+//dZQTVJhamqKwMBAbN++Hffv31euv379Onbt2qXR5wHV8xMEAYsXLy53m/r164f8/HwsX75cuU4ul2PJkiUa76NJkyZo0aIFYmJiEBMTAzc3N5Vwq2j78z01S5YsKVYWXpdtVne9ACA6OrrYPmvVqgUAGoW9fv364eTJkzh27JhyXWZmJr7//nt4eXmhadOmmp6KVgIDA2FhYYFvvvlG5Zx+/PFHpKWloX///gCA9PR05Ofnq3y2RYsWMDExQU5ODgBxuOTzWrVqBQDKbYiIKgt7roiIjFDnzp3h4OCA0NBQTJgwARKJBGvXrtXr8CttRUREYM+ePejSpQvGjh0LuVyOpUuXonnz5jh37lypn/Xz84OPjw8mT56Me/fuwdbWFlu2bNH62Z2igoOD0aVLF0ydOhW3bt1C06ZNsXXrVq2fRwoJCcGsWbMgk8kwevRolYILAPDyyy9j7dq1sLOzQ9OmTXHs2DHs27dPWaJeH222tbVF9+7dMX/+fOTl5aFu3brYs2eP2p7Mtm3bAgCmT5+OYcOGwdzcHMHBwcrQVdTUqVOxceNG9O3bFxMmTEDt2rWxZs0axMfHY8uWLcXOXVecnZ0xbdo0REZGok+fPhgwYADi4uLw7bffon379spnC//66y+MGzcOQ4YMQePGjZGfn4+1a9fC1NQUr776KgBgzpw5OHToEPr37w9PT08kJyfj22+/Rb169VQKdRARVQaGKyIiI+To6Ijff/8dH330EWbMmAEHBwe8+eabePHFF5XzLRla27ZtsWvXLkyePBkzZ86Eh4cH5syZg8uXL5dZzdDc3Bw7duxQPj8jk8kwaNAgjBs3Dv7+/uVqj4mJCX777TdMmjQJ69atg0QiwYABA/DVV1+hdevWGu8nJCQEM2bMQFZWlkqVQIXFixfD1NQU69evR3Z2Nrp06YJ9+/aV6/uiTZs3bNiA8ePHY9myZRAEAS+99BJ27dqlUq0RANq3b4+5c+dixYoV2L17NwoKChAfH682XLm4uODo0aOYMmUKlixZguzsbLRs2RI7duxQ9h7pS0REBJydnbF06VJ8+OGHqF27NsaMGYN58+Yp52Hz9/dHUFAQduzYgXv37sHKygr+/v7YtWuXslLigAEDcOvWLaxcuRIpKSlwcnJCjx49EBkZqaw2SERUWSSCMf0alIiIqryBAwfi0qVLap8HIiIiqs74zBUREZXbs2fPVF5fu3YNO3fuRM+ePQ3TICIiIgNizxUREZWbm5sbwsLClHMTLV++HDk5OTh79iwaNWpk6OYRERFVKj5zRURE5danTx9s3LgRiYmJkEql6NSpE+bNm8dgRURENRJ7roiIiIiIiHSAz1wRERERERHpAMMVERERERGRDvCZKzUKCgpw//592NjYQCKRGLo5RERERERkIIIg4OnTp3B3dy9zcnWGKzXu378PDw8PQzeDiIiIiIiMxJ07d1CvXr1St2G4UsPGxgaAeAFtbW0N3BoiIiIiIjKU9PR0eHh4KDNCaRiu1FAMBbS1tWW4IiIiIiIijR4XYkELIiIiIiIiHagS4WrZsmXw8vKCTCZDQEAATp48WeK2q1evhkQiUVlkMlkltpaIiIiIiGoiow9XMTExCA8Px+zZs3HmzBn4+/sjKCgIycnJJX7G1tYWDx48UC63b9+uxBYTEREREVFNZPThatGiRXjnnXcwcuRING3aFCtWrICVlRVWrlxZ4mckEglcXV2Vi4uLSyW2mIiIiIiIaiKjDle5ubk4ffo0AgMDletMTEwQGBiIY8eOlfi5jIwMeHp6wsPDA6+88gouXbpU6nFycnKQnp6ushiN3FxAEAzdCiIiIiIiKoNRh6uUlBTI5fJiPU8uLi5ITExU+xlfX1+sXLkSv/76K9atW4eCggJ07twZd+/eLfE4UVFRsLOzUy5GNcdVRATQqROwbx9DFhERERGRETPqcFUenTp1wogRI9CqVSv06NEDW7duhbOzM7777rsSPzNt2jSkpaUplzt37lRii0uRkwP873/AiRNA795Ar17A4cOGbhUREREREalh1OHKyckJpqamSEpKUlmflJQEV1dXjfZhbm6O1q1b4/r16yVuI5VKlXNaGdXcVlIp8O+/wIQJgIUFcPAg0L07EBQElFIxkYiIiIiIKp9RhysLCwu0bdsWsbGxynUFBQWIjY1Fp06dNNqHXC7HhQsX4Obmpq9m6perK7B4MXD9OvDuu4CZGbBnDxAQAAwYAJw7Z+gWEhERERERjDxcAUB4eDh++OEHrFmzBpcvX8bYsWORmZmJkSNHAgBGjBiBadOmKbefM2cO9uzZg5s3b+LMmTN48803cfv2bbz99tuGOgXd8PAAVqwA4uKA0FDAxATYsQNo3RoYOhT47z9Dt5CIiIiIqEYz+nAVEhKChQsXYtasWWjVqhXOnTuH3bt3K4tcJCQk4MGDB8rtnzx5gnfeeQdNmjRBv379kJ6ejqNHj6Jp06aGOgXd8vYGVq8GLl0Chg0T123eDDRvDrz1ltjDRURERERElU4iCCxB97z09HTY2dkhLS3NeJ6/KsmFC8Ds2cC2beJrU1Ng5EhgxgzA09OwbSMiIiIiquK0yQZG33NFZWjRAti6FTh1CujbF5DLxQqDjRoB48YB9+8buoVERERERDUCw1V10a4dsHMn8PffwAsvAHl5wLJlgI8P8NFHQHKyoVtIRERERFStMVxVN507A7Gx4tK5M5CdDSxaJD6rNX068PixoVtIRERERFQtMVxVVy+8ABw5IvZmtW0LZGYC8+YBDRoAc+YA6emGbiERERERUbXCcFWdSSTic1inTokFL1q0EEPV7NliyJo/XwxdRERERERUYQxXNYFEAgwcKE44/PPPgK+vODxwyhRxuODixeLwQSIiIiIiKjeGq5rExAQICQEuXhTnymrQQCx0MWkS0LChOElxbq6hW0lEREREVCUxXNVEZmZAaCgQFwd89x1Qrx5w7x4wdqzYq7V6NZCfb+hWEhERERFVKQxXNZm5OTBmDHDtmjg00MUFuHVLnIS4WTNg40agoMDQrSQiIiIiqhIYrgiQyYAJE4CbN8UiF46OwNWrwOuvA/7+YjEMQTB0K4mIiIiIjBrDFRWysgI+/hiIjwfmzgXs7MTnswYPLpykmCGLiIiIiEgthisqzsYGmDFDDFnTpwPW1sCZM0D//kCXLsBffxm6hURERERERofhikrm4AB89pk4XHDyZHH44LFjwIsvAr16iZMUExERERERAEAiCBzn9bz09HTY2dkhLS0Ntra2hm6O8XjwAIiKEisMKkq29+kjDiFs186wbSMiIiKiKkUuB5KSgLt3gTt3xD+Lfu3mBmzebOhWapcNGK7UYLgqQ0KC2KO1cqX4twIAXnkFmDMHaNnSsG0jIiIiIoOTy4HExOKBqWiIun+/9Nl/PD3FQtaGxnBVQQxXGrpxQwxU69YVlmwPCQEiIgA/P4M2jYiIiIj0Qy4XBzQ9H5yKfn3/fuHv4Etjagq4u4vTrtarB3h4FH7t6Ql06KD/8ykLw1UFMVxp6fJlMVBt2iS+NjEB3nwTmDUL8PExaNOIiIiISHP5+WKPk7qeJsXXDx5oF5yKBqbnv3ZxAczM9H9eFcFwVUEMV+V0/jwwezbw66/iazMzcULiGTOA+vUN2zYiIiKiGi4/XwxG6gKT4usHDwoHJJXG1BSoW1c1MKkLTqam+j8vfWO4qiCGqwo6dUrstdq9W3xtYQG8+y4wbZr4ZCIRERER6VReXuFQPXXh6c4dsUdKk+BkZlY8OD3/dXUJTppguKoghisdOXJE7LU6eFB8bWkJfPAB8MkngLOzYdtGREREVEXk5YnPMJUUnO7e1Tw4mZsXBqeSwpOLi/iUB4kYriqI4UqHBEGcdHjmTHGOLECclHjSJOCjjwB7e0O2joiIiMigcnMLg1NJ4SkxUfyRqizm5oVBqaTgVKcOg5O2GK4qiOFKDwQB2LVL7Mk6e1ZcZ2cnTk48cSJgY2PY9hERERHpWG4ucO9e6cEpKUm74FRacQhnZwYnfWC4qiCGKz0SBGD7drEn69IlcZ2jIzBlijhk0MrKoM0jIiIi0kROjtjjVNLzTYrgpAkLi7KDk5MTg5OhMFxVEMNVJZDLxdLts2cD166J61xcgOnTgTFjAKnUsO0jIiKiGisnR+xxKq2qXnKyZvuSSksfplevntjjJJHo95yo/BiuKojhqhLl54uTEEdGFk7BXa+e2LM1cqTYB05ERESkI9nZhUP1Sup1evhQs33JZOqfcSoanJycGJyqOoarCmK4MoDcXGDlSuCzz8R/8QDA21vs2XrjjZpT65OIiIjKLTu79Oeb7t7VLjiVNkyvXj3xyQYGp+qP4aqCGK4MKDsb+O47YN68wv52X1+xZ2vIEA42JiIiqqGePSsMSCWFp5QUzfZlaVn2M061azM4kYjhqoIYroxAZiawbBnw5ZfA48fiuhYtgDlzgFde4b92RERE1UhWluozTuqC06NHmu3L0lIMR6UFJwcH/ihBmmO4qiCGKyOSng5ERwNffSV+DQDt2gFz5wJBQfyXkYiIyMhlZZU+TO/OncLfo5bFykr9c01Fv2ZwIl1juKoghisj9PixGLAWLxZ7tQCgc2fxGa1evQzbNiIiohoqM7PkMuSKr5880WxftWqVHZzs7RmcqPIxXFUQw5URS04Whwp++634fBYAvPCC2JPVubNh20ZERFSNZGSUXRxC0+BkbV12cQg7OwYnMk4MVxXEcFUF3L8vFr34/nsgL09c17evGLLatjVs24iIiIxcRkbpk9/evQukpmq2L0VwUheYFH/a2jI4UdXFcFVBDFdVyO3b4tDAVavEiYkBYNAgsbpgixaGbRsREZEBFBSIIenqVfFPdSEqLU2zfdnall1Vjz8qUXXHcFVBDFdV0PXrYqBavx4QBPHXYyEhQESEWMqdiIiomklPB+Liii/Xrolly8tiZ1f6MD1FjxNRTcdwVUEMV1XYf/+JgWrzZvG1iQnw1lvArFnipMRERERVSH4+cOuW+hCVmFjy58zNAR8fwMur5OBkY1NZZ0FUtTFcVRDDVTVw7pwYqHbsEF+bmQGjRwMzZoj/oxARERmRlBQxMF29qhqgrl8vfLRYHVdXcYBG48bin4qlQQPxvz4iqjiGqwpiuKpGTp4EZs4E9uwRX0ulwLvvAtOmif8jERERVZLcXDEsqeuFKm2eJ5mseHhSBCo7u8prP1FNxXBVQQxX1dDhw2Kv1aFD4mtLS2D8eODjjwEnJ8O2jYiIqg1BEIfrqQtQ8fFisYmSeHgUD1C+vuJ6E5PKOwciUsVwVUEMV9WUIACxsWLIOnFCXGdtDXz4IRAeLs5MSEREpIGsLLFwxPMB6upVsdBESayt1QeoRo3ESXSJyPgwXFUQw1U1JwjAzp1iyDp3Tlxnbw9MngxMmMAnfImICIDYy3T3rvpeqISEkj9nYiIWklAXotzcON8TUVXDcFVBDFc1REEBsG2bWPjiv//EdU5OwNSpwPvvi0MHiYio2ktPL15IQtELVVpJcwcH9QGqYUPxEV8iqh4YriqI4aqGkcuBmBhg9mzxSWNA/NXip58C77zD/yGJiKoBubzkkuYPHpT8OTMzMSypq8jn5MReKKKagOGqghiuaqj8fGDtWnEy4tu3xXUeHmLPVmioOGkIEREZtUeP1PdCXb8uVusriYuL+l4oljQnIoarCmK4quFyc4EffwQ++wy4f19c5+0tTk78+uuAqalBm0dEVNPl5gI3bqjvhXr0qOTPyWRi4Qh1Jc1Z04iISsJwVUEMVwRAHGj/3XfAvHnAw4fiuiZNxJD12musi0tEpEeCACQllVzSXC4v+bP16qnvhapfn/90E5H2ql24WrZsGRYsWIDExET4+/tjyZIl6NChQ5mf+/nnnzF8+HC88sor2L59u8bHY7giFRkZwNKlwPz5wJMn4rqWLYG5c4HgYA64JyKqgGfP1Jc0j4sru6R5SRPrsqQ5EelStQpXMTExGDFiBFasWIGAgABER0dj8+bNiIuLQ506dUr83K1bt9C1a1d4e3ujdu3aDFdUcWlpQHQ0sGhR4f/47duLIeullxiyiIhKUFAA3LtXcknzkn4SkUhKLmnu7s5/domoclSrcBUQEID27dtj6dKlAICCggJ4eHhg/PjxmDp1qtrPyOVydO/eHaNGjcLhw4eRmprKcEW68+gRsHAh8M034iySANC1q/iMVo8ehm0bEZEBPX1acklzxT+X6qgrad64sVilTyarvPYTEamjTTYw6vo3ubm5OH36NKZNm6ZcZ2JigsDAQBw7dqzEz82ZMwd16tTB6NGjcfjw4TKPk5OTg5ycHOXr9NLGIRA5OgJRUcCkScCXXwLffgscOQL07Am8+KIYsjp2NHQriYj0Qi4XC6qq64VS1ABSx8wM8PFR3wvFkuZEVF0YdbhKSUmBXC6Hi4uLynoXFxdcuXJF7WeOHDmCH3/8EefOndP4OFFRUYiMjKxIU6kmcnERhwh+9JFY9OKHH4DYWHHp3x+YMwdo08bQrSQiKpfHj9UHqLJKmtepU3JJc85oQUTVnVGHK209ffoUb731Fn744Qc4OTlp/Llp06YhPDxc+To9PR0eHh76aCJVR3XrAsuWAR9/LD5/tWYN8Mcf4jJ4sDhvVvPmhm4lEVExeXkllzRPSSn5c1Kp+pLmvr4saU5ENZtRhysnJyeYmpoiKSlJZX1SUhJcXV2LbX/jxg3cunULwcHBynUFBQUAADMzM8TFxcHHx6fY56RSKaRSqY5bTzWOl5c4P9bUqWKg2rAB2LoV2LYNGD4cmD1bfIiAiKgSCQKQnKw+QN28WXpJ87p1Sy5pzin/iIiKqxIFLTp06IAlS5YAEMNS/fr1MW7cuGIFLbKzs3H9+nWVdTNmzMDTp0+xePFiNG7cGBYWFmUekwUtSCcuXRID1ZYt4mtTU2DECGDWLDGIERHpUHZ2ySXN09JK/lytWiWXNLe2rrz2ExEZq2pT0AIAwsPDERoainbt2qFDhw6Ijo5GZmYmRo4cCQAYMWIE6tati6ioKMhkMjR/bviV/f+PT3h+PZHeNWsG/PILcPasGKh+/x1YtQpYtw54+21g+nTx18JERBoShJJLmt++rX1J88aNxX+GWEyCiEg3jD5chYSE4OHDh5g1axYSExPRqlUr7N69W1nkIiEhASacbp2MWevWwI4dwPHjYsjauxdYvhxYuRIYO1YcRvhc0RYiqtkyMkouaZ6ZWfLn7O3VD+NjSXMiosph9MMCDYHDAkmvDh4EZs4EFNMEWFkB48eLBTEcHQ3bNiKqNEVLmj8fpO7dK/lzZmaAt7f6EOXszF4oIiJdq1aTCBsCwxXpnSCIPVgzZwInT4rrbGyA8HDgww8BOzvDto+IdObJk5JLmheZYrEYZ2f1AcrbmyXNiYgqE8NVBTFcUaURBPFZrJkzgfPnxXUODmIv1vjxfJqcqIrIyxMr76kLUQ8flvw5C4uSS5o7OFRe+4mIqGQMVxXEcEWVrqBArCo4ezZw+bK4ztkZmDYNeO89wNLSsO0jIgiCGJRKKmmen1/yZ93d1QcoT0+WNCciMnYMVxXEcEUGI5cDGzcCERHizJ6A+FPZ9OnA6NHizJ1EpBMFBWJxiPR04OlTcXn+6ydPVMubp6aWvD8rK/XV+Bo3Fkf9EhFR1cRwVUHGFK5u3BB/ALC2FuciqVWLv+WsEfLygJ9+AubMARISxHWenmK1wREjxCfaiWogubww/KgLQ5p+nZ4uBitt/weUSMS/iup6oVjSnIioemK4qiBjCledOwPHjqmuk8lUw5bi69LWafKehQV/MDA6OTnA//4HfP458OCBuK5hQ7Fna9gwJm2qEvLyKhaEin6dlaX79pmaij1LNjaAra3q13Z2qpX5GjbkKF0iopqG4aqCjClcBQYCp06Jc54UFOj3WKam5QtlZb1nZQVwKrIKevZMnBvriy8Kn45v2hSIjAQGD+YFJp0SBDHXVzQIKb4urSJeeZmbFw9C5f3a0pK/WCIiopIxXFWQMYUrBcUPO5mZYtBS92d539PHDz7Ps7LSbWBTfF3jyhFnZABLlgDz5xc+/NGqFTB3LtC/P39CrMEEQczgzw99K28oysvTfRtlsvIFIHXr+PghERFVFoarCjLGcKVP+fkVC2elvadvFha6D2zW1uIPgUadU1JTga+/FpenT8V1AQFiyAoMNPLGk4KioIIueoiePhWfR9I1Kyvd9RDVuF+GEBFRtcBwVUE1LVzpi+I36SUFr4oEt9JKHuuCiUlh6NI2sJW1vU4fk3r0CFiwAPjmG/FiA0D37mLI6t5dhwciBblcvAd18fxQRob2BRU0oQgzFe0hsrbmY31EREQMVxXEcGX8cnNLD2XlDW6KfKJPMpnun2uzzkiExaIvIPluReE4z969xZAVEKD/kzJyioIKunh+SB8FFUxMKt4rpPi6Vi0+gkdERKRLDFcVxHBVc8nl4g/P+ghulVKQpFYBauWnwzorCbWQiVrIhLWzFWq19IZ1PYdyhTlDFSRRFFSoSKltxbrsbN23z8ys/AHo+XUsqEBERGS8tMkGnCyHqIiiJZl1SRDEH/DLCmXlCW65ueIx5HIgLd0EabAHYF948IcAYivW/qIFSbTtYZNKxXZqG5D0UVBBKtVdD5FUykBEREREqhiuiCqBRCL2TlhaAk5Out13Xl7x0KX8+uo9ZGzcgcwTF5Eh9mMh068tMvy7INPMrtTgVrQgSVaWfobDacLSUjc9RDY2YgEUIiIiIn3hsEA1OCyQqp2LF4HZs4GtW8XXpqZAWBgwcybg6an2IwUF6guSaNvjlp0t9mKVJyBZW4vD74iIiIgMhc9cVRDDFVVbp08Ds2YBO3eKr83NgXfeAaZPB9zdDds2IiIiIiOkTTZgTSmimqRtW+CPP4CjR4EXXxTHFH77LeDjA3z0EZCcbOgWEhEREVVZDFdENVGnTsC+fcD+/UCXLuLYvUWLAG9v4NNPgcePDd1CIiIioiqH4YqoJuvZEzh8GNi9G2jXTnxIKioKaNAAiIwUy/YRERERkUYYrohqOokECAoCTp4Efv0VaNlSDFUREWLI+vJL1dKBRERERKQWwxURiSQSYMAA4OxZICYG8PMThwdOnSoOF4yO1s9svERERETVBMMVEakyMQGGDhXLt//0kxiskpOBDz8EGjYEVqwonLmYiIiIiJT0Fq7u3LmDu3fvKl+fPHkSkyZNwvfff6+vQxKRLpmaAm+9BVy5Anz/PeDhAdy7B4wdC/j6AqtWAfn5hm4lERERkdHQW7h6/fXXsX//fgBAYmIievfujZMnT2L69OmYM2eOvg5LRLqmmAvr2jVgyRLA1RW4dQsYNQpo2hTYsAGQyw3dSiIiIiKD01u4unjxIjp06AAA2LRpE5o3b46jR49i/fr1WL16tb4OS0T6IpUC48YBN24ACxcCTk5i4HrjDcDfH9i6FeCc5ERERFSD6S1c5eXlQSqVAgD27duHAQMGAAD8/Pzw4MEDfR2WiPTNykqccPjmTeCzzwB7e+DSJeDVV8Vy7n/8wZBFRERENZLewlWzZs2wYsUKHD58GHv37kWfPn0AAPfv34ejo6O+DktElcXGBpg+HYiPB2bOBKytgTNngJdfBjp3BmJjGbKIiIioRtFbuPryyy/x3XffoWfPnhg+fDj8/f0BAL/99ptyuCARVQP29sCcOWLI+uQTwNISOH4cCAwEevUCDh1iyCIiIqIaQSII+vupRy6XIz09HQ4ODsp1t27dgpWVFerUqaOvw1ZYeno67OzskJaWBltbW0M3h6hqSUwEoqJUS7bXqQP07CmGrV69gMaNxXm1iIiIiIycNtlAb+Hq2bNnEAQBVlZWAIDbt29j27ZtaNKkCYKCgvRxSJ1huCLSgTt3xGey1q4Fnj1Tfc/NrTBo9eolzqXFsEVERERGyCjC1UsvvYTBgwfjvffeQ2pqKvz8/GBubo6UlBQsWrQIY8eO1cdhdYLhikiHcnKAkyeB/fvF5dgxcV1RHh6qYcvT0zBtJSIiInqOUYQrJycnHDx4EM2aNcP//vc/LFmyBGfPnsWWLVswa9YsXL58WR+H1QmGKyI9ys4WA5YibJ04AeTlqW7ToIFq2Kpb1zBtJSIiohpPm2xgpq9GZGVlwcbGBgCwZ88eDB48GCYmJujYsSNu376tr8MSkbGTyQpDEwBkZQFHjxaGrVOnxOIY8fHAypXiNo0aidsrnttydTVY84mIiIhKordw1bBhQ2zfvh2DBg3Cn3/+iQ8//BAAkJyczN4gIipkZSVWFgwMFF9nZABHjhSGrdOnxcmKr10Dvv9e3MbPrzCg9ewJODsbrPlERERECnobFvjLL7/g9ddfh1wuxwsvvIC9e/cCAKKionDo0CHs2rVLH4fVCQ4LJDIiaWnA4cOFYevcueKl3Zs3LwxbPXoAtWsbpKlERERU/RjFM1cAkJiYiAcPHsDf3x8mJuKUWidPnoStrS38/Pz0ddgKY7giMmKPH4tzZynC1oULqu9LJIC/f2HY6t4dsLMzTFuJiIioyjOacKVw9+5dAEC9evX0fSidYLgiqkIePgQOHiwMW88XyzExAdq0KQxbXbsC//88KBEREVFZjCJcFRQU4LPPPsNXX32FjIwMAICNjQ0++ugjTJ8+XdmTZYwYroiqsMRE4MCBwrB17Zrq+6amQPv2hWGrSxfxuS8iIiIiNYwiXE2bNg0//vgjIiMj0aVLFwDAkSNHEBERgXfeeQeff/65Pg6rEwxXRNXIvXuFQevAAeDmTdX3zc2BgIDCsNWpk1jRkIiIiAhGEq7c3d2xYsUKDBgwQGX9r7/+ivfffx/37t3Tx2F1guGKqBq7fVu1ZyshQfV9qRTo2LEwbAUEiOuIiIioRjKKcCWTyfDvv/+icePGKuvj4uLQqlUrPHv2TB+H1QmGK6IaQhDE+bQUQWv/fuD+fdVtLC2Bzp0Lw1b79mJvFxEREdUIRhGuAgICEBAQgG+++UZl/fjx43Hy5EmcOHFCH4fVCYYrohpKEMRntIqGreRk1W1q1RKLYijCVps2gJnepgwkIiIiAzOKcHXw4EH0798f9evXR6dOnQAAx44dw507d7Bz505069ZNH4fVCYYrIgIghq3Ll1Wf2Xr0SHUbW1ugW7fCsOXvLxbNICIiomrBKMIVANy/fx/Lli3DlStXAABNmjTBmDFj8Nlnn+H777/X12ErjOGKiNQqKAAuXiwMWwcPAqmpqtvY24sTGSvCVvPmYjl4IiIiqpKMJlypc/78ebRp0wZyubwyD6sVhisi0ohcDpw/Xxi2Dh0Cnj5V3cbREejZszBsNWkiTnRMREREVQLDVQUxXBFRueTnA2fOFFYjPHwYyMxU3cbFpTBs9ewJNG7MsEVERGTEtMkGVWKsyrJly+Dl5QWZTIaAgACcPHmyxG23bt2Kdu3awd7eHrVq1UKrVq2wdu3aSmwtEdVYZmZAhw7AJ58Au3YBT54AR48Cn38OBAaKlQeTkoCYGOC99wA/P6BePeCNN4D//Q+4cUN8zouIiIiqJKPvuYqJicGIESOwYsUKBAQEIDo6Gps3b0ZcXBzq1KlTbPsDBw7gyZMn8PPzg4WFBX7//Xd89NFH+OOPPxAUFKTRMdlzRUR6kZMDnDxZOIzw2DFxXVEeHoVDCHv1Ajw9DdNWIiIiAmDgYYGDBw8u9f3U1FQcPHhQ43AVEBCA9u3bY+nSpQCAgoICeHh4YPz48Zg6dapG+2jTpg369++PuXPnarQ9wxURVYpnz4DjxwvD1okTQF6e6jYNGqiGrbp1DdNWIiKiGkqbbKDzyVns7OzKfH/EiBEa7Ss3NxenT5/GtGnTlOtMTEwQGBiIY8eOlfl5QRDw119/IS4uDl9++WWJ2+Xk5CCnyG+P09PTNWofEVGFWFoWhiZAfD7r6NHCsHXqlDjJcXw8sHKluE2jRoWf6dkTcHU1WPOJiIhIlc7D1apVq3S2r5SUFMjlcri4uKisd3FxUZZ3VyctLQ1169ZFTk4OTE1N8e2336J3794lbh8VFYXIyEidtZuIqFxq1QJ69xYXQKw8eORIYdg6c0ac5PjaNUAxnUWTJqphy8nJYM0nIiKq6XQeroyBjY0Nzp07h4yMDMTGxiI8PBze3t7o2bOn2u2nTZuG8PBw5ev09HR4eHhUUmuJiEpgYwP07SsuAJCWJpZ7V4St8+fFSY4vXwa+/VbcpkWLwrDVowfg4GC49hMREdUwRh2unJycYGpqiqSkJJX1SUlJcC1lKIyJiQkaNmwIAGjVqhUuX76MqKioEsOVVCqFVCrVWbuJiPTCzg4IDhYXAHj8WJzIWBG2Ll4ELlwQl2++EUu8t2pVWPq9e3dxH0RERKQXRl2K3cLCAm3btkVsbKxyXUFBAWJjY9GpUyeN91NQUKDyTBURUbVQuzYwaJAYpC5cAJKTgc2bgfffF4cLCgJw9izw9dfAgAHi9u3bF5aKf37CYyIiIqoQo+65AoDw8HCEhoaiXbt26NChA6Kjo5GZmYmRI0cCAEaMGIG6desiKioKgPj8VLt27eDj44OcnBzs3LkTa9euxfLlyw15GkRE+ufsDLz2mrgAQGJi4YTG+/eLz2r984+4LFgAmJqKYUsxjLBLF8DKyqCnQEREVJUZfbgKCQnBw4cPMWvWLCQmJqJVq1bYvXu3sshFQkICTEwKO+AyMzPx/vvv4+7du7C0tISfnx/WrVuHkJAQQ50CEZFhuLoCw4aJCwDcvasatuLjxVLwx48DUVGAuTkQEFAYtjp1AmQyg54CERFRVVLpkwhXBZzniohqhNu3C4PW/v3AnTuq70ulYsBShK2AAMDCwjBtJSIiMhCDTiJcHTBcEVGNIwjAzZuqYevBA9VtLC3FoYOKsNWundjbRUREVI0xXFUQwxUR1XiCAFy9Whi0DhwQC2YUVasW0K1bYdhq3RowM/rR5kRERFphuKoghisioucIAvDff4Vh6+BB4NEj1W1sbVXDlr+/WDSDiIioCmO4qiCGKyKiMhQUiPNqFQ1bqamq2zg4iHNrKcJW8+aAiVHPAEJERFQMw1UFMVwREWlJLgfOny8MW4cOFZ9Hy8kJ6NGjMGw1aSJOdExERGTEGK4qiOGKiKiC8vOBM2cKw9aRI0Bmpuo2Li5Az56FYatRI4YtIiIyOgxXFcRwRUSkY3l5wKlThWHr77+B7GzVbdzdC4NWr15AgwYMW0REZHAMVxXEcEVEpGc5OcCJE4Vh69gxIDdXdZv69VXDVv36hmkrERHVaAxXFcRwRURUyZ49EwOWImydPCn2dhXl7a06jLBuXYM0lYiIahaGqwpiuCIiMrDMTODo0cKwdeqUWDSjqEaNVHu2XFwM01YiIqrWGK4qiOGKiMjIPH0qFsVQhK0zZ8Ry8EU1aVIYtHr2FKsTEhERVRDDVQUxXBERGbnUVODw4cKwdf68ONFxUS1aFIatHj3EebeIiIi0xHBVQQxXRERVzOPH4kTGirB18aLq+xIJ0KpVYdjq1g2wszNIU4mIqGphuKoghisioiouOVk1bF25ovq+iQnQtm1h2OraFbC2NkxbiYjIqDFcVRDDFRFRNfPgAXDgQGHYun5d9X0zM6B9+8Kw1bkzYGVlkKYSEZFxYbiqIIYrIqJq7u7dwqB14AAQH6/6vrk5EBAgBq2AALGXy9XVIE0lIiLDYriqIIYrIqIa5tYt1Z6tO3eKb1O3rhiyii4MXERE1R7DVQUxXBER1WCCANy8KYasQ4eAf/4Rn9lS998lAxcRUbXHcFVBDFdERKQiIwM4dw44fVoMW6dPax642rXjBMdERFUYw1UFMVwREVGZyhu42rUT/2TgIiKqEhiuKojhioiIyoWBi4io2mG4qiCGKyIi0hlF4FKELQYuIqIqheGqghiuiIhIr8oTuBRhi4GLiKhSMVxVEMMVERFVOgYuIiKjxHBVQQxXRERkFDIygLNnC8MWAxcRUaVjuKoghisiIjJaDFxERJWK4aqCGK6IiKhK0TZwFQ1bDFxERKViuKoghisiIqrynj4tLAvPwEVEVG4MVxWk6QWUy+XIy8urxJZRdWRubg5TU1NDN4OIagIGLiIirTFcVVBZF1AQBCQmJiI1NbXyG0fVkr29PVxdXSGRSAzdFCKqabQJXPXqqYYtBi4iqgEYriqorAv44MEDpKamok6dOrCysuIPxFRugiAgKysLycnJsLe3h5ubm6GbRERUPHD98w8QF8fARUQ1EsNVBZV2AeVyOa5evYo6derA0dHRQC2k6ubRo0dITk5G48aNOUSQiIwTAxcR1VDahCuzSmpTtaF4xsrKysrALaHqRHE/5eXlMVwRkXGysQG6dRMXhZIC19274vLrr4XbMnARUQ3AcFVOHApIusT7iYiqpLIC1z//iH8ycBFRDcFwRURERLrDwEVENRjDFZWbl5cXJk2ahEmTJmm0/YEDB9CrVy88efIE9vb2emvX6tWrMWnSJFZzJCIyFroMXIry8HXqVPppEBGVheGqBihryNns2bMRERGh9X5PnTqFWrVqabx9586d8eDBA9jZ2Wl9LCIiqmZKC1yKsMXARURVDMNVDfDgwQPl1zExMZg1axbi4uKU66ytrZVfC4IAuVwOM7Oybw1nZ2et2mFhYQFXV1etPkNERDUIAxcRVXEmhm5AtSAIQGZm5S8aVtF3dXVVLnZ2dpBIJMrXV65cgY2NDXbt2oW2bdtCKpXiyJEjuHHjBl555RW4uLjA2toa7du3x759+1T26+XlhejoaOVriUSC//3vfxg0aBCsrKzQqFEj/Pbbb8r3Dxw4AIlEohyut3r1atjb2+PPP/9EkyZNYG1tjT59+qiEwfz8fEyYMAH29vZwdHTElClTEBoaioEDB2r1LVq+fDl8fHxgYWEBX19frF27tsi3T0BERATq168PqVQKd3d3TJgwQfn+t99+i0aNGkEmk8HFxQWvvfaaVscmIqIKUASuDz8E1q0DLl8G0tKAQ4eARYuAN94A/PwAiaQwbM2aBfTrJz6r5eEBDBwIfPYZsGsXkJxs6DMiomqMPVe6kJUFFOn9qTQZGYAWw/JKM3XqVCxcuBDe3t5wcHDAnTt30K9fP3z++eeQSqX46aefEBwcjLi4ONSvX7/E/URGRmL+/PlYsGABlixZgjfeeAO3b99G7dq11W6flZWFhQsXYu3atTAxMcGbb76JyZMnY/369QCAL7/8EuvXr8eqVavQpEkTLF68GNu3b0evXr00Prdt27Zh4sSJiI6ORmBgIH7//XeMHDkS9erVQ69evbBlyxZ8/fXX+Pnnn9GsWTMkJibi/PnzAIB//vkHEyZMwNq1a9G5c2c8fvwYhw8f1uLKEhGRzpXUw3X2bGHvliY9XIreLfZwEZGOMFwRAGDOnDno3bu38nXt2rXh7++vfD137lxs27YNv/32G8aNG1fifsLCwjB8+HAAwLx58/DNN9/g5MmT6NOnj9rt8/LysGLFCvj4+AAAxo0bhzlz5ijfX7JkCaZNm4ZBgwYBAJYuXYqdO3dqdW4LFy5EWFgY3n//fQBAeHg4jh8/joULF6JXr15ISEiAq6srAgMDYW5ujvr166NDhw4AgISEBNSqVQsvv/wybGxs4OnpidatW2t1fCIiqgQ2NkD37uKiwMBFRJWM4UoXrKzEXiRDHFdH2rVrp/I6IyMDERER+OOPP/DgwQPk5+fj2bNnSEhIKHU/LVu2VH5dq1Yt2NraIrmUIRhWVlbKYAUAbm5uyu3T0tKQlJSkDDoAYGpqirZt26KgoEDjc7t8+TLGjBmjsq5Lly5YvHgxAGDIkCGIjo6Gt7c3+vTpg379+iE4OBhmZmbo3bs3PD09le/16dNHOeyRiIiMHAMXEVUyhitdkEh0NjzPUJ6v+jd58mTs3bsXCxcuRMOGDWFpaYnXXnsNubm5pe7H3Nxc5bVEIik1CKnbXtDwWTJd8fDwQFxcHPbt24e9e/fi/fffx4IFC3Dw4EHY2NjgzJkzOHDgAPbs2YNZs2YhIiICp06d0ms5eSIi0hNdBK6iYYuBi4iKYLgitf7++2+EhYUph+NlZGTg1q1bldoGOzs7uLi44NSpU+j+//8JyuVynDlzBq1atdJ4P02aNMHff/+N0NBQ5bq///4bTZs2Vb62tLREcHAwgoOD8cEHH8DPzw8XLlxAmzZtYGZmhsDAQAQGBmL27Nmwt7fHX3/9hcGDB+vsXImIyIDKE7i2by/cloGLiP4fwxWp1ahRI2zduhXBwcGQSCSYOXOmVkPxdGX8+PGIiopCw4YN4efnhyVLluDJkydlzt1V1Mcff4yhQ4eidevWCAwMxI4dO7B161Zl9cPVq1dDLpcjICAAVlZWWLduHSwtLeHp6Ynff/8dN2/eRPfu3eHg4ICdO3eioKAAvr6++jplIiIyBgxcRFQODFek1qJFizBq1Ch07twZTk5OmDJlCtLT0yu9HVOmTEFiYiJGjBgBU1NTjBkzBkFBQTA1NdV4HwMHDsTixYuxcOFCTJw4EQ0aNMCqVavQs2dPAIC9vT2++OILhIeHQy6Xo0WLFtixYwccHR1hb2+PrVu3IiIiAtnZ2WjUqBE2btyIZs2a6emMiYjIaGkSuP75B7h6VX3g8vBQDVsMXETVjkSo7AdcymHZsmVYsGABEhMT4e/vjyVLlqgUOSjqhx9+wE8//YSLFy8CANq2bYt58+aVuL066enpsLOzQ1paGmxtbVXey87ORnx8PBo0aACZTFb+k6JyKSgoQJMmTTB06FDMnTvX0M3RGd5XRETVSEmBS92PXAxcREavtGzwPKPvuYqJiUF4eDhWrFiBgIAAREdHIygoCHFxcaij5h+fAwcOYPjw4ejcuTNkMhm+/PJLvPTSS7h06RLq1q1rgDOgirh9+zb27NmDHj16ICcnB0uXLkV8fDxef/11QzeNiIhIvbJ6uP75R/zz6lXgzh1xYQ8XUbVg9D1XAQEBaN++PZYuXQpA7Lnw8PDA+PHjMXXq1DI/L5fL4eDggKVLl2LEiBEaHZM9V8bjzp07GDZsGC5evAhBENC8eXN88cUXygIX1QXvKyKiGqikwMUeLiKjUm16rnJzc3H69GlMmzZNuc7ExASBgYE4duyYRvvIyspCXl4eateuXeI2OTk5yMnJUb42xLNFpJ6Hhwf+/vtvQzeDiIhI99jDRVTtGHW4SklJgVwuh4uLi8p6FxcXXLlyRaN9TJkyBe7u7ggMDCxxm6ioKERGRlaorUREREQVVlrgUoQtbQJXo0Zi5UKOiiCqFEYdrirqiy++wM8//4wDBw6UOtRq2rRpCA8PV75OT0+Hh4dHZTSRiIiIqHQVDVyA2KNVv764eHio/lm/PuDiApiYVOppEVVHRh2unJycYGpqiqSkJJX1SUlJcHV1LfWzCxcuxBdffIF9+/ahZcuWpW4rlUohlUor3F4iIiKiSqFJ4Dp3Drh1C8jKApKTxeWff9Tvz9xc7OEqGrieD2F2dpVxZkRVmlGHKwsLC7Rt2xaxsbEYOHAgALGgRWxsLMaNG1fi5+bPn4/PP/8cf/75J9q1a1dJrSUiIiIyIHWBSxCAx4+BhASxR6von4qv790D8vKA+HhxKYmtbfHAVTSM1a0L8JfVVMMZdbgCgPDwcISGhqJdu3bo0KEDoqOjkZmZiZEjRwIARowYgbp16yIqKgoA8OWXX2LWrFnYsGEDvLy8kJiYCACwtraGtbW1wc6DiIiIqNJJJICjo7i0bq1+m/x84MED1cD1fAh7/BhITwcuXRKXkri6lt77VacOhx9StWb04SokJAQPHz7ErFmzkJiYiFatWmH37t3KIhcJCQkwKfKXdPny5cjNzcVrr72msp/Zs2cjIiKiMptOREREZPzMzMTw4+EBdOmifpvMzMLnuUoKYdnZQGKiuJw6pX4/Fhbi8MPne72KhrAySl0TGTOjn+fKEDjPlXo9e/ZEq1atEB0dDQDw8vLCpEmTMGnSpBI/I5FIsG3bNuWwzvLS1X5KExERge3bt+PcuXN6O0ZJavJ9RURE1YAgACkpxQNX0TD24AFQUFD2vuzsSh566OEhDj+0sND/ORH9v2ozzxXpRnBwMPLy8rB79+5i7x0+fBjdu3fH+fPnyyz88bxTp06hVq1aumomgJIDzoMHD+Dg4KDTYxEREZGOSCSAs7O4tGmjfpu8POD+/dJ7v548AdLSgAsXxKWkY7m6ll790NlZ3I6okjFc1QCjR4/Gq6++irt376JevXoq761atQrt2rXTOlgBgLOzs66aWKayqkMSERGRkTM3Bzw9xaUkGRklF95Q/JmTI/aCPXgAnDihfj9SaeFQx5JCGJ/FJz3gE4U6IAjiUOTKXjQd0Pnyyy/D2dkZq1evVlmfkZGBzZs3Y/To0Xj06BGGDx+OunXrwsrKCi1atMDGjRtL3a+Xl5dyiCAAXLt2Dd27d4dMJkPTpk2xd+/eYp+ZMmUKGjduDCsrK3h7e2PmzJnIy8sDAKxevRqRkZE4f/48JBIJJBKJss0SiQTbi8zZceHCBbzwwguwtLSEo6MjxowZg4yMDOX7YWFhGDhwIBYuXAg3Nzc4Ojrigw8+UB5LEwUFBZgzZw7q1asHqVSqfN5PITc3F+PGjYObmxtkMhk8PT2VhVUEQUBERATq168PqVQKd3d3TJgwQeNjExER1UjW1kCTJkBQEPD228CcOcDq1UBsLHDtGvDsGZCUJD7TtXUrEB0NfPQRMGQIEBAAuLuLPVY5OcD168D+/cCaNcDcucCYMUCfPkCzZmJlRQcHwN8fCA4G3n8f+OILYP164PBh4PZtsaeNSEvsudKBrCzD/PIjIwPQZFSemZkZRowYgdWrV2P69OmQ/H83+ebNmyGXyzF8+HBkZGSgbdu2mDJlCmxtbfHHH3/grbfego+PDzp06FDmMQoKCjB48GC4uLjgxIkTSEtLU/sslo2NDVavXg13d3dcuHAB77zzDmxsbPDJJ58gJCQEFy9exO7du7Fv3z4AgJ2aOTUyMzMRFBSETp064dSpU0hOTsbbb7+NcePGqQTI/fv3w83NDfv378f169cREhKCVq1a4Z133in7ogFYvHgxvvrqK3z33Xdo3bo1Vq5ciQEDBuDSpUto1KgRvvnmG/z222/YtGkT6tevjzt37uDOnTsAgC1btuDrr7/Gzz//jGbNmiExMRHnz5/X6LhERERUAolErDhYpw5Q0nQ7ubni8MPSqh+mpQGpqeLy77/q92NiAri5ld775eTE4YekguGqhhg1ahQWLFiAgwcPomfPngDEIYGvvvoq7OzsYGdnh8mTJyu3Hz9+PP78809s2rRJo3C1b98+XLlyBX/++Sfc3d0BAPPmzUPfvn1VtpsxY4byay8vL0yePBk///wzPvnkE1haWsLa2hpmZmalDgPcsGEDsrOz8dNPPymf+Vq6dCmCg4Px5ZdfKitJOjg4YOnSpTA1NYWfnx/69++P2NhYjcPVwoULMWXKFAwbNgyAWOZ///79iI6OxrJly5CQkIBGjRqha9eukEgk8CwyzCEhIQGurq4IDAyEubk56tevr9F1JCIiogqysAC8vMSlJOnppVc/vHNHDGn37onL8ePq9yOTlVx4Q/Gnjp9PJ+PGcKUDVlZiL5IhjqspPz8/dO7cGStXrkTPnj1x/fp1HD58GHPmzAEAyOVyzJs3D5s2bcK9e/eQm5uLnJwcWGl4kMuXL8PDw0MZrACgU6dOxbaLiYnBN998gxs3biAjIwP5+fllVl1Rdyx/f3+VYhpdunRBQUEB4uLilOGqWbNmMDU1VW7j5uaGCyU9HPuc9PR03L9/H12eK0nbpUsXZQ9UWFgYevfuDV9fX/Tp0wcvv/wyXnrpJQDAkCFDEB0dDW9vb/Tp0wf9+vVDcHAwzMz4V46IiMjgbG3F4YHNmql/v6AASE4u/fmvxESx/Py1a+JSktq1S69+6O4ulsOnaoHfSR2QSKrGLyVGjx6N8ePHY9myZVi1ahV8fHzQo0cPAMCCBQuwePFiREdHo0WLFqhVqxYmTZqE3NxcnR3/2LFjeOONNxAZGYmgoCDY2dnh559/xldffaWzYxRlbm6u8loikaBAkxKwGmrTpg3i4+Oxa9cu7Nu3D0OHDkVgYCB++eUXeHh4IC4uDvv27cPevXvx/vvvK3sOn28XERERGRkTE7Eioasr0L69+m1ycsReLXVDD+/cEZ/bevpUnID58WOgpKleTEzEgFXS0EMPD3ESaA4/rBIYrmqQoUOHYuLEidiwYQN++uknjB07Vvn81d9//41XXnkFb775JgDxGaqrV6+iadOmGu27SZMmuHPnDh48eAA3NzcAwPHnutCPHj0KT09PTJ8+Xbnu9u3bKttYWFhALpeXeazVq1cjMzNT2Xv1999/w8TEBL6+vhq1tyy2trZwd3fH33//rQygiuMUHd5na2uLkJAQhISE4LXXXkOfPn3w+PFj1K5dG5aWlggODkZwcDA++OAD+Pn54cKFC2hTUolaIiIiqjqkUsDbW1xKkpZWeu/X3bti4Yy7d8Xl6FH1+7G0LL33y8NDuyFNpDcMVzWItbU1QkJCMG3aNKSnpyMsLEz5XqNGjfDLL7/g6NGjcHBwwKJFi5CUlKRxuAoMDETjxo0RGhqKBQsWID09XSVEKY6RkJCAn3/+Ge3bt8cff/yBbdu2qWzj5eWF+Ph4nDt3DvXq1YONjQ2kUqnKNm+88QZmz56N0NBQRERE4OHDhxg/fjzeeust5ZBAXfj4448xe/Zs+Pj4oFWrVli1ahXOnTuH9evXAwAWLVoENzc3tG7dGiYmJti8eTNcXV1hb2+P1atXQy6XIyAgAFZWVli3bh0sLS1VnssiIiKias7OTlyaN1f/fkGBWP2wpMIbd+6I7z97BsTFiUtJHB1Ln/vLzQ0o8rgE6QfDVQ0zevRo/Pjjj+jXr5/K81EzZszAzZs3ERQUBCsrK4wZMwYDBw5EWlqaRvs1MTHBtm3bMHr0aHTo0AFeXl745ptv0KdPH+U2AwYMwIcffohx48YhJycH/fv3x8yZMxEREaHc5tVXX8XWrVvRq1cvpKamYtWqVSohEACsrKzw559/YuLEiWjfvj2srKzw6quvYtGiRRW6Ns+bMGEC0tLS8NFHHyE5ORlNmzbFb7/9hkaNGgEQKx/Onz8f165dg6mpKdq3b4+dO3fCxMQE9vb2+OKLLxAeHg65XI4WLVpgx44dcHR01GkbiYiIqApTVCR0cxNLyauTnV04/LCkEJaRATx6JC5nz6rfj6kpULdu6dUPHRw4/LCCJIKg6WxJNUd6ejrs7OyQlpZWrNhCdnY24uPj0aBBA8hkMgO1kKob3ldERERULoIgDj8sbeLlu3eB/Pyy91WrlvpnvhRhrF49cYhiDVNaNngee66IiIiIiKoqiQSwtxeXli3VbyOXi9UNS3v+6+FDIDMTuHJFXEri7Fx675era40efshwRURERERUnSmGBNatC3TsqH6bZ8/EHq7Snv/KzBRD2MOHwJkz6vdjZiYep7S5v+ztq+3wQ4YrIiIiIqKaztISaNRIXNQRBODJk9J7v+7dE4cf3r4tLiWxti69+mG9euIEzVUQwxUREREREZVOIhEnRK5dG/D3V7+NXA48eFB671dKiliA47//xKUkdeqIx9mzRz/noycMV+XEOiCkS7yfiIiIqMozNRV7nerVK3mbrKzC4YclhbBnz4DkZHH4YRXDcKUlc3NzAEBWVhYsa2C1FNKPrKwsAIX3FxEREVG1ZGUFNG4sLuoIAvD4sRiycnMrt206wHClJVNTU9jb2yM5ORmAOOeSpJo+kEf6JwgCsrKykJycDHt7e5jW4Oo6RERERJBIxAmRq+jcoAxX5eDq6goAyoBFVFH29vbK+4qIiIiIqiaGq3KQSCRwc3NDnTp1kJeXZ+jmUBVnbm7OHisiIiKiaoDhqgJMTU35QzEREREREQEATAzdACIiIiIiouqA4YqIiIiIiEgHGK6IiIiIiIh0gM9cqaGY0DU9Pd3ALSEiIiIiIkNSZAJFRigNw5UaT58+BQB4eHgYuCVERERERGQMnj59Cjs7u1K3kQiaRLAapqCgAPfv34eNjY3BJwhOT0+Hh4cH7ty5A1tbW4O2pTri9dUvXl/94vXVP15j/eL11S9eX/3i9dUvY7q+giDg6dOncHd3h4lJ6U9VsedKDRMTE9SrV8/QzVBha2tr8BurOuP11S9eX/3i9dU/XmP94vXVL15f/eL11S9jub5l9VgpsKAFERERERGRDjBcERERERER6QDDlZGTSqWYPXs2pFKpoZtSLfH66hevr37x+uofr7F+8frqF6+vfvH66ldVvb4saEFERERERKQD7LkiIiIiIiLSAYYrIiIiIiIiHWC4IiIiIiIi0gGGKyIiIiIiIh1guDKwQ4cOITg4GO7u7pBIJNi+fXuZnzlw4ADatGkDqVSKhg0bYvXq1XpvZ1Wl7fU9cOAAJBJJsSUxMbFyGlyFREVFoX379rCxsUGdOnUwcOBAxMXFlfm5zZs3w8/PDzKZDC1atMDOnTsrobVVU3mu8erVq4vdvzKZrJJaXLUsX74cLVu2VE5Q2alTJ+zatavUz/D+1Zy215f3bvl98cUXkEgkmDRpUqnb8f4tH02uL+9f7URERBS7Xn5+fqV+pqrcvwxXBpaZmQl/f38sW7ZMo+3j4+PRv39/9OrVC+fOncOkSZPw9ttv488//9RzS6smba+vQlxcHB48eKBc6tSpo6cWVl0HDx7EBx98gOPHj2Pv3r3Iy8vDSy+9hMzMzBI/c/ToUQwfPhyjR4/G2bNnMXDgQAwcOBAXL16sxJZXHeW5xoA4m33R+/f27duV1OKqpV69evjiiy9w+vRp/PPPP3jhhRfwyiuv4NKlS2q35/2rHW2vL8B7tzxOnTqF7777Di1btix1O96/5aPp9QV4/2qrWbNmKtfryJEjJW5bpe5fgYwGAGHbtm2lbvPJJ58IzZo1U1kXEhIiBAUF6bFl1YMm13f//v0CAOHJkyeV0qbqJDk5WQAgHDx4sMRthg4dKvTv319lXUBAgPDuu+/qu3nVgibXeNWqVYKdnV3lNaqacXBwEP73v/+pfY/3b8WVdn1572rv6dOnQqNGjYS9e/cKPXr0ECZOnFjitrx/tafN9eX9q53Zs2cL/v7+Gm9fle5f9lxVMceOHUNgYKDKuqCgIBw7dsxALaqeWrVqBTc3N/Tu3Rt///23oZtTJaSlpQEAateuXeI2vH8rRpNrDAAZGRnw9PSEh4dHmT0FJJLL5fj555+RmZmJTp06qd2G92/5aXJ9Ad672vrggw/Qv3//YvelOrx/tafN9QV4/2rr2rVrcHd3h7e3N9544w0kJCSUuG1Vun/NDN0A0k5iYiJcXFxU1rm4uCA9PR3Pnj2DpaWlgVpWPbi5uWHFihVo164dcnJy8L///Q89e/bEiRMn0KZNG0M3z2gVFBRg0qRJ6NKlC5o3b17idiXdv3ymrWyaXmNfX1+sXLkSLVu2RFpaGhYuXIjOnTvj0qVLqFevXiW2uGq4cOECOnXqhOzsbFhbW2Pbtm1o2rSp2m15/2pPm+vLe1c7P//8M86cOYNTp05ptD3vX+1oe315/2onICAAq1evhq+vLx48eIDIyEh069YNFy9ehI2NTbHtq9L9y3BFVISvry98fX2Vrzt37owbN27g66+/xtq1aw3YMuP2wQcf4OLFi6WOl6aK0fQad+rUSaVnoHPnzmjSpAm+++47zJ07V9/NrHJ8fX1x7tw5pKWl4ZdffkFoaCgOHjxYYgAg7WhzfXnvau7OnTuYOHEi9u7dy6IJelCe68v7Vzt9+/ZVft2yZUsEBATA09MTmzZtwujRow3YsopjuKpiXF1dkZSUpLIuKSkJtra27LXSkw4dOjA0lGLcuHH4/fffcejQoTJ/O1fS/evq6qrPJlZ52lzj55mbm6N169a4fv26nlpXtVlYWKBhw4YAgLZt2+LUqVNYvHgxvvvuu2Lb8v7VnjbX93m8d0t2+vRpJCcnq4yokMvlOHToEJYuXYqcnByYmpqqfIb3r+bKc32fx/tXO/b29mjcuHGJ16sq3b985qqK6dSpE2JjY1XW7d27t9Qx7FQx586dg5ubm6GbYXQEQcC4ceOwbds2/PXXX2jQoEGZn+H9q53yXOPnyeVyXLhwgfewhgoKCpCTk6P2Pd6/FVfa9X0e792Svfjii7hw4QLOnTunXNq1a4c33ngD586dU/uDP+9fzZXn+j6P9692MjIycOPGjRKvV5W6fw1dUaOme/r0qXD27Fnh7NmzAgBh0aJFwtmzZ4Xbt28LgiAIU6dOFd566y3l9jdv3hSsrKyEjz/+WLh8+bKwbNkywdTUVNi9e7ehTsGoaXt9v/76a2H79u3CtWvXhAsXLggTJ04UTExMhH379hnqFIzW2LFjBTs7O+HAgQPCgwcPlEtWVpZym7feekuYOnWq8vXff/8tmJmZCQsXLhQuX74szJ49WzA3NxcuXLhgiFMweuW5xpGRkcKff/4p3LhxQzh9+rQwbNgwQSaTCZcuXTLEKRi1qVOnCgcPHhTi4+OFf//9V5g6daogkUiEPXv2CILA+7eitL2+vHcr5vlqdrx/daus68v7VzsfffSRcODAASE+Pl74+++/hcDAQMHJyUlITk4WBKFq378MVwamKP39/BIaGioIgiCEhoYKPXr0KPaZVq1aCRYWFoK3t7ewatWqSm93VaHt9f3yyy8FHx8fQSaTCbVr1xZ69uwp/PXXX4ZpvJFTd10BqNyPPXr0UF5rhU2bNgmNGzcWLCwshGbNmgl//PFH5TbcwEJDQwVPT0+Nti3PNZ40aZJQv359wcLCQnBxcRH69esnnDlzRrcnoUfx8fHFzlFfRo0aJXh6egoWFhaCnZ2dAEBYsGCB8n0XFxehVq1aKp9Rd//qq82enp7F/v5UJUWvr7Ozs/Diiy8qg5UgVL9719Ce/+Gf//7qVlnXl/evdkJCQgQ3NzfBwsJCqFu3rhASEiJcv35d+X5Vvn8lgiAIldRJRkRktCQSiUbb7d+/Hz179iz3ccLCwnDgwAHcunVL689GREQgMjIS1fmf7Vu3bqFBgwZYtWoVwsLCKu24Bw4cQK9evVS+v5p+ryrS5qNHj2LPnj2YNGkS7O3tVd7z8vJCz549sXr1aq32SUREhsOCFkREQLFqkD/99BP27t1bbH2TJk0qdJwffvgBBQUF5frsjBkzMHXq1AodnzRXke+Vpo4ePYrIyEiEhYUVC1dxcXEwMeGj0UREVQnDFRERgDfffFPl9fHjx7F3795i65+XlZUFKysrjY9jbm5ervYBgJmZGczM+M92ZanI90oXpFKpQY9fVWRmZqJWrVqGbgYREQBWCyQi0ljPnj3RvHlznD59Gt27d4eVlRU+/fRTAMCvv/6K/v37w93dHVKpFD4+Ppg7dy7kcrnKPsLCwuDl5aV8fevWLUgkEixcuBDff/89fHx8IJVK0b59+2KTV0ZERBQbviiRSDBu3Dhs374dzZs3h1QqRbNmzbB79+5i7T9w4ADatWsHmUwGHx8ffPfdd2r3qc7hw4cxZMgQ1K9fH1KpFB4eHvjwww/x7NmzYudnbW2Ne/fuYeDAgbC2toazszMmT55c7FqkpqYiLCwMdnZ2sLe3R2hoKFJTU8tsyz///AOJRII1a9YUe+/PP/+ERCLB77//DgC4ffs23n//ffj6+sLS0hKOjo4YMmSIRsMyn/9eadPmf//9F2FhYfD29oZMJoOrqytGjRqFR48eKbeJiIjAxx9/DABo0KABJBIJJBKJsm1eXl7FhhnevHkTQ4YMQe3atWFlZYWOHTvijz/+UNnmwIEDkEgk2LRpEz7//HPUq1cPMpkML774okZlobW5Zqmpqfjwww/h5eUFqVSKevXqYcSIEUhJSVFuk52djYiICDRu3BgymQxubm4YPHgwbty4odLeAwcOqOxb8Xej6LBIxf1148YN9OvXDzY2NnjjjTcAaH6PAsCVK1cwdOhQODs7w9LSEr6+vpg+fToAceivRCLBtm3bin1uw4YNkEgkOHbsWJnXkYhqJv4KlIhIC48ePULfvn0xbNgwvPnmm8oZ41evXg1ra2uEh4fD2toaf/31F2bNmoX09HQsWLCgzP1u2LABT58+xbvvvguJRIL58+dj8ODBuHnzZpk9KEeOHMHWrVvx/vvvw8bGBt988w1effVVJCQkwNHREQBw9uxZ9OnTB25uboiMjIRcLsecOXPg7Oys0Xlv3rwZWVlZGDt2LBwdHXHy5EksWbIEd+/exebNm1W2lcvlCAoKQkBAABYuXIh9+/bhq6++go+PD8aOHQtALDP/yiuv4MiRI3jvvffQpEkTbNu2DaGhoWW2pV27dvD29samTZuKbR8TEwMHBwcEBQUBAE6dOoWjR49i2LBhqFevHm7duoXly5ejZ8+e+O+//7TqddSmzXv37sXNmzcxcuRIuLq64tKlS/j+++9x6dIlHD9+HBKJBIMHD8bVq1exceNGfP3113BycgKAEr8nSUlJ6Ny5M7KysjBhwgQ4OjpizZo1GDBgAH755RcMGjRIZfsvvvgCJiYmmDx5MtLS0jB//ny88cYbOHHiRKnnqek1y8jIQLdu3XD58mWMGjUKbdq0QUpKCn777TfcvXsXTk5OkMvlePnllxEbG4thw4Zh4sSJePr0Kfbu3YuLFy/Cx8dH4+uvkJ+fj6CgIHTt2hULFy5UtkfTe/Tff/9Ft27dYG5ujjFjxsDLyws3btzAjh078Pnnn6Nnz57w8PDA+vXri13T9evXw8fHxzjLPxORcTBoOQ0iIiP1wQcfCM//E9mjRw8BgLBixYpi2xctj67w7rvvClZWVkJ2drZy3fPVAhWV5hwdHYXHjx8r1//6668CAGHHjh3KdbNnzy7WJgCChYWFSpWl8+fPCwCEJUuWKNcFBwcLVlZWwr1795Trrl27JpiZmRXbpzrqzi8qKkqQSCTKqQ0U5wdAmDNnjsq2rVu3Ftq2bat8vX37dgGAMH/+fOW6/Px8oVu3bhpV3ps2bZpgbm6ucs1ycnIEe3t7YdSoUaW2+9ixYwIA4aefflKuU1QW3b9/v8q5FP1eadNmdcfduHGjAEA4dOiQct2CBQsEAEJ8fHyx7Z+vFjhp0iQBgHD48GHluqdPnwoNGjQQvLy8BLlcrnIuTZo0EXJycpTbLl68WABQZuliTa/ZrFmzBADC1q1bi21fUFAgCIIgrFy5UjkNRknbqLv2gqC+cqTi/ipaorm0dqu7R7t37y7Y2NiorCvaHkEQ7y+pVCqkpqYq1yUnJwtmZmbC7Nmzix2HiEiBwwKJiLQglUoxcuTIYustLS2VXz99+hQpKSno1q0bsrKycOXKlTL3GxISAgcHB+Xrbt26ARCHgZUlMDBQpQegZcuWsLW1VX5WLpdj3759GDhwINzd3ZXbNWzYEH379i1z/4Dq+WVmZiIlJQWdO3eGIAg4e/Zsse3fe+89ldfdunVTOZedO3fCzMxM2ZMFAKamphg/frxG7QkJCUFeXh62bt2qXLdnzx6kpqYiJCREbbvz8vLw6NEjNGzYEPb29jhz5oxGxypPm4seNzs7GykpKejYsSMAaH3cosfv0KEDunbtqlxnbW2NMWPG4NatW/jvv/9Uth85ciQsLCyUrzW9pzS9Zlu2bIG/v3+x3h2gsPrmli1b4OTkpPYaaVqhU52i3wN17S7pHn348CEOHTqEUaNGoX79+iW2Z8SIEcjJycEvv/yiXBcTE4P8/Pwyn8MkopqN4YqISAt169ZV+YFV4dKlSxg0aBDs7Oxga2sLZ2dn5Q9haWlpZe73+R/0FEHryZMnWn9W8XnFZ5OTk/Hs2TM0bNiw2Hbq1qmTkJCAsLAw1K5dW/kcVY8ePQAUPz+ZTFZsaFvR9gDicz1ubm6wtrZW2c7X11ej9vj7+8PPzw8xMTHKdTExMXBycsILL7ygXPfs2TPMmjULHh4ekEqlcHJygrOzM1JTUzX6vhSlTZsfP36MiRMnwsXFBZaWlnB2dkaDBg0AaHY/lHR8dcdSVLC8ffu2yvry3lOaXrMbN26gefPmpe7rxo0b8PX11WkhFjMzM9SrV6/Yek3uUUWwLKvdfn5+aN++PdavX69ct379enTs2FHjvzNEVDPxmSsiIi0U/e24QmpqKnr06AFbW1vMmTMHPj4+kMlkOHPmDKZMmaJROW9TU1O16wUN5rSqyGc1IZfL0bt3bzx+/BhTpkyBn58fatWqhXv37iEsLKzY+ZXUHl0LCQnB559/jpSUFNjY2OC3337D8OHDVX6QHz9+PFatWoVJkyahU6dOsLOzg0QiwbBhw/RaZn3o0KE4evQoPv74Y7Rq1QrW1tYoKChAnz599F7eXaG890VlX7OSerCeL4CiIJVKi5Wo1/Ye1cSIESMwceJE3L17Fzk5OTh+/DiWLl2q9X6IqGZhuCIiqqADBw7g0aNH2Lp1K7p3765cHx8fb8BWFapTpw5kMpnaSnGaVI+7cOECrl69ijVr1mDEiBHK9Xv37i13mzw9PREbG4uMjAyVnqC4uDiN9xESEoLIyEhs2bIFLi4uSE9Px7Bhw1S2+eWXXxAaGoqvvvpKuS47O1ujqoTlbfOTJ08QGxuLyMhIzJo1S7n+2rVrxfapzdA4T09PtddHMezU09NT432VRtNr5uPjg4sXL5a6Lx8fH5w4cQJ5eXklFmZR9Kg9v//ne+JKo+k96u3tDQBlthsAhg0bhvDwcGzcuBHPnj2Dubm5ypBTIiJ1OCyQiKiCFD0ERXsEcnNz8e233xqqSSpMTU0RGBiI7du34/79+8r1169fx65duzT6PKB6foIgYPHixeVuU79+/ZCfn4/ly5cr18nlcixZskTjfTRp0gQtWrRATEwMYmJi4ObmphJuFW1/vqdmyZIlJfaK6KLN6q4XAERHRxfbp2J+Jk3CXr9+/XDy5EmVMuCZmZn4/vvv4eXlhaZNm2p6KqXS9Jq9+uqrOH/+vNqS5YrPv/rqq0hJSVHb46PYxtPTE6ampjh06JDK+9r8/dH0HnV2dkb37t2xcuVKJCQkqG2PgpOTE/r27Yt169Zh/fr16NOnj7KiIxFRSdhzRURUQZ07d4aDgwNCQ0MxYcIESCQSrF27VmfD8nQhIiICe/bsQZcuXTB27FjI5XIsXboUzZs3x7lz50r9rJ+fH3x8fDB58mTcu3cPtra22LJli0bPg5UkODgYXbp0wdSpU3Hr1i00bdoUW7du1fp5pJCQEMyaNQsymQyjR48uNlzs5Zdfxtq1a2FnZ4emTZvi2LFj2Ldvn7JEvT7abGtri+7du2P+/PnIy8tD3bp1sWfPHrU9mW3btgUATJ8+HcOGDYO5uTmCg4PVToo7depUbNy4EX379sWECRNQu3ZtrFmzBvHx8diyZUuxcy8vTa/Zxx9/jF9++QVDhgzBqFGj0LZtWzx+/Bi//fYbVqxYAX9/f4wYMQI//fQTwsPDcfLkSXTr1g2ZmZnYt28f3n//fbzyyiuws7PDkCFDsGTJEkgkEvj4+OD3339HcnKyxm3W5h795ptv0LVrV7Rp0wZjxoxBgwYNcOvWLfzxxx/F/i6MGDECr732GgBg7ty52l9MIqpxGK6IiCrI0dERv//+Oz766CPMmDEDDg4OePPNN/Hiiy8q51sytLZt22LXrl2YPHkyZs6cCQ8PD8yZMweXL18us5qhubk5duzYgQkTJiAqKgoymQyDBg3CuHHj4O/vX672mJiY4LfffsOkSZOwbt06SCQSDBgwAF999RVat26t8X5CQkIwY8YMZGVlqR2ytXjxYpiammL9+vXIzs5Gly5dsG/fvnJ9X7Rp84YNGzB+/HgsW7YMgiDgpZdewq5du1SqNQJA+/btMXfuXKxYsQK7d+9GQUEB4uPj1YYrFxcXHD16FFOmTMGSJUuQnZ2Nli1bYseOHejfv7/W51MSTa+ZtbU1Dh8+jNmzZ2Pbtm1Ys2YN6tSpgxdffFFZcMLU1BQ7d+7E559/jg0bNmDLli1wdHRE165d0aJFC+W+lixZgry8PKxYsQJSqRRDhw7FggULyiw8oaDNPerv74/jx49j5syZWL58ObKzs+Hp6YmhQ4cW229wcDAcHBxQUFCAAQMGaHspiagGkgjG9KtVIiKqVAMHDsSlS5fUPg9EVNPl5+fD3d0dwcHB+PHHHw3dHCKqAvjMFRFRDfHs2TOV19euXcPOnTvRs2dPwzSIyMht374dDx8+VCmSQURUGvZcERHVEG5ubggLC4O3tzdu376N5cuXIycnB2fPnkWjRo0M3Twio3HixAn8+++/mDt3LpycnMo98TMR1Tx85oqIqIbo06cPNm7ciMTEREilUnTq1Anz5s1jsCJ6zvLly7Fu3Tq0atUKq1evNnRziKgKYc8VERERERGRDvCZKyIiIiIiIh0weLhatmwZvLy8IJPJEBAQgJMnT5a4bV5eHubMmQMfHx/IZDL4+/tj9+7dKttERERAIpGoLH5+fvo+DSIiIiIiquEM+sxVTEwMwsPDsWLFCgQEBCA6OhpBQUGIi4tDnTp1im0/Y8YMrFu3Dj/88AP8/Pzw559/YtCgQTh69KjKHCPNmjXDvn37lK/NzLQ7zYKCAty/fx82NjaQSCTlP0EiIiIiIqrSBEHA06dP4e7uXvaE7YIBdejQQfjggw+Ur+VyueDu7i5ERUWp3d7NzU1YunSpyrrBgwcLb7zxhvL17NmzBX9//wq1686dOwIALly4cOHChQsXLly4cBEACHfu3CkzRxis5yo3NxenT5/GtGnTlOtMTEwQGBiIY8eOqf1MTk4OZDKZyjpLS0scOXJEZd21a9fg7u4OmUyGTp06ISoqCvXr1y+xLTk5OcjJyVG+Fv6/xsedO3dga2ur9bkREREREVH1kJ6eDg8PD9jY2JS5rcHCVUpKCuRyOVxcXFTWu7i44MqVK2o/ExQUhEWLFqF79+7w8fFBbGwstm7dCrlcrtwmICAAq1evhq+vLx48eIDIyEh069YNFy9eLPGCREVFITIysth6W1tbhisiIiIiItLocSGDF7TQxuLFi9GoUSP4+fnBwsIC48aNw8iRI1XGPvbt2xdDhgxBy5YtERQUhJ07dyI1NRWbNm0qcb/Tpk1DWlqacrlz505lnA4REREREVUjBgtXTk5OMDU1RVJSksr6pKQkuLq6qv2Ms7Mztm/fjszMTNy+fRtXrlyBtbU1vL29SzyOvb09GjdujOvXr5e4jVQqVfZSsbeKiIiIiIjKw2DhysLCAm3btkVsbKxyXUFBAWJjY9GpU6dSPyuTyVC3bl3k5+djy5YteOWVV0rcNiMjAzdu3ICbm5vO2k5ERERERPQ8gw4LDA8Pxw8//IA1a9bg8uXLGDt2LDIzMzFy5EgAwIgRI1QKXpw4cQJbt27FzZs3cfjwYfTp0wcFBQX45JNPlNtMnjwZBw8exK1bt3D06FEMGjQIpqamGD58eKWfHxERERER1RwGnecqJCQEDx8+xKxZs5CYmIhWrVph9+7dyiIXCQkJKs9TZWdnY8aMGbh58yasra3Rr18/rF27Fvb29spt7t69i+HDh+PRo0dwdnZG165dcfz4cTg7O1f26RERERERUQ0iERR1x0kpPT0ddnZ2SEtL4/NXRERERES6JAhAWhqQnCwuSUmFXxdd3NyAn382dGu1ygYG7bkiIiIiIqJqIDsbePiw5KD0/JKXV/Y+GzTQf7t1jOGKiIiIiIhUFRQAjx5pFpSSk4H0dO2PYWsL1KkDuLiIfz6/uLvr/rz0jOGKiIiIiKgmyMjQPCw9fCgGLG2Ym5celoouzs6ATKaf8zQghisiIiIioqooLw9ISdE8MGVlaX8MR8eyg5JisbMDJBLdn2cVwnBFRERERGQMni/0UNqSlAQ8fqz9MSwtNetZqlMHcHISe6NIYwxXRERERET6oij0oElY0rTQQ1EmJuIQO017l6yt9XOeBIDhioiIiIhIcwUFYo+RJkGpooUeylpcXAAHB8DUVPfnSeXCcEVERERENVtmpuZhKSUFkMu127+i0ENZQakaF3qoKRiuiIiIiKh6yc8vudCDunmYylPooXZtzcISCz3UKAxXRERERGTcBEEcXqdJUEpOFudn0pZMVnKhh+fXs9ADlYDhioiIiIgqX05O8UIPJYWl5GQgN1e7/ZuYiCFIk7BUpw5QqxZ7l6jCGK6IiIiIqOIKCoAnTzQPS2lp2h/DxkbzsFS7Ngs9UKVjuCIiIiIi9bKyNAtKycliL5S2hR7MzDQLSopCD5aW+jlPIh1huCIiIiKqKfLzxeeRNAlLycliFT1tOThoFpbq1AHs7TkUj6oVhisiIiKi6iIzE7h4EbhwQfzzwYPihR4EQbt9ymSaBSVFoQcLC/2cG1EVwHBFREREVNUUFADx8cC//6ouN26UHZ4kEjEElRWUFIu1NXuXiDTEcEVERERkzFJTxZ6ooiHqwoWSh+y5ugItWwItWgD16xcPS46OLPRApCcMV0RERETGID8fuHq1MDwpglRCgvrtpVKgWTMxSCmWFi3EAEVEBsFwRURERFTZkpOLD+n77z9x7id16tdXDVEtWwKNGonV9ojIaPBvJBEREZG+5OQAly8XD1JJSeq3t7YWe5+KhqjmzcWqekRk9BiuiIiIiCpKEIC7d4s/G3Xlivq5nyQSoGHD4r1RXl6AiUmlN5+IdIPhioiIiEgbinLnz/dGpaaq397BoXiIatYMqFWrUptNRPrHcEVERESkjrblzs3MAD+/4gUm6tZlKXOiGoLhioiIiOjJE3FIX9FhfZqUOy+6+PmJFfyIqMZiuCIiIqKao2i586LLnTvqt2e5cyLSAsMVERERVU/aljv39CzeG9WwIcudE5HG+K8FERERVW0sd05ERoLhioiIiKoGRbnz50NUXBzLnRORUWC4IiIiIuNTnnLn/v6qz0Wx3DkRVTKGKyIiIjKcggLg5s3ik+9qU+68ZUvA3Z3lzonI4BiuiIiIqHIoyp0XDVEXL7LcORFVGwxXREREpFvlKXfevHnxcufOzpXbbiKiCmK4IiIiovJjuXMiIiX+S0ZERERly84uXu78wgWWOyciKoLhioiIiAqVp9x5o0aqw/lY7pyIaiiGKyIiopoqIwO4dKn85c5btgSaNmW5cyKi/8dwRUREVN0pyp0/H6Ju3mS5cyIiHWK4IiIiqk60LXfu5lZ8SB/LnRMRlYvBw9WyZcuwYMECJCYmwt/fH0uWLEGHDh3UbpuXl4eoqCisWbMG9+7dg6+vL7788kv06dOn3PskIiKqkrQtdy6TAc2asdw5EZEeGTRcxcTEIDw8HCtWrEBAQACio6MRFBSEuLg41KlTp9j2M2bMwLp16/DDDz/Az88Pf/75JwYNGoSjR4+idevW5donERGR0UtKKl6l79IlIDdX/fYsd05EZBASQVA32LpyBAQEoH379li6dCkAoKCgAB4eHhg/fjymTp1abHt3d3dMnz4dH3zwgXLdq6++CktLS6xbt65c+1QnPT0ddnZ2SEtLg62tbUVPk4iISDPqyp3/+684l5Q61tbFh/S1aAHY2VVuu4mIqjFtsoHBfoWVm5uL06dPY9q0acp1JiYmCAwMxLFjx9R+JicnBzKZTGWdpaUljhw5Uu59KvabU2Syw/T09HKdExERkUYqWu5csXh6stw5EZERMVi4SklJgVwuh4uLi8p6FxcXXLlyRe1ngoKCsGjRInTv3h0+Pj6IjY3F1q1bIf///4jKs08AiIqKQmRkZAXPiIiISI2MDLGgxPPD+koqd167dvEQ1awZYGVVqc0mIiLtVanB14sXL8Y777wDPz8/SCQS+Pj4YOTIkVi5cmWF9jtt2jSEh4crX6enp8PDw6OizSUiopqkpHLnN26o397MDGjSpHA4H8udExFVeQYLV05OTjA1NUVSUpLK+qSkJLi6uqr9jLOzM7Zv347s7Gw8evQI7u7umDp1Kry9vcu9TwCQSqWQsuQsERFpSl258wsXgKws9dsXLXeuWPz8AAuLym03ERHplcHClYWFBdq2bYvY2FgMHDgQgFh8IjY2FuPGjSv1szKZDHXr1kVeXh62bNmCoUOHVnifRERExeTlqZY7VwQqljsnIiI1DDosMDw8HKGhoWjXrh06dOiA6OhoZGZmYuTIkQCAESNGoG7duoiKigIAnDhxAvfu3UOrVq1w7949REREoKCgAJ988onG+yQiIirR3bvAsWPicvw4cOYMUKTgkQovL9UqfSx3TkRU4xn0f4CQkBA8fPgQs2bNQmJiIlq1aoXdu3crC1IkJCTApEgVpOzsbMyYMQM3b96EtbU1+vXrh7Vr18Le3l7jfRIREQEQy56fOVMYpI4dA+7dK75d0XLniqV5c5Y7JyKiYgw6z5Wx4jxXRETVjCAACQmqQersWXHYX1GmpoC/P9CxI9CpExAQAPj4sNw5EVENViXmuSIiItKbZ8+Af/5RDVOJicW3q1NHDFGdOomBql07oFatym8vERFVCwxXRERUtQkCEB+vGqTOnwfy81W3MzMDWrUqDFKdOonPTbHsORER6QjDFRERVS2ZmcCpU4VB6vhxIDm5+HZubqpBqm1bwNKy8ttLREQ1BsMVEREZL0EArl9XDVL//gvI5arbmZsDbdqohikPD/ZKERFRpWK4IiIi4/H0qdgrpQhSx48DKSnFt6tXTzVItW4tzjFFRERkQAxXRERkGAUFwLVrqvNKXbwori9KKhWH9CmCVMeOYrgiIiIyMgxXRERUOdLSgJMnVXulnjwpvp2nZ2GQ6tRJLI0ulVZ+e4mIiLTEcEVERLpXUABcuaJawe+//8RnqIqSycTy50XLobu5GabNREREFcRwRUREFffkCXDiRGGQOnFC7Kl6XoMGqkHK318sRkFERFQNMFwREZF25HKxF0oRpI4dE3upnmdlBbRvXxikOnYEXFwqv71ERESVhOGKiIhK9+hR4TNSx46Jz009fVp8u4YNVXulWrQQJ+4lIiKqIfi/HhERFcrPFyv2FZ1X6urV4ttZWwMdOqj2Sjk5VX57iYiIjAjDFRFRTfbwoWqQOnkSyMwsvp2vr+q8Us2aAaamld9eIiIiI8ZwRURUU+TlARcuqM4rdeNG8e1sbYGAgMIgFRAA1K5d+e0lIiKqYhiuiIiqq6Qk1SB16hTw7Fnx7Zo2VZ2gt0kT9koRERGVA8MVEVF1kJsLnD+vOq/UrVvFt7O3F3uiFIUnOnQQ1xEREVGFMVwREVVF9++rBqnTp4HsbNVtJBKgeXPVXilfX8DExDBtJiIiquYYroiIjF1ODnD2rGrhiYSE4tvVrq0apDp0EJ+fIiIiokqhdbjy8vLCqFGjEBYWhvr16+ujTURENdudO6oT9J45Iw77K8rERJxHqmgFv0aNxN4qIiIiMgitw9WkSZOwevVqzJkzB7169cLo0aMxaNAgSKVSfbSPiKh6y84Ww1PRwhP37hXfzslJdYLe9u3FuaaIiIjIaEgEQRDK88EzZ85g9erV2LhxI+RyOV5//XWMGjUKbdq00XUbK116ejrs7OyQlpYGWw6pISJdEQTg9m3V4X1nz4ol0osyNQX8/VV7pby92StFRERkANpkg3KHK4W8vDx8++23mDJlCvLy8tCiRQtMmDABI0eOhKSK/iDAcEVEOpGVJRaaKFp4IjGx+HYuLqpBqm1boFatym8vERERFaNNNih3QYu8vDxs27YNq1atwt69e9GxY0eMHj0ad+/exaeffop9+/Zhw4YN5d09EVHVIghAfLxqkDp/HsjPV93OzAxo3Vq18ISXF3uliIiIqgGtw9WZM2ewatUqbNy4ESYmJhgxYgS+/vpr+Pn5KbcZNGgQ2rdvr9OGEhEZlcxMcVLeokP8kpOLb+fmVvisVKdOQJs2gKVl5beXiIiI9E7rcNW+fXv07t0by5cvx8CBA2Fubl5smwYNGmDYsGE6aSARkcEJAnD9umqv1IULgFyuup2FhRieivZKeXiwV4qIiKiG0Dpc3bx5E56enqVuU6tWLaxatarcjSIiMqinT4GTJ1V7pR49Kr6dh4dqkGrdGpDJKr+9REREZBS0DlfJyclITExEQECAyvoTJ07A1NQU7dq101njiIj0rqAAuHpVNUhdvCiuL0oqFQtNFC08UbeuYdpMRERERknrcPXBBx/gk08+KRau7t27hy+//BInTpzQWeOIiHQuLU3slVLMK3XiBPDkSfHtPD1Vg1SrVuKwPyIiIqISaB2u/vvvP7VzWbVu3Rr//fefThpFRKQTBQXAlSuqE/T+95/4DFVRlpZAu3aqQ/zc3AzTZiIiIqqytA5XUqkUSUlJ8Pb2Vln/4MEDmJmVu7I7EVHFPXki9kQpgtSJE2JP1fO8vVV7pVq2BNQU5yEiIiLShtZp6KWXXsK0adPw66+/ws7ODgCQmpqKTz/9FL1799Z5A4mI1JLLxV6oohX8rlwpvp2VFdChg2qvVJ06ld9eIiIiqva0DlcLFy5E9+7d4enpidatWwMAzp07BxcXF6xdu1bnDSQiAiBW6zt+vDBInTwpVvV7XqNGhUGqUyegeXNx4l4iIiIiPdP6J466devi33//xfr163H+/HlYWlpi5MiRGD58uNo5r4iItJafL1bsUwSpY8eAa9eKb2dtLfZKKYJUQADg5FT57SUiIiJCOcIVIM5jNWbMGF23hYhqqocPVYf3nToFZGYW387XtzBIdewINGsGmJpWfnuJiIiI1Cj3WJn//vsPCQkJyM3NVVk/YMCACjeKiKqxvDzg339V55W6caP4dra2Yk+UIkgFBAC1a1d+e4mIiIg0pHW4unnzJgYNGoQLFy5AIpFA+P+SxhKJBAAgl8t120IiqtoSE1WD1KlTwLNnxbdr2lS1gl+TJoCJSeW3l4iIiKictA5XEydORIMGDRAbG4sGDRrg5MmTePToET766CMsXLhQH20koqro1i3gww+B7duLv2dvr1q9r0MHcR0RERFRFaZ1uDp27Bj++usvODk5wcTEBCYmJujatSuioqIwYcIEnD17Vh/tJKKqIjsbmD8fiIoSv5ZIxIp9RSv4NW7MXikiIqIaSBDE2VQUS36+6p9FvzY1BTw9Dd1i7WgdruRyOWxsbAAATk5OuH//Pnx9feHp6Ym4uDitG7Bs2TIsWLAAiYmJ8Pf3x5IlS9ChQ4cSt4+Ojsby5cuRkJAAJycnvPbaa4iKioJMJgMAREREIDIyUuUzvr6+uKJu/hsi0q3ffwcmTgRu3hRf9+oFLFkiFp4gqkSCABQUFC5yufqvNXktkYi/C9DVIpGICxFVH0UDQ2lhQRfrqvp+Cwo0v65NmohTWlYlWoer5s2b4/z582jQoAECAgIwf/58WFhY4Pvvv4e3t7dW+4qJiUF4eDhWrFiBgIAAREdHIygoCHFxcaijZpLPDRs2YOrUqVi5ciU6d+6Mq1evIiwsDBKJBIsWLVJu16xZM+zbt6/wJDnHDZF+3bgBTJokhisAcHcHFi0Chg6tsj9FavPDd3l/cK+M/dSUYz7/3v8/Dmy0dB3YuFTOoqvvW1X5Z1ERGIz1h3Rj2q82gYFKJpGIU1Oamop/WlkZukXa0zp1zJgxA5n/XyJ5zpw5ePnll9GtWzc4OjoiJiZGq30tWrQI77zzDkaOHAkAWLFiBf744w+sXLkSU6dOLbb90aNH0aVLF7z++usAAC8vLwwfPhwnTpxQPSkzM7i6ump7akSkpYKMLKRFRuPJN2vxOLcWnpgE4cnLb+HJi6/i8U0ZnkwB0tML/zOqSj+4U81hYiL+R170h1/Fa8UPwUXvDXWLtmGu6G+5qWaqrECouM/KEyr4b6FuKP5NUYSGol/rYl112m9V+cVDabQOV0FBQcqvGzZsiCtXruDx48dwcHBQVgzURG5uLk6fPo1p06Yp15mYmCAwMBDHjh1T+5nOnTtj3bp1OHnyJDp06ICbN29i586deOutt1S2u3btGtzd3SGTydCpUydERUWhfv36JbYlJycHOTk5ytfp6ekanwdRVScIQEYG8OQJ8Pix+GfZXwt4kpyH1AwZBHwK4FNxZwUAfvv/pYZQ9wO5Jq+NYVtjbFNlb6ur/8gFofhQxJq01ORzVyzaKu/njMXzgcHYfkg3pv1Wh8BAmtMqXOXl5cHS0hLnzp1D8+bNletrl2PumZSUFMjlcri4uKisd3FxKfH5qNdffx0pKSno2rUrBEFAfn4+3nvvPXz66afKbQICArB69Wr4+vriwYMHiIyMRLdu3XDx4kXls2LPi4qKKvacFlFV8+yZtgGpcMnP1/ZoEgAWyldW0nw4OJmidm0JHBwABwdxSioHB8DOTvwPpjoGAz47QwqKe8HExNAtIUPRNmBWViDVRwhiYCAqmVbhytzcHPXr14eh5rI6cOAA5s2bh2+//RYBAQG4fv06Jk6ciLlz52LmzJkAgL59+yq3b9myJQICAuDp6YlNmzZh9OjRavc7bdo0hIeHK1+np6fDw8NDvydDpEZurmroKS0QPf9ekc7XcrGwKAxERcOR8murHDgc/g21d62HQ34yHMwy4DB2GBwiJkJau5ZuLgARURUlkRQGDyKqubQeFjh9+nR8+umnWLt2bbl6rBScnJxgamqKpKQklfVJSUklPi81c+ZMvPXWW3j77bcBAC1atEBmZibGjBmD6dOnw0TNrwzt7e3RuHFjXL9+vcS2SKVSSKXScp8LUVFyOZCaql3vkeLr/3+csdxMTQsDkdqAVMrXlpYl/CZSEIAtW4DwcODOHXFdnz7A4tViSXUiIiIiAlCOcLV06VJcv34d7u7u8PT0RK1aqr+xPnPmjEb7sbCwQNu2bREbG4uBAwcCAAoKChAbG4tx48ap/UxWVlaxAGX6/78iEkp4mjgjIwM3btwo9lwWUWkEQSzEUJ6AlJZWsWNLJOJQuudDkCYBycZGx0M1rlwBxo8HFNU3PT2B6GjglVc4JoSIiIjoOVqHK0UQ0oXw8HCEhoaiXbt26NChA6Kjo5GZmamsHjhixAjUrVsXUVFRAIDg4GAsWrQIrVu3Vg4LnDlzJoKDg5Uha/LkyQgODoanpyfu37+P2bNnw9TUFMOHD9dZu6lqEAQgK6v8zyFV9EFja2vte48UzygZfFhJRgYwdy7w9ddAXh4glQKffAJMnVo166ISERERVQKtw9Xs2bN1dvCQkBA8fPgQs2bNQmJiIlq1aoXdu3cri1wkJCSo9FTNmDEDEokEM2bMwL179+Ds7Izg4GB8/vnnym3u3r2L4cOH49GjR3B2dkbXrl1x/PhxODs766zdVLlycsoXkB4/FnNBRchk5QtIDg6Aubluzr9SCQKwaRPw0UfAvXviuv79gcWLAR8fw7aNiIiIyMhJhJLG09Vg6enpsLOzQ1paGmxtbQ3dnGohP1+zQg3qijY8e1axY5uZaR6Inn9taamb868SLl0ShwDu3y++9vYWQ9XLLxu2XUREREQGpE020LrnysTEpNT5rAxVSZD0r6BAfJ6oPM8hPX1asWNLJOUv1FCrFh8PKlV6OhAZCXzzjZiCZTJg2jRxGKBMZujWEREREVUZWoerbdu2qbzOy8vD2bNnsWbNGs4VVQUUnTBW24CUmip+viJsbcsXkGxtOX+MzgkCsGED8PHHwIMH4rpXXhGfs2rQwLBtIyIiIqqCdDYscMOGDYiJicGvv/6qi90ZVFUYFli5E8aqsrLS7tkjxWt7e3GIHhmBCxeAceOAQ4fE1w0bij1XReaJIyIiIiI9DwssSceOHTFmzBhd7Y7+39SpwH//6WfC2PIWauCUYFVYWhowezawdKk4IZelJTBjhljAgt9YIiIiogrRSbh69uwZvvnmG9StW1cXu6Mi9u8HTp5U/15pE8aWFZZKnDCWqqeCAmDtWvE5quRkcd2rrwKLFgH16xu2bURERETVhNbhysHBQaWghSAIePr0KaysrLBu3TqdNo6AyZPFZ50qZcJYqp7OnQM++AA4elR87esrDgF86SWDNouIiIioutE6XH399dcq4crExATOzs4ICAiAg4ODThtHwJAhhm4BVVlPngAzZwLLl4s9V7Vqia8//FAcF0pEREREOqV1uAoLC9NDM4hIZwoKgNWrxQf2Hj4U1w0dCnz1FVCvnkGbRkRERFSdaV3cetWqVdi8eXOx9Zs3b8aaNWt00igiKqfTp4HOnYHRo8Vg1aQJsG8fEBPDYEVERESkZ1qHq6ioKDg5ORVbX6dOHcybN08njSIiLT16BLz3HtC+PXDiBGBtDSxcCJw/D7z4oqFbR0RERFQjaD0sMCEhAQ3UTDDq6emJhIQEnTSKiDQklwM//ghMmybW6AeA118HFiwA3N0N2zYiIiKiGkbrnqs6derg33//Lbb+/PnzcHR01EmjiEgDJ08CHTsC774rBqvmzYEDB4D16xmsiIiIiAxA63A1fPhwTJgwAfv374dcLodcLsdff/2FiRMnYtiwYfpoIxEV9fAh8M47YrD65x/A1haIjgbOnAF69DB064iIiIhqLK2HBc6dOxe3bt3Ciy++CDMz8eMFBQUYMWIEn7ki0ie5HPjuO2DGDLHMOgCMGAF8+SXg6mrYthERERERJIIgCOX54LVr13Du3DlYWlqiRYsW8PT01HXbDCY9PR12dnZIS0uDra2toZtDBBw7Jk4EfPas+NrfH1i2DOjSxbDtIiIiIqrmtMkGWvdcKTRq1AiNGjUq78eJSBPJycCUKeK8VQBgZwd89plYGdCs3H99iYiIiEgPtH7m6tVXX8WXX35ZbP38+fMxZMgQnTSKqMbLzweWLAEaNy4MVqNGAVevAuPGMVgRERERGSGtw9WhQ4fQr1+/Yuv79u2LQ4cO6aRRRDXakSNA27bAhAlAWhrQpo04LPDHH4E6dQzdOiIiIiIqgdbhKiMjAxYWFsXWm5ubIz09XSeNIqqRHjwA3noL6NYN+PdfwMEBWL68sOQ6ERERERk1rcNVixYtEBMTU2z9zz//jKZNm+qkUUQ1Sl4e8PXXgK8vsG4dIJGIpdavXhWfrTI1NXQLiYiIiEgDWj+4MXPmTAwePBg3btzACy+8AACIjY3Fhg0b8Msvv+i8gUTV2sGDYhXAS5fE1+3bi1UA27c3bLuIiIiISGtah6vg4GBs374d8+bNwy+//AJLS0v4+/vjr7/+Qu3atfXRRqLq5/59YPJkYONG8bWjI/DFF2LRChOtO5SJiIiIyAiUe54rhfT0dGzcuBE//vgjTp8+Dblcrqu2GQznuSK9yc0FFi8G5swBMjLEIYDvvSeWV+cvJ4iIiIiMjjbZoNy/Ij906BBCQ0Ph7u6Or776Ci+88AKOHz9e3t0RVX+xseLkv598Igarjh2Bf/4Bvv2WwYqIiIioGtBqWGBiYiJWr16NH3/8Eenp6Rg6dChycnKwfft2FrMgKsmdO8BHHwGbN4uvnZ2BL78EQkM5BJCIiIioGtH4J7vg4GD4+vri33//RXR0NO7fv48lS5bos21EVVtOjvgclZ+fGKxMTIDx48UqgCNHMlgRERERVTMa91zt2rULEyZMwNixY9GoUSN9tomo6vvzT3ES4KtXxddduwJLl4rDAomIiIioWtL4V+dHjhzB06dP0bZtWwQEBGDp0qVISUnRZ9uIqp7bt4HBg4E+fcRg5eIC/PQTcOgQgxURERFRNadxuOrYsSN++OEHPHjwAO+++y5+/vlnuLu7o6CgAHv37sXTp0/12U4i45adLVb8a9IE2LZNnPh30iQgLg546y2xKiARERERVWsVKsUeFxeHH3/8EWvXrkVqaip69+6N3377TZftMwiWYiet7NwpDgG8cUN83b27OASwRQvDtouIiIiIKqxSSrEDgK+vL+bPn4+7d+9io2IyVKKaIj4eeOUVoH9/MVi5uQEbNgAHDjBYEREREdVAFZ5EuDpizxWV6tkzYP58sRJgdjZgZiYOAZw1C7CxMXTriIiIiEiHtMkGWs1zRVSjCQKwY4cYpOLjxXUvvAAsWQJwnjciIiKiGo8T7RBp4vp14OWXxWGA8fFA3bpATAywbx+DFREREREBYLgiKl1WFjBzJtCsmVi4wtwcmDoVuHIFGDqUVQCJiIiISInDAonUEQRg+3bgww/FuasA4KWXgG++AXx9Ddo0IiIiIjJODFdEz7t6FRg/HtizR3xdvz7w9dfAoEHsqSIiIiKiEnFYIJFCZiYwbRrQvLkYrCwsgOnTgcuXgcGDGayIiIiIqFQGD1fLli2Dl5cXZDIZAgICcPLkyVK3j46Ohq+vLywtLeHh4YEPP/wQ2dnZFdon1XCCAGzeDPj5ieXV8/KAvn2BixeBzz4DrKwM3UIiIiIiqgIMGq5iYmIQHh6O2bNn48yZM/D390dQUBCSk5PVbr9hwwZMnToVs2fPxuXLl/Hjjz8iJiYGn376abn3STXc5ctA795icYq7dwEvL+DXX4E//gAaNTJ064iIiIioCjHoJMIBAQFo3749li5dCgAoKCiAh4cHxo8fj6lTpxbbfty4cbh8+TJiY2OV6z766COcOHECR44cKdc+ASAnJwc5OTnK1+np6fDw8OAkwtXZ06fAnDlAdDSQnw9IpWIVwClTAEtLQ7eOiIiIiIyENpMIG6znKjc3F6dPn0ZgYGBhY0xMEBgYiGPHjqn9TOfOnXH69GnlML+bN29i586d6NevX7n3CQBRUVGws7NTLh4eHro4RTJGggBs3CgOAVy4UAxWwcHAf/8BEREMVkRERERUbgYLVykpKZDL5XBxcVFZ7+LigsTERLWfef311zFnzhx07doV5ubm8PHxQc+ePZXDAsuzTwCYNm0a0tLSlMudO3cqeHZklC5eBF54AXj9deD+fcDbG/j9d+C338SviYiIiIgqwOAFLbRx4MABzJs3D99++y3OnDmDrVu34o8//sDcuXMrtF+pVApbW1uVhaqRtDQgPBxo1Qo4cACQycQhgZcuAf37G7p1RERERFRNGGyeKycnJ5iamiIpKUllfVJSElxdXdV+ZubMmXjrrbfw9ttvAwBatGiBzMxMjBkzBtOnTy/XPqkaEwRg/Xpg8mRAcU8MGgQsWiQWriAiIiIi0iGD9VxZWFigbdu2KsUpCgoKEBsbi06dOqn9TFZWFkxMVJtsamoKABAEoVz7pGrq/Hmge3fgrbfEYNWoEbB7N7B1K4MVEREREemFwXquACA8PByhoaFo164dOnTogOjoaGRmZmLkyJEAgBH/1969R1VRrn8A/24QNmyuXhDQEC8gIgEqqAf6eSD1BGokHk1UVEiMLmBy1ETzyvGYluYl9ZiVyrGLppUeV+YFL6ihJqkgKJESqSlImoIbEIX9/v7YuU9brhs2DBu/n7VmLWbmnZlnHt/l4uGdeWfiRHTs2BFLliwBAISEhGDFihXo3bs3+vfvj8uXL2PevHkICQnRFFm1nZNauLt3gfnzgXXrAJVK/Y2quXPVjwXK5VJHR0REREQtmKTFVVhYGH777TfMnz8f+fn56NWrF/bt26eZkOLq1ataI1Vz586FTCbD3Llzcf36ddjZ2SEkJASLFy+u8zmphVKpgC1b1FOpP/qm2ahRwHvvAZ06SRsbERERET0RJP3OVXOly1z21AycOwfExACPptvv0QNYswb405T8RERERET1oUttIOnIFVGD/P47MG8e8MEH6pErCwtgwQJg6lTA1FTq6IiIiKgJVVRU4OHDh1KHQQbIxMRE84pRQ7G4IsOjUgGbNgGzZwO3bqm3jRmj/ihwx47SxkZERERNSgiB/Px83L17V+pQyIDZ2trCwcEBMpmsQedhcUWG5Ycf1I8Anj6tXu/ZE1i7Fnj2WWnjIiIiIkk8Kqzat28PhULR4F+O6ckihEBJSQkK/nhn39HRsUHnY3FFhuH2beCtt4CPPlJ/v8rKCkhIAGJjARMTqaMjIiIiCVRUVGgKq7Zt20odDhkoc3NzAEBBQQHat2/foEcEWVxR81ZRoS6o5sxRv2MFAOPHA+++CzTwLwtERERk2B69Y6VQKCSOhAzdoz708OFDFlfUQn3/vfoRwDNn1OuenurvVw0YIG1cRERE1KzwUUBqKH31IaPamxA1sd9+A6KigL/8RV1YWVsDq1cDZ8+ysCIiIiKiZovFFTUfFRXqkanu3dWzAQJARATw00/AG28ArTjQSkRERFSVzp07Y9WqVXVun5ycDJlMxlkW9YzFFTUPJ04Avr7qCSru3gV69QJSUoDERMDeXuLgiIiIiPRDJpPVuCxcuLBe501NTUV0dHSd2/v7+yMvLw82Njb1uh5VjUMBJK2bN4H4eOA//1Gv29oCixcDr7wC6OljbkRERETNRV5enubnL774AvPnz0d2drZmm6WlpeZnIQQqKirQqg5P79jZ2ekUh6mpKRwcHHQ6hmrHkSuSRnm5+j2q7t3/V1hFRakfAXz9dRZWREREVD9CAMXFTb8IUafwHBwcNIuNjQ1kMplm/ccff4SVlRX27t0LHx8fyOVyfPfdd8jJycHw4cNhb28PS0tL9O3bFwcPHtQ67+OPBcpkMnz88ccYMWIEFAoFXF1dsXv3bs3+xx8LTExMhK2tLfbv3w93d3dYWloiODhYqxgsLy/HG2+8AVtbW7Rt2xbx8fGIiIhAaGhotfd7+/ZtjB07Fh07doRCoYCnpye2bt2q1UalUuHdd9+Fi4sL5HI5OnXqhMWLF2v2//rrrxg7dizatGkDCwsL+Pr64vvvv69TvpsaiytqeseOAX36AHFxQFER4OMDnDoFfPwxoONfXYiIiIi0lJQAlpZNv5SU6O0WZs2ahaVLlyIrKwteXl5QKpUYOnQoDh06hHPnziE4OBghISG4evVqjedJSEjA6NGjcf78eQwdOhTh4eH4/dGnbapMXQmWL1+OTz75BMeOHcPVq1cxY8YMzf533nkHn332GTZv3oyUlBQUFRVh165dNcZw//59+Pj4YM+ePcjMzER0dDQmTJiA06dPa9rMnj0bS5cuxbx583Dx4kV8/vnnsP/jtRClUomAgABcv34du3fvRnp6OmbOnAmVSlWHTEpAUCWFhYUCgCgsLJQ6lJblxg0hwsOFUP9tR4g2bYT44AMhysuljoyIiIgMUGlpqbh48aIoLS3930al8n+/azTlolTqHP/mzZuFjY2NZv3IkSMCgNi1a1etx3p4eIg1a9Zo1p2dncXKlSs16wDE3Llz/5QWpQAg9u7dq3WtO3fuaGIBIC5fvqw5Zt26dcLe3l6zbm9vL5YtW6ZZLy8vF506dRLDhw+v6y0LIYQYNmyYmD59uhBCiKKiIiGXy8VHH31UZdsNGzYIKysrcfv2bZ2uoasq+9IfdKkN+M4VNb6HD4E1a4CFC4F79wCZDIiOVr9bxa+pExERkT4pFIBSKc119cTX11drXalUYuHChdizZw/y8vJQXl6O0tLSWkeuvLy8ND9bWFjA2toaBQUF1bZXKBTo1q2bZt3R0VHTvrCwEDdv3kS/fv00+42NjeHj41PjKFJFRQXefvttbN++HdevX8eDBw9QVlam+WhvVlYWysrKMGjQoCqPT0tLQ+/evdGmTZsa77W5YHFFjevIEfUMgBcvqtf79VNPt/7YfxpEREREeiGTARYWUkfRIBaPxT9jxgwkJSVh+fLlcHFxgbm5OUaNGoUHDx7UeB4TExOtdZlMVmMhVFV7Ucd3yaqzbNkyrF69GqtWrYKnpycsLCwQFxenid3c3LzG42vb39zwnStqHNevA2PGAAMHqgurdu3U71SdPMnCioiIiEgHKSkpiIyMxIgRI+Dp6QkHBwf88ssvTRqDjY0N7O3tkZqaqtlWUVGBs2fP1nhcSkoKhg8fjvHjx8Pb2xtdu3bFTz/9pNnv6uoKc3NzHDp0qMrjvby8kJaWVuO7Ys0JiyvSrwcPgHffBdzcgC++AIyMgJgYIDtbPRugEbscERERkS5cXV3x9ddfIy0tDenp6Rg3bpwkEzpMmTIFS5YswX//+19kZ2dj6tSpuHPnDmQyWbXHuLq6IikpCSdOnEBWVhZeeeUV3Lx5U7PfzMwM8fHxmDlzJrZs2YKcnBycOnUKGzduBACMHTsWDg4OCA0NRUpKCn7++Wd89dVXOHnyZKPfb33wsUDSn4MHgSlTgB9/VK/7+wNr1wK9e0sbFxEREZEBW7FiBSZNmgR/f3+0a9cO8fHxKCoqavI44uPjkZ+fj4kTJ8LY2BjR0dEICgqCcQ2f0Jk7dy5+/vlnBAUFQaFQIDo6GqGhoSgsLNS0mTdvHlq1aoX58+fjxo0bcHR0xKuvvgpA/T2uAwcOYPr06Rg6dCjKy8vRs2dPrFu3rtHvtz5koqEPUrZARUVFsLGxQWFhIaytraUOp/m7ehWYNg346iv1evv26tGrCRM4UkVERESN5v79+8jNzUWXLl1gZmYmdThPHJVKBXd3d4wePRqLFi2SOpwGqakv6VIbcOSK6q+sDHjvPfWsfyUl6kIqNhZISABsbaWOjoiIiIj06MqVKzhw4AACAgJQVlaGtWvXIjc3F+PGjZM6tGaDxRXVz759wBtvAJcuqdcHDFA/AvinKT+JiIiIqOUwMjJCYmIiZsyYASEEnn76aRw8eBDu7u5Sh9ZssLgi3fzyC/CPfwCPvsbt4AAsXw6MG6ee+pSIiIiIWiQnJyekpKRIHUazxhdiqG7u3wcWLQLc3dWFlbGx+j2r7GwgPJyFFRERERE98ThyRbXbsweYOhXIyVGvBwaqHwH08JA0LCIiIiKi5oQjV1S9n38GQkKA559XF1YdOgBbtwKHD7OwIiIiIiJ6DIsrqqy0FFiwAOjZE/jmG6BVK+DNN9Xfrxozho8AEhERERFVgY8F0v8IAezeDcTFqSeuAIDBg4E1a4AePaSMjIiIiIio2ePIFaldugQMGwaEhqoLKycnYMcO4MABFlZERERERHXA4upJV1wMzJkDPP00sHcvYGICzJ4NZGUBo0bxEUAiIiKiZigwMBBxcXGa9c6dO2PVqlU1HiOTybDr0ed0GkBf52mJWFw9qYQAvvpKPbX6228DDx4AQUFAZqZ63cJC6giJiIiIWpyQkBAEBwdXue/48eOQyWQ4f/68zudNTU1FdHR0Q8PTsnDhQvTq1avS9ry8PAwZMkSv12opWFw9ibKz1YXUqFHAtWuAszOwc6d65Kp7d6mjIyIiImqxoqKikJSUhF9//bXSvs2bN8PX1xdeXl46n9fOzg4KhUIfIdbKwcEBcrm8Sa5laFhcPUmUSmDWLMDTE0hKAuRyYN484OJF9btWfASQiIiIDJwQ6rcemnoRom7xPf/887Czs0NiYqLWdqVSiR07diAqKgq3b9/G2LFj0bFjRygUCnh6emLr1q01nvfxxwIvXbqEv/71rzAzM0PPnj2RlJRU6Zj4+Hh0794dCoUCXbt2xbx58/Dw4UMAQGJiIhISEpCeng6ZTAaZTKaJ+fHHAjMyMjBw4ECYm5ujbdu2iI6OhlKp1OyPjIxEaGgoli9fDkdHR7Rt2xYxMTGaa1UlJycHw4cPh729PSwtLdG3b18cPHhQq01ZWRni4+Ph5OQEuVwOFxcXbNy4UbP/woULeP7552FtbQ0rKysMGDAAOY++29pIOFvgk0AI9eQU06YB16+rtw0bBqxeDXTrJm1sRERERHpUUgJYWjb9dZXKur1V0apVK0ycOBGJiYmYM2cOZH/8cXvHjh2oqKjA2LFjoVQq4ePjg/j4eFhbW2PPnj2YMGECunXrhn79+tV6DZVKhb///e+wt7fH999/j8LCQq33sx6xsrJCYmIiOnTogIyMDLz88suwsrLCzJkzERYWhszMTOzbt09T1NjY2FQ6R3FxMYKCguDn54fU1FQUFBRg8uTJiI2N1Sogjxw5AkdHRxw5cgSXL19GWFgYevXqhZdffrmafCoxdOhQLF68GHK5HFu2bEFISAiys7PRqVMnAMDEiRNx8uRJvP/++/D29kZubi5u3boFALh+/Tr++te/IjAwEIcPH4a1tTVSUlJQXl5ea/4aRFAlhYWFAoAoLCyUOpSGu3BBiIEDhVCXWEJ06SLE7t1SR0VERETUYKWlpeLixYuitLRUs02p/N+vPU25KJV1jzsrK0sAEEeOHNFsGzBggBg/fny1xwwbNkxMnz5dsx4QECCmTp2qWXd2dhYrV64UQgixf/9+0apVK3H9+nXN/r179woAYufOndVeY9myZcLHx0ezvmDBAuHt7V2p3Z/P8+GHH4rWrVsL5Z8SsGfPHmFkZCTy8/OFEEJEREQIZ2dnUV5ermnz4osvirCwsGpjqYqHh4dYs2aNEEKI7OxsAUAkJSVV2Xb27NmiS5cu4sGDB3U6d1V96RFdagOOXLVU9+4BCQnq0anycsDMTD0L4JtvAubmUkdHRERE1CgUCvUokhTXrasePXrA398fmzZtQmBgIC5fvozjx4/jn//8JwCgoqICb7/9NrZv347r16/jwYMHKCsrq/M7VVlZWXByckKHDh002/z8/Cq1++KLL/D+++8jJycHSqUS5eXlsLa2rvuN/HEtb29vWPxp2O6ZZ56BSqVCdnY27O3tAQAeHh4wNjbWtHF0dERGRka151UqlVi4cCH27NmDvLw8lJeXo7S0FFevXgUApKWlwdjYGAEBAVUen5aWhgEDBsDExESn+2koFlctjRDA1q3AjBlAXp562/DhwMqVQJcu0sZGRERE1MhkMsOY9DgqKgpTpkzBunXrsHnzZnTr1k1TKCxbtgyrV6/GqlWr4OnpCQsLC8TFxeHBgwd6u/7JkycRHh6OhIQEBAUFwcbGBtu2bcN7772nt2v82eNFjkwmg0qlqrb9jBkzkJSUhOXLl8PFxQXm5uYYNWqUJgfmtQwW1La/sXBCi5YkIwMIDATCw9WFlYsLsGcPsGsXCysiIiKiZmT06NEwMjLC559/ji1btmDSpEma969SUlIwfPhwjB8/Ht7e3ujatSt++umnOp/b3d0d165dQ96jP7QDOHXqlFabEydOwNnZGXPmzIGvry9cXV1x5coVrTampqaoqKio9Vrp6ekoLi7WbEtJSYGRkRHc3NzqHPPjUlJSEBkZiREjRsDT0xMODg745ZdfNPs9PT2hUqlw9OjRKo/38vLC8ePHa5w0ozE0i+Jq3bp16Ny5M8zMzNC/f3+cPn262raBgYGaGUv+vAwbNkzTJjIystL+6r4n0CIUFgJxcUDv3sCxY+rH/v71L3WxNXSo1NERERER0WMsLS0RFhaG2bNnIy8vD5GRkZp9rq6uSEpKwokTJ5CVlYVXXnkFN2/erPO5Bw8ejO7duyMiIgLp6ek4fvw45syZo9XG1dUVV69exbZt25CTk4P3338fO3fu1GrTuXNn5ObmIi0tDbdu3UJZWVmla4WHh8PMzAwRERHIzMzEkSNHMGXKFEyYMEHzSGB9uLq64uuvv0ZaWhrS09Mxbtw4rZGuzp07IyIiApMmTcKuXbuQm5uL5ORkbN++HQAQGxuLoqIijBkzBj/88AMuXbqETz75BNnZ2fWOqS4kL66++OILTJs2DQsWLMDZs2fh7e2NoKAgFBQUVNn+66+/Rl5enmbJzMyEsbExXnzxRa12wcHBWu1qm77SIAkBbNkCuLmp362qqABGjgSysoA5c9TvWRERERFRsxQVFYU7d+4gKChI6/2ouXPnok+fPggKCkJgYCAcHBwQGhpa5/MaGRlh586dKC0tRb9+/TB58mQsXrxYq80LL7yAf/zjH4iNjUWvXr1w4sQJzJs3T6vNyJEjERwcjGeffRZ2dnZV/j6tUCiwf/9+/P777+jbty9GjRqFQYMGYe3atbol4zErVqxA69at4e/vj5CQEAQFBaFPnz5abdavX49Ro0bh9ddfR48ePfDyyy9rRtDatm2Lw4cPQ6lUIiAgAD4+Pvjoo48a/R0smRB1nZW/cfTv3x99+/bV/AOoVCo4OTlhypQpmDVrVq3Hr1q1CvPnz0deXp7mRbrIyEjcvXtXa/59XRQVFcHGxgaFhYU6v9TXZNLTgZgYICVFvd69O7BmDfDcc9LGRURERNRE7t+/j9zcXHTp0gVm/KMyNUBNfUmX2kDSkasHDx7gzJkzGDx4sGabkZERBg8ejJMnT9bpHBs3bsSYMWO0ZigBgOTkZLRv3x5ubm547bXXcPv27WrPUVZWhqKiIq2l2bp7F5gyBejTR11YWVgAS5eqHwFkYUVEREREJBlJi6tbt26hoqKi0vOY9vb2yM/Pr/X406dPIzMzE5MnT9baHhwcjC1btuDQoUN45513cPToUQwZMqTaF/KWLFkCGxsbzeLk5FT/m2osKhWwaZN6hGrtWvX66NHAjz8C8fGAqanUERIRERERPdEMeir2jRs3wtPTs9KXqseMGaP52dPTE15eXujWrRuSk5MxaNCgSueZPXs2pk2bplkvKipqXgXWmTNAbCzwaJYXd3f1I4BV3AsREREREUlD0pGrdu3awdjYuNLsJzdv3oSDg0ONxxYXF2Pbtm2Iioqq9Tpdu3ZFu3btcPny5Sr3y+VyWFtbay3Nwv37wGuvAX37qgsrS0tg2TIgLY2FFRERERFRMyNpcWVqagofHx8cOnRIs02lUuHQoUNVfkX6z3bs2IGysjKMHz++1uv8+uuvuH37NhwdHRscc5OSy4HMTPWsgOPGAdnZ6o8D8xFAIiIiIg2J52ejFkBffUjyxwKnTZuGiIgI+Pr6ol+/fli1ahWKi4vx0ksvAQAmTpyIjh07YsmSJVrHbdy4EaGhoWjbtq3WdqVSiYSEBIwcORIODg7IycnBzJkz4eLigqCgoCa7L72QyYD164Hbt4E/vthNRERERGqPptUuKSmBubm5xNGQISspKQGABk/VLnlxFRYWht9++w3z589Hfn4+evXqhX379mkmubh69SqMjLQH2LKzs/Hdd9/hwIEDlc5nbGyM8+fP4z//+Q/u3r2LDh064LnnnsOiRYsgl8ub5J706umnpY6AiIiIqFkyNjaGra2t5vuoCoUCMplM4qjIkAghUFJSgoKCAtja2sLY2LhB55P8O1fNkUF854qIiIiIIIRAfn4+7t69K3UoZMBsbW3h4OBQZXGuS20g+cgVEREREVF9yWQyODo6on379nj48KHU4ZABMjExafCI1SMsroiIiIjI4BkbG+vtF2Si+pJ0tkAiIiIiIqKWgsUVERERERGRHrC4IiIiIiIi0gO+c1WFRxMoFhUVSRwJERERERFJ6VFNUJdJ1llcVeHevXsAACcnJ4kjISIiIiKi5uDevXuwsbGpsQ2/c1UFlUqFGzduwMrKSvIP0RUVFcHJyQnXrl3jN7caAfPbuJjfxsX8Nj7muHExv42L+W1czG/jak75FULg3r176NChA4yMan6riiNXVTAyMsJTTz0ldRharK2tJe9YLRnz27iY38bF/DY+5rhxMb+Ni/ltXMxv42ou+a1txOoRTmhBRERERESkByyuiIiIiIiI9IDFVTMnl8uxYMECyOVyqUNpkZjfxsX8Ni7mt/Exx42L+W1czG/jYn4bl6HmlxNaEBERERER6QFHroiIiIiIiPSAxRUREREREZEesLgiIiIiIiLSAxZXREREREREesDiSmLHjh1DSEgIOnToAJlMhl27dtV6THJyMvr06QO5XA4XFxckJiY2epyGStf8JicnQyaTVVry8/ObJmADsmTJEvTt2xdWVlZo3749QkNDkZ2dXetxO3bsQI8ePWBmZgZPT098++23TRCtYapPjhMTEyv1XzMzsyaK2LCsX78eXl5emg9U+vn5Ye/evTUew/5bd7rml323/pYuXQqZTIa4uLga27H/1k9d8sv+q5uFCxdWylePHj1qPMZQ+i+LK4kVFxfD29sb69atq1P73NxcDBs2DM8++yzS0tIQFxeHyZMnY//+/Y0cqWHSNb+PZGdnIy8vT7O0b9++kSI0XEePHkVMTAxOnTqFpKQkPHz4EM899xyKi4urPebEiRMYO3YsoqKicO7cOYSGhiI0NBSZmZlNGLnhqE+OAfXX7P/cf69cudJEERuWp556CkuXLsWZM2fwww8/YODAgRg+fDguXLhQZXv2X93oml+Afbc+UlNTsWHDBnh5edXYjv23fuqaX4D9V1ceHh5a+fruu++qbWtQ/VdQswFA7Ny5s8Y2M2fOFB4eHlrbwsLCRFBQUCNG1jLUJb9HjhwRAMSdO3eaJKaWpKCgQAAQR48erbbN6NGjxbBhw7S29e/fX7zyyiuNHV6LUJccb968WdjY2DRdUC1M69atxccff1zlPvbfhqspv+y7urt3755wdXUVSUlJIiAgQEydOrXatuy/utMlv+y/ulmwYIHw9vauc3tD6r8cuTIwJ0+exODBg7W2BQUF4eTJkxJF1DL16tULjo6O+Nvf/oaUlBSpwzEIhYWFAIA2bdpU24b9t2HqkmMAUCqVcHZ2hpOTU60jBaRWUVGBbdu2obi4GH5+flW2Yf+tv7rkF2Df1VVMTAyGDRtWqV9Whf1Xd7rkF2D/1dWlS5fQoUMHdO3aFeHh4bh69Wq1bQ2p/7aSOgDSTX5+Puzt7bW22dvbo6ioCKWlpTA3N5cospbB0dERH3zwAXx9fVFWVoaPP/4YgYGB+P7779GnTx+pw2u2VCoV4uLi8Mwzz+Dpp5+utl11/ZfvtNWurjl2c3PDpk2b4OXlhcLCQixfvhz+/v64cOECnnrqqSaM2DBkZGTAz88P9+/fh6WlJXbu3ImePXtW2Zb9V3e65Jd9Vzfbtm3D2bNnkZqaWqf27L+60TW/7L+66d+/PxITE+Hm5oa8vDwkJCRgwIAByMzMhJWVVaX2htR/WVwR/Ymbmxvc3Nw06/7+/sjJycHKlSvxySefSBhZ8xYTE4PMzMwan5emhqlrjv38/LRGBvz9/eHu7o4NGzZg0aJFjR2mwXFzc0NaWhoKCwvx5ZdfIiIiAkePHq22ACDd6JJf9t26u3btGqZOnYqkpCROmtAI6pNf9l/dDBkyRPOzl5cX+vfvD2dnZ2zfvh1RUVESRtZwLK4MjIODA27evKm17ebNm7C2tuaoVSPp168fi4YaxMbG4ptvvsGxY8dq/etcdf3XwcGhMUM0eLrk+HEmJibo3bs3Ll++3EjRGTZTU1O4uLgAAHx8fJCamorVq1djw4YNldqy/+pOl/w+jn23emfOnEFBQYHWExUVFRU4duwY1q5di7KyMhgbG2sdw/5bd/XJ7+PYf3Vja2uL7t27V5svQ+q/fOfKwPj5+eHQoUNa25KSkmp8hp0aJi0tDY6OjlKH0ewIIRAbG4udO3fi8OHD6NKlS63HsP/qpj45flxFRQUyMjLYh+tIpVKhrKysyn3svw1XU34fx75bvUGDBiEjIwNpaWmaxdfXF+Hh4UhLS6vyF3/237qrT34fx/6rG6VSiZycnGrzZVD9V+oZNZ509+7dE+fOnRPnzp0TAMSKFSvEuXPnxJUrV4QQQsyaNUtMmDBB0/7nn38WCoVCvPnmmyIrK0usW7dOGBsbi3379kl1C82arvlduXKl2LVrl7h06ZLIyMgQU6dOFUZGRuLgwYNS3UKz9dprrwkbGxuRnJws8vLyNEtJSYmmzYQJE8SsWbM06ykpKaJVq1Zi+fLlIisrSyxYsECYmJiIjIwMKW6h2atPjhMSEsT+/ftFTk6OOHPmjBgzZowwMzMTFy5ckOIWmrVZs2aJo0ePitzcXHH+/Hkxa9YsIZPJxIEDB4QQ7L8NpWt+2Xcb5vHZ7Nh/9au2/LL/6mb69OkiOTlZ5ObmipSUFDF48GDRrl07UVBQIIQw7P7L4kpij6b+fnyJiIgQQggREREhAgICKh3Tq1cvYWpqKrp27So2b97c5HEbCl3z+84774hu3boJMzMz0aZNGxEYGCgOHz4sTfDNXFV5BaDVHwMCAjS5fmT79u2ie/fuwtTUVHh4eIg9e/Y0beAGpD45jouLE506dRKmpqbC3t5eDB06VJw9e7bpgzcAkyZNEs7OzsLU1FTY2dmJQYMGaX7xF4L9t6F0zS/7bsM8/ss/+69+1ZZf9l/dhIWFCUdHR2Fqaio6duwowsLCxOXLlzX7Dbn/yoQQounGyYiIiIiIiFomvnNFRERERESkByyuiIiIiIiI9IDFFRERERERkR6wuCIiIiIiItIDFldERERERER6wOKKiIiIiIhID1hcERERERER6QGLKyIiIiIiIj1gcUVERNRAMpkMu3btkjoMIiKSGIsrIiIyaJGRkZDJZJWW4OBgqUMjIqInTCupAyAiImqo4OBgbN68WWubXC6XKBoiInpSceSKiIgMnlwuh4ODg9bSunVrAOpH9tavX48hQ4bA3NwcXbt2xZdffql1fEZGBgYOHAhzc3O0bdsW0dHRUCqVWm02bdoEDw8PyOVyODo6IjY2Vmv/rVu3MGLECCgUCri6umL37t2afXfu3EF4eDjs7Oxgbm4OV1fXSsUgEREZPhZXRETU4s2bNw8jR45Eeno6wsPDMWbMGGRlZQEAiouLERQUhNatWyM1NRU7duzAwYMHtYqn9evXIyYmBtHR0cjIyMDu3bvh4uKidY2EhASMHj0a58+fx9ChQxEeHo7ff/9dc/2LFy9i7969yMrKwvr169GuXbumSwARETUJmRBCSB0EERFRfUVGRuLTTz+FmZmZ1va33noLb731FmQyGV599VWsX79es+8vf/kL+vTpg3//+9/46KOPEB8fj2vXrsHCwgIA8O233yIkJAQ3btyAvb09OnbsiJdeegn/+te/qoxBJpNh7ty5WLRoEQB1wWZpaYm9e/ciODgYL7zwAtq1a4dNmzY1UhaIiKg54DtXRERk8J599lmt4gkA2rRpo/nZz89Pa5+fnx/S0tIAAFlZWfD29tYUVgDwzDPPQKVSITs7GzKZDDdu3MCgQYNqjMHLy0vzs4WFBaytrVFQUAAAeO211zBy5EicPXsWzz33HEJDQ+Hv71+veyUiouaLxRURERk8CwuLSo/p6Yu5uXmd2pmYmGity2QyqFQqAMCQIUNw5coVfPvtt0hKSsKgQYMQExOD5cuX6z1eIiKSDt+5IiKiFu/UqVOV1t3d3QEA7u7uSE9PR3FxsWZ/SkoKjIyM4ObmBisrK3Tu3BmHDh1qUAx2dnaIiIjAp59+ilWrVuHDDz9s0PmIiKj54cgVEREZvLKyMuTn52tta9WqlWbSiB07dsDX1xf/93//h88++wynT5/Gxo0bAQDh4eFYsGABIiIisHDhQvz222+YMmUKJkyYAHt7ewDAwoUL8eqrr6J9+/YYMmQI7t27h5SUFEyZMqVO8c2fPx8+Pj7w8PBAWVkZvvnmG01xR0RELQeLKyIiMnj79u2Do6Oj1jY3Nzf8+OOPANQz+W3btg2vv/46HB0dsXXrVvTs2RMAoFAosH//fkydOhV9+/aFQqHAyJEjsWLFCs25IiIicP/+faxcuRIzZsxAu3btMGrUqDrHZ2pqitmzZ+OXX36Bubk5BgwYgG3btunhzomIqDnhbIFERNSiyWQy7Ny5E6GhoVKHQkRELRzfuSIiIiIiItIDFldERERERER6wHeuiIioRePT70RE1FQ4ckVERERERKQHLK6IiIiIiIj0gMUVERERERGRHrC4IiIiIiIi0gMWV0RERERERHrA4oqIiIiIiEgPWFwRERERERHpAYsrIiIiIiIiPfh/PsYyS02mBEUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1000x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "history_dict = history.history\n",
     "print(history_dict.keys())\n",
@@ -747,16 +1094,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {
     "id": "ShcvqJAgVera"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:absl:Found untraced functions such as restored_function_body, restored_function_body, restored_function_body, restored_function_body, restored_function_body while saving (showing 5 of 124). These functions will not be directly callable after loading.\n"
+     ]
+    }
+   ],
    "source": [
     "dataset_name = \"imdb\"\n",
     "saved_model_path = \"./{}_bert\".format(dataset_name.replace(\"/\", \"_\"))\n",
+    "TIMESTAMP = datetime.datetime.now().strftime(\"%Y%m%d%H%M%S\")\n",
     "\n",
-    "classifier_model.save(saved_model_path, include_optimizer=False)"
+    "EXPORT_PATH = os.path.join(saved_model_path, TIMESTAMP)\n",
+    "\n",
+    "classifier_model.save(EXPORT_PATH, include_optimizer=False)"
    ]
   },
   {
@@ -770,13 +1128,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {
     "id": "gUEWVskZjEF0"
    },
    "outputs": [],
    "source": [
-    "reloaded_model = tf.saved_model.load(saved_model_path)"
+    "reloaded_model = tf.saved_model.load(EXPORT_PATH)"
    ]
   },
   {
@@ -790,11 +1148,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {
     "id": "VBWzH6exlCPS"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Results from the saved model:\n",
+      "input: this is such an amazing movie! : score: 0.999055\n",
+      "input: The movie was great!           : score: 0.994220\n",
+      "input: The movie was meh.             : score: 0.921660\n",
+      "input: The movie was okish.           : score: 0.013223\n",
+      "input: The movie was terrible...      : score: 0.001282\n",
+      "\n",
+      "Results from the model in memory:\n",
+      "input: this is such an amazing movie! : score: 0.999055\n",
+      "input: The movie was great!           : score: 0.994220\n",
+      "input: The movie was meh.             : score: 0.921660\n",
+      "input: The movie was okish.           : score: 0.013223\n",
+      "input: The movie was terrible...      : score: 0.001282\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "def print_my_examples(inputs, results):\n",
     "    result_for_printing = [\n",
@@ -813,13 +1192,20 @@
     "    \"The movie was terrible...\",\n",
     "]\n",
     "\n",
-    "reloaded_results = tf.sigmoid(reloaded_model(tf.constant(examples)))\n",
-    "original_results = tf.sigmoid(classifier_model(tf.constant(examples)))\n",
+    "reloaded_results = reloaded_model(tf.constant(examples))\n",
+    "original_results = classifier_model(tf.constant(examples))\n",
     "\n",
     "print(\"Results from the saved model:\")\n",
     "print_my_examples(examples, reloaded_results)\n",
     "print(\"Results from the model in memory:\")\n",
     "print_my_examples(examples, original_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (Optional) Deploy your model on Vertex AI to get online predictions"
    ]
   },
   {
@@ -833,17 +1219,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {
     "id": "0FdVD3973S-O"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "input: this is such an amazing movie! : score: 0.999055\n",
+      "input: The movie was great!           : score: 0.994220\n",
+      "input: The movie was meh.             : score: 0.921660\n",
+      "input: The movie was okish.           : score: 0.013223\n",
+      "input: The movie was terrible...      : score: 0.001282\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "serving_results = reloaded_model.signatures[\"serving_default\"](\n",
     "    tf.constant(examples)\n",
     ")\n",
     "\n",
-    "serving_results = tf.sigmoid(serving_results[\"classifier\"])\n",
+    "serving_results = serving_results[\"classifier\"]\n",
     "\n",
     "print_my_examples(examples, serving_results)"
    ]
@@ -852,7 +1251,439 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Continued Learning\n",
+    "We'll export the model to a TensorFlow SavedModel format. Once we have a model in this format, we have lots of ways to \"serve\" the model, from a web application, from JavaScript, from mobile applications, etc.\n",
+    "\n",
+    "Next, print the signature of your saved model using the SavedModel Command Line Interface command saved_model_cli. You can read more about the command line interface and the show and run commands it supports in the [documentation here](https://www.tensorflow.org/guide/saved_model#overview_of_commands)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The given SavedModel SignatureDef contains the following input(s):\n",
+      "  inputs['text'] tensor_info:\n",
+      "      dtype: DT_STRING\n",
+      "      shape: (-1)\n",
+      "      name: serving_default_text:0\n",
+      "The given SavedModel SignatureDef contains the following output(s):\n",
+      "  outputs['classifier'] tensor_info:\n",
+      "      dtype: DT_FLOAT\n",
+      "      shape: (-1, 1)\n",
+      "      name: StatefulPartitionedCall_2:0\n",
+      "Method name is: tensorflow/serving/predict\n",
+      "./imdb_bert/20230407154959\n",
+      "./imdb_bert/20230407154959/variables\n",
+      "./imdb_bert/20230407154959/variables/variables.index\n",
+      "./imdb_bert/20230407154959/variables/variables.data-00000-of-00001\n",
+      "./imdb_bert/20230407154959/assets\n",
+      "./imdb_bert/20230407154959/assets/vocab.txt\n",
+      "./imdb_bert/20230407154959/saved_model.pb\n",
+      "./imdb_bert/20230407154959/keras_metadata.pb\n"
+     ]
+    }
+   ],
+   "source": [
+    "!saved_model_cli show \\\n",
+    "    --tag_set serve \\\n",
+    "    --signature_def serving_default \\\n",
+    "    --dir {EXPORT_PATH}\n",
+    "\n",
+    "!find {EXPORT_PATH}\n",
+    "os.environ['EXPORT_PATH'] = EXPORT_PATH"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MODEL_DISPLAYNAME: classification-bert-20230407163903\n"
+     ]
+    }
+   ],
+   "source": [
+    "TIMESTAMP = datetime.datetime.now().strftime(\"%Y%m%d%H%M%S\")\n",
+    "PROJECT = !gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "PROJECT = PROJECT[0]\n",
+    "BUCKET = PROJECT\n",
+    "REGION = \"us-central1\"\n",
+    "MODEL_DISPLAYNAME = f\"classification-bert-{TIMESTAMP}\"\n",
+    "\n",
+    "print(f\"MODEL_DISPLAYNAME: {MODEL_DISPLAYNAME}\")\n",
+    "\n",
+    "# from https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers\n",
+    "SERVING_CONTAINER_IMAGE_URI = (\n",
+    "    \"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-8:latest\"\n",
+    ")\n",
+    "\n",
+    "os.environ[\"BUCKET\"] = BUCKET\n",
+    "os.environ[\"REGION\"] = REGION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bucket exists, let's not recreate it.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "# Create GCS bucket if it doesn't exist already...\n",
+    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "\n",
+    "if [ -n \"$exists\" ]; then\n",
+    "    echo -e \"Bucket exists, let's not recreate it.\"\n",
+    "else\n",
+    "    echo \"Creating a new GCS bucket.\"\n",
+    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    echo \"\\nHere are your current buckets:\"\n",
+    "    gsutil ls\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Copying file://./imdb_bert/20230407154959/saved_model.pb [Content-Type=application/octet-stream]...\n",
+      "Copying file://./imdb_bert/20230407154959/keras_metadata.pb [Content-Type=application/octet-stream]...\n",
+      "Copying file://./imdb_bert/20230407154959/variables/variables.index [Content-Type=application/octet-stream]...\n",
+      "Copying file://./imdb_bert/20230407154959/variables/variables.data-00000-of-00001 [Content-Type=application/octet-stream]...\n",
+      "| [4 files][117.6 MiB/117.6 MiB]                                                \n",
+      "==> NOTE: You are performing a sequence of gsutil operations that may\n",
+      "run significantly faster if you instead use gsutil -m cp ... Please\n",
+      "see the -m section under \"gsutil help options\" for further information\n",
+      "about when gsutil -m can be advantageous.\n",
+      "\n",
+      "Copying file://./imdb_bert/20230407154959/assets/vocab.txt [Content-Type=text/plain]...\n",
+      "/ [5 files][117.8 MiB/117.8 MiB]                                                \n",
+      "Operation completed over 5 objects/117.8 MiB.                                    \n"
+     ]
+    }
+   ],
+   "source": [
+    "!gsutil cp -r $EXPORT_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating Model\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Creating Model\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Create Model backing LRO: projects/550642080325/locations/us-central1/models/241798000110731264/operations/4462402919542554624\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Create Model backing LRO: projects/550642080325/locations/us-central1/models/241798000110731264/operations/4462402919542554624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model created. Resource name: projects/550642080325/locations/us-central1/models/241798000110731264@1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Model created. Resource name: projects/550642080325/locations/us-central1/models/241798000110731264@1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "To use this Model in another session:\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:To use this Model in another session:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "model = aiplatform.Model('projects/550642080325/locations/us-central1/models/241798000110731264@1')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:model = aiplatform.Model('projects/550642080325/locations/us-central1/models/241798000110731264@1')\n"
+     ]
+    }
+   ],
+   "source": [
+    "uploaded_model = aiplatform.Model.upload(\n",
+    "    display_name=MODEL_DISPLAYNAME,\n",
+    "    artifact_uri=f\"gs://{BUCKET}/{MODEL_DISPLAYNAME}\",\n",
+    "    serving_container_image_uri=SERVING_CONTAINER_IMAGE_URI,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating Endpoint\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Creating Endpoint\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Create Endpoint backing LRO: projects/550642080325/locations/us-central1/endpoints/8775206699326767104/operations/769099381377859584\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Create Endpoint backing LRO: projects/550642080325/locations/us-central1/endpoints/8775206699326767104/operations/769099381377859584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Endpoint created. Resource name: projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Endpoint created. Resource name: projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "To use this Endpoint in another session:\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:To use this Endpoint in another session:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "endpoint = aiplatform.Endpoint('projects/550642080325/locations/us-central1/endpoints/8775206699326767104')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:endpoint = aiplatform.Endpoint('projects/550642080325/locations/us-central1/endpoints/8775206699326767104')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploying model to Endpoint : projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Deploying model to Endpoint : projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploy Endpoint model backing LRO: projects/550642080325/locations/us-central1/endpoints/8775206699326767104/operations/2185481464185880576\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Deploy Endpoint model backing LRO: projects/550642080325/locations/us-central1/endpoints/8775206699326767104/operations/2185481464185880576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Endpoint model deployed. Resource name: projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.models:Endpoint model deployed. Resource name: projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
+     ]
+    }
+   ],
+   "source": [
+    "MACHINE_TYPE = \"n1-standard-4\"\n",
+    "\n",
+    "endpoint = uploaded_model.deploy(\n",
+    "    machine_type=MACHINE_TYPE,\n",
+    "    accelerator_type=None,\n",
+    "    accelerator_count=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the model has been uploaded to the endpoint, you can query the endpoint to get predictions from the model. The query has to be a list of instances. From the signature of the model we see that the key for the query has to be `text`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instances = [\n",
+    "    {\"text\": [\"I loved the movie and highly recomment it\"]},\n",
+    "    {\"text\": [\"It was an okay movie in my opinion\"]},\n",
+    "    {\"text\": [\"I hated the movie\"]},\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = endpoint.predict(instances=instances)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " prediction: [[0.998149872], [0.83823961], [0.00687500834]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\" prediction:\", response.predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Cleanup\n",
+    "When deploying a model to an endpoint for online prediction, the minimum min-replica-count is 1, and it is charged per node hour. So let's delete the endpoint to reduce unnecessary charges. Before we can delete the endpoint, we first undeploy all attached models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint.undeploy_all()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "...then delete the endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint.delete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Continued Learning\n",
     "\n",
     "In this lab, we chose small BERT to train our text classifier. There are other pre-trained BERT models which you can find here. Consider experiementing with some of these. However, remember that the bigger the model you choose to fine-tune, the longer it will take to train.\n",
     "\n",

--- a/notebooks/text_models/solutions/classify_text_with_bert.ipynb
+++ b/notebooks/text_models/solutions/classify_text_with_bert.ipynb
@@ -56,189 +56,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "./kernels/bert_kernel.sh\n",
-      "creating bert_kernel at /home/jupyter/asl-ml-immersion/notebooks/text_models\n",
-      "Requirement already satisfied: pip in ./bert_kernel/lib/python3.7/site-packages (23.0.1)\n",
-      "Requirement already satisfied: ipykernel in ./bert_kernel/lib/python3.7/site-packages (6.16.2)\n",
-      "Requirement already satisfied: debugpy>=1.0 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (1.6.7)\n",
-      "Requirement already satisfied: matplotlib-inline>=0.1 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (0.1.6)\n",
-      "Requirement already satisfied: nest-asyncio in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (1.5.6)\n",
-      "Requirement already satisfied: packaging in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (23.0)\n",
-      "Requirement already satisfied: pyzmq>=17 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (25.0.2)\n",
-      "Requirement already satisfied: tornado>=6.1 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (6.2)\n",
-      "Requirement already satisfied: ipython>=7.23.1 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (7.34.0)\n",
-      "Requirement already satisfied: jupyter-client>=6.1.12 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (7.4.9)\n",
-      "Requirement already satisfied: psutil in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (5.9.4)\n",
-      "Requirement already satisfied: traitlets>=5.1.0 in ./bert_kernel/lib/python3.7/site-packages (from ipykernel) (5.9.0)\n",
-      "Requirement already satisfied: setuptools>=18.5 in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (47.1.0)\n",
-      "Requirement already satisfied: pexpect>4.3 in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (4.8.0)\n",
-      "Requirement already satisfied: decorator in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (5.1.1)\n",
-      "Requirement already satisfied: pickleshare in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (0.7.5)\n",
-      "Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (3.0.38)\n",
-      "Requirement already satisfied: backcall in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (0.2.0)\n",
-      "Requirement already satisfied: pygments in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (2.14.0)\n",
-      "Requirement already satisfied: jedi>=0.16 in ./bert_kernel/lib/python3.7/site-packages (from ipython>=7.23.1->ipykernel) (0.18.2)\n",
-      "Requirement already satisfied: jupyter-core>=4.9.2 in ./bert_kernel/lib/python3.7/site-packages (from jupyter-client>=6.1.12->ipykernel) (4.12.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in ./bert_kernel/lib/python3.7/site-packages (from jupyter-client>=6.1.12->ipykernel) (2.8.2)\n",
-      "Requirement already satisfied: entrypoints in ./bert_kernel/lib/python3.7/site-packages (from jupyter-client>=6.1.12->ipykernel) (0.4)\n",
-      "Requirement already satisfied: parso<0.9.0,>=0.8.0 in ./bert_kernel/lib/python3.7/site-packages (from jedi>=0.16->ipython>=7.23.1->ipykernel) (0.8.3)\n",
-      "Requirement already satisfied: ptyprocess>=0.5 in ./bert_kernel/lib/python3.7/site-packages (from pexpect>4.3->ipython>=7.23.1->ipykernel) (0.7.0)\n",
-      "Requirement already satisfied: wcwidth in ./bert_kernel/lib/python3.7/site-packages (from prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0->ipython>=7.23.1->ipykernel) (0.2.6)\n",
-      "Requirement already satisfied: six>=1.5 in ./bert_kernel/lib/python3.7/site-packages (from python-dateutil>=2.8.2->jupyter-client>=6.1.12->ipykernel) (1.16.0)\n",
-      "Installed kernelspec bert_kernel in /home/jupyter/.local/share/jupyter/kernels/bert_kernel\n",
-      "Collecting google-cloud-aiplatform==1.19.0\n",
-      "  Using cached google_cloud_aiplatform-1.19.0-py2.py3-none-any.whl (2.3 MB)\n",
-      "Requirement already satisfied: tensorflow==2.8.4 in ./bert_kernel/lib/python3.7/site-packages (from -r requirements.txt (line 2)) (2.8.4)\n",
-      "Requirement already satisfied: tensorflow_text==2.8.2 in ./bert_kernel/lib/python3.7/site-packages (from -r requirements.txt (line 3)) (2.8.2)\n",
-      "Requirement already satisfied: tf-models-official==2.8.0 in ./bert_kernel/lib/python3.7/site-packages (from -r requirements.txt (line 4)) (2.8.0)\n",
-      "Collecting google-cloud-resource-manager<3.0.0dev,>=1.3.3\n",
-      "  Downloading google_cloud_resource_manager-1.9.1-py2.py3-none-any.whl (276 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m276.8/276.8 kB\u001b[0m \u001b[31m10.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hCollecting google-cloud-storage<3.0.0dev,>=1.32.0\n",
-      "  Downloading google_cloud_storage-2.8.0-py2.py3-none-any.whl (113 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m113.6/113.6 kB\u001b[0m \u001b[31m20.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hCollecting google-cloud-bigquery<3.0.0dev,>=1.15.0\n",
-      "  Using cached google_cloud_bigquery-2.34.4-py2.py3-none-any.whl (206 kB)\n",
-      "Requirement already satisfied: protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5 in ./bert_kernel/lib/python3.7/site-packages (from google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (3.19.6)\n",
-      "Collecting proto-plus<2.0.0dev,>=1.22.0\n",
-      "  Downloading proto_plus-1.22.2-py3-none-any.whl (47 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m47.9/47.9 kB\u001b[0m \u001b[31m10.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hCollecting packaging<22.0.0dev,>=14.3\n",
-      "  Using cached packaging-21.3-py3-none-any.whl (40 kB)\n",
-      "Requirement already satisfied: google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0 in ./bert_kernel/lib/python3.7/site-packages (from google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (2.11.0)\n",
-      "Requirement already satisfied: astunparse>=1.6.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.6.3)\n",
-      "Requirement already satisfied: google-pasta>=0.1.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (0.2.0)\n",
-      "Requirement already satisfied: wrapt>=1.11.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.15.0)\n",
-      "Requirement already satisfied: opt-einsum>=2.3.2 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (3.3.0)\n",
-      "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.23.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (0.32.0)\n",
-      "Requirement already satisfied: tensorflow-estimator<2.9,>=2.8 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (2.8.0)\n",
-      "Requirement already satisfied: numpy>=1.20 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.21.6)\n",
-      "Requirement already satisfied: h5py>=2.9.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (3.8.0)\n",
-      "Requirement already satisfied: typing-extensions>=3.6.6 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (4.5.0)\n",
-      "Requirement already satisfied: absl-py>=0.4.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.4.0)\n",
-      "Requirement already satisfied: flatbuffers>=1.12 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (23.3.3)\n",
-      "Requirement already satisfied: tensorboard<2.9,>=2.8 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (2.8.0)\n",
-      "Requirement already satisfied: keras<2.9,>=2.8.0rc0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (2.8.0)\n",
-      "Requirement already satisfied: grpcio<2.0,>=1.24.3 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.53.0)\n",
-      "Requirement already satisfied: gast>=0.2.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (0.5.3)\n",
-      "Requirement already satisfied: termcolor>=1.1.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (2.2.0)\n",
-      "Requirement already satisfied: six>=1.12.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.16.0)\n",
-      "Requirement already satisfied: setuptools in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (47.1.0)\n",
-      "Requirement already satisfied: libclang>=9.0.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (16.0.0)\n",
-      "Requirement already satisfied: keras-preprocessing>=1.1.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow==2.8.4->-r requirements.txt (line 2)) (1.1.2)\n",
-      "Requirement already satisfied: tensorflow-hub>=0.8.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow_text==2.8.2->-r requirements.txt (line 3)) (0.13.0)\n",
-      "Requirement already satisfied: scipy>=0.19.1 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.7.3)\n",
-      "Requirement already satisfied: Pillow in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (9.5.0)\n",
-      "Requirement already satisfied: sentencepiece in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.1.97)\n",
-      "Requirement already satisfied: tensorflow-addons in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.19.0)\n",
-      "Requirement already satisfied: google-api-python-client>=1.6.7 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.84.0)\n",
-      "Requirement already satisfied: oauth2client in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.1.3)\n",
-      "Requirement already satisfied: kaggle>=1.3.9 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.5.13)\n",
-      "Requirement already satisfied: tf-slim>=1.1.0 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.1.0)\n",
-      "Requirement already satisfied: gin-config in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.5.0)\n",
-      "Requirement already satisfied: psutil>=5.4.3 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (5.9.4)\n",
-      "Requirement already satisfied: matplotlib in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (3.5.3)\n",
-      "Requirement already satisfied: sacrebleu in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.3.1)\n",
-      "Requirement already satisfied: pandas>=0.22.0 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.3.5)\n",
-      "Requirement already satisfied: tensorflow-model-optimization>=0.4.1 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.7.3)\n",
-      "Requirement already satisfied: opencv-python-headless in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.7.0.72)\n",
-      "Requirement already satisfied: pyyaml<6.0,>=5.1 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (5.4.1)\n",
-      "Requirement already satisfied: pycocotools in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.0.6)\n",
-      "Requirement already satisfied: seqeval in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.2.2)\n",
-      "Requirement already satisfied: tensorflow-datasets in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.8.2)\n",
-      "Requirement already satisfied: py-cpuinfo>=3.3.0 in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (9.0.0)\n",
-      "Requirement already satisfied: Cython in ./bert_kernel/lib/python3.7/site-packages (from tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.29.34)\n",
-      "Requirement already satisfied: wheel<1.0,>=0.23.0 in ./bert_kernel/lib/python3.7/site-packages (from astunparse>=1.6.0->tensorflow==2.8.4->-r requirements.txt (line 2)) (0.40.0)\n",
-      "Requirement already satisfied: googleapis-common-protos<2.0dev,>=1.56.2 in ./bert_kernel/lib/python3.7/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (1.59.0)\n",
-      "Requirement already satisfied: requests<3.0.0dev,>=2.18.0 in ./bert_kernel/lib/python3.7/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (2.28.2)\n",
-      "Requirement already satisfied: google-auth<3.0dev,>=2.14.1 in ./bert_kernel/lib/python3.7/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (2.17.2)\n",
-      "Collecting grpcio-status<2.0dev,>=1.33.2\n",
-      "  Downloading grpcio_status-1.53.0-py3-none-any.whl (5.1 kB)\n",
-      "Requirement already satisfied: uritemplate<5,>=3.0.1 in ./bert_kernel/lib/python3.7/site-packages (from google-api-python-client>=1.6.7->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.1.1)\n",
-      "Requirement already satisfied: google-auth-httplib2>=0.1.0 in ./bert_kernel/lib/python3.7/site-packages (from google-api-python-client>=1.6.7->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.1.0)\n",
-      "Requirement already satisfied: httplib2<1dev,>=0.15.0 in ./bert_kernel/lib/python3.7/site-packages (from google-api-python-client>=1.6.7->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.22.0)\n",
-      "Collecting google-cloud-core<3.0.0dev,>=1.4.1\n",
-      "  Downloading google_cloud_core-2.3.2-py2.py3-none-any.whl (29 kB)\n",
-      "Collecting google-resumable-media<3.0dev,>=0.6.0\n",
-      "  Downloading google_resumable_media-2.4.1-py2.py3-none-any.whl (77 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m77.7/77.7 kB\u001b[0m \u001b[31m15.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: python-dateutil<3.0dev,>=2.7.2 in ./bert_kernel/lib/python3.7/site-packages (from google-cloud-bigquery<3.0.0dev,>=1.15.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (2.8.2)\n",
-      "Collecting grpc-google-iam-v1<1.0.0dev,>=0.12.4\n",
-      "  Downloading grpc_google_iam_v1-0.12.6-py2.py3-none-any.whl (26 kB)\n",
-      "Requirement already satisfied: certifi in ./bert_kernel/lib/python3.7/site-packages (from kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2022.12.7)\n",
-      "Requirement already satisfied: tqdm in ./bert_kernel/lib/python3.7/site-packages (from kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.65.0)\n",
-      "Requirement already satisfied: python-slugify in ./bert_kernel/lib/python3.7/site-packages (from kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (8.0.1)\n",
-      "Requirement already satisfied: urllib3 in ./bert_kernel/lib/python3.7/site-packages (from kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.26.15)\n",
-      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in ./bert_kernel/lib/python3.7/site-packages (from packaging<22.0.0dev,>=14.3->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (3.0.9)\n",
-      "Requirement already satisfied: pytz>=2017.3 in ./bert_kernel/lib/python3.7/site-packages (from pandas>=0.22.0->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2023.3)\n",
-      "Requirement already satisfied: werkzeug>=0.11.15 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (2.2.3)\n",
-      "Requirement already satisfied: markdown>=2.6.8 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (3.4.3)\n",
-      "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (0.6.1)\n",
-      "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (0.4.6)\n",
-      "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (1.8.1)\n",
-      "Requirement already satisfied: dm-tree~=0.1.1 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-model-optimization>=0.4.1->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.1.8)\n",
-      "Requirement already satisfied: cycler>=0.10 in ./bert_kernel/lib/python3.7/site-packages (from matplotlib->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.11.0)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in ./bert_kernel/lib/python3.7/site-packages (from matplotlib->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.38.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in ./bert_kernel/lib/python3.7/site-packages (from matplotlib->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.4.4)\n",
-      "Requirement already satisfied: rsa>=3.1.4 in ./bert_kernel/lib/python3.7/site-packages (from oauth2client->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.9)\n",
-      "Requirement already satisfied: pyasn1>=0.1.7 in ./bert_kernel/lib/python3.7/site-packages (from oauth2client->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.4.8)\n",
-      "Requirement already satisfied: pyasn1-modules>=0.0.5 in ./bert_kernel/lib/python3.7/site-packages (from oauth2client->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.2.8)\n",
-      "Requirement already satisfied: portalocker in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.7.0)\n",
-      "Requirement already satisfied: colorama in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.4.6)\n",
-      "Requirement already satisfied: tabulate>=0.8.9 in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.9.0)\n",
-      "Requirement already satisfied: regex in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2022.10.31)\n",
-      "Requirement already satisfied: lxml in ./bert_kernel/lib/python3.7/site-packages (from sacrebleu->tf-models-official==2.8.0->-r requirements.txt (line 4)) (4.9.2)\n",
-      "Requirement already satisfied: scikit-learn>=0.21.3 in ./bert_kernel/lib/python3.7/site-packages (from seqeval->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.0.2)\n",
-      "Requirement already satisfied: typeguard>=2.7 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-addons->tf-models-official==2.8.0->-r requirements.txt (line 4)) (3.0.2)\n",
-      "Requirement already satisfied: tensorflow-metadata in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.12.0)\n",
-      "Requirement already satisfied: click in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (8.1.3)\n",
-      "Requirement already satisfied: toml in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.10.2)\n",
-      "Requirement already satisfied: promise in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (2.3)\n",
-      "Requirement already satisfied: importlib-resources in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (5.12.0)\n",
-      "Requirement already satisfied: etils[enp,epath]>=0.9.0 in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.9.0)\n",
-      "Requirement already satisfied: dill in ./bert_kernel/lib/python3.7/site-packages (from tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (0.3.6)\n",
-      "Requirement already satisfied: zipp in ./bert_kernel/lib/python3.7/site-packages (from etils[enp,epath]>=0.9.0->tensorflow-datasets->tf-models-official==2.8.0->-r requirements.txt (line 4)) (3.15.0)\n",
-      "Requirement already satisfied: cachetools<6.0,>=2.0.0 in ./bert_kernel/lib/python3.7/site-packages (from google-auth<3.0dev,>=2.14.1->google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (5.3.0)\n",
-      "Requirement already satisfied: requests-oauthlib>=0.7.0 in ./bert_kernel/lib/python3.7/site-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (1.3.1)\n",
-      "Collecting google-crc32c<2.0dev,>=1.0\n",
-      "  Downloading google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (32 kB)\n",
-      "Collecting grpcio-status<2.0dev,>=1.33.2\n",
-      "  Downloading grpcio_status-1.51.3-py3-none-any.whl (5.1 kB)\n",
-      "  Downloading grpcio_status-1.51.1-py3-none-any.whl (5.1 kB)\n",
-      "  Downloading grpcio_status-1.50.0-py3-none-any.whl (14 kB)\n",
-      "  Downloading grpcio_status-1.49.1-py3-none-any.whl (14 kB)\n",
-      "  Downloading grpcio_status-1.48.2-py3-none-any.whl (14 kB)\n",
-      "Requirement already satisfied: importlib-metadata>=4.4 in ./bert_kernel/lib/python3.7/site-packages (from markdown>=2.6.8->tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (6.1.0)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in ./bert_kernel/lib/python3.7/site-packages (from requests<3.0.0dev,>=2.18.0->google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (3.4)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in ./bert_kernel/lib/python3.7/site-packages (from requests<3.0.0dev,>=2.18.0->google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0->google-cloud-aiplatform==1.19.0->-r requirements.txt (line 1)) (3.1.0)\n",
-      "Requirement already satisfied: threadpoolctl>=2.0.0 in ./bert_kernel/lib/python3.7/site-packages (from scikit-learn>=0.21.3->seqeval->tf-models-official==2.8.0->-r requirements.txt (line 4)) (3.1.0)\n",
-      "Requirement already satisfied: joblib>=0.11 in ./bert_kernel/lib/python3.7/site-packages (from scikit-learn>=0.21.3->seqeval->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.2.0)\n",
-      "Requirement already satisfied: MarkupSafe>=2.1.1 in ./bert_kernel/lib/python3.7/site-packages (from werkzeug>=0.11.15->tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (2.1.2)\n",
-      "Requirement already satisfied: text-unidecode>=1.3 in ./bert_kernel/lib/python3.7/site-packages (from python-slugify->kaggle>=1.3.9->tf-models-official==2.8.0->-r requirements.txt (line 4)) (1.3)\n",
-      "Requirement already satisfied: oauthlib>=3.0.0 in ./bert_kernel/lib/python3.7/site-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.9,>=2.8->tensorflow==2.8.4->-r requirements.txt (line 2)) (3.2.2)\n",
-      "Installing collected packages: proto-plus, packaging, google-crc32c, grpcio-status, google-resumable-media, grpc-google-iam-v1, google-cloud-core, google-cloud-storage, google-cloud-resource-manager, google-cloud-bigquery, google-cloud-aiplatform\n",
-      "  Attempting uninstall: packaging\n",
-      "    Found existing installation: packaging 23.0\n",
-      "    Uninstalling packaging-23.0:\n",
-      "      Successfully uninstalled packaging-23.0\n",
-      "Successfully installed google-cloud-aiplatform-1.19.0 google-cloud-bigquery-2.34.4 google-cloud-core-2.3.2 google-cloud-resource-manager-1.9.1 google-cloud-storage-2.8.0 google-crc32c-1.5.0 google-resumable-media-2.4.1 grpc-google-iam-v1-0.12.6 grpcio-status-1.48.2 packaging-21.3 proto-plus-1.22.2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!cd ~/asl-ml-immersion && make bert_kernel"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
     "id": "_XgTpm9ZxoN9",
     "tags": []
@@ -268,17 +95,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Num GPUs Available:  1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Num GPUs Available: \", len(tf.config.list_physical_devices(\"GPU\")))"
    ]
@@ -309,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
     "id": "pOdqCMoQDRJL",
     "tags": []
@@ -349,24 +168,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {
     "id": "6IwI_2bcIeX8",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 25000 files belonging to 2 classes.\n",
-      "Using 20000 files for training.\n",
-      "Found 25000 files belonging to 2 classes.\n",
-      "Using 5000 files for validation.\n",
-      "Found 25000 files belonging to 2 classes.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "AUTOTUNE = tf.data.AUTOTUNE\n",
     "batch_size = 32\n",
@@ -411,32 +218,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
     "id": "JuxDkcvVIoev",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Review: b'\"Pandemonium\" is a horror movie spoof that comes off more stupid than funny. Believe me when I tell you, I love comedies. Especially comedy spoofs. \"Airplane\", \"The Naked Gun\" trilogy, \"Blazing Saddles\", \"High Anxiety\", and \"Spaceballs\" are some of my favorite comedies that spoof a particular genre. \"Pandemonium\" is not up there with those films. Most of the scenes in this movie had me sitting there in stunned silence because the movie wasn\\'t all that funny. There are a few laughs in the film, but when you watch a comedy, you expect to laugh a lot more than a few times and that\\'s all this film has going for it. Geez, \"Scream\" had more laughs than this film and that was more of a horror film. How bizarre is that?<br /><br />*1/2 (out of four)'\n",
-      "Label : 0 (neg)\n",
-      "Review: b\"David Mamet is a very interesting and a very un-equal director. His first movie 'House of Games' was the one I liked best, and it set a series of films with characters whose perspective of life changes as they get into complicated situations, and so does the perspective of the viewer.<br /><br />So is 'Homicide' which from the title tries to set the mind of the viewer to the usual crime drama. The principal characters are two cops, one Jewish and one Irish who deal with a racially charged area. The murder of an old Jewish shop owner who proves to be an ancient veteran of the Israeli Independence war triggers the Jewish identity in the mind and heart of the Jewish detective.<br /><br />This is were the flaws of the film are the more obvious. The process of awakening is theatrical and hard to believe, the group of Jewish militants is operatic, and the way the detective eventually walks to the final violent confrontation is pathetic. The end of the film itself is Mamet-like smart, but disappoints from a human emotional perspective.<br /><br />Joe Mantegna and William Macy give strong performances, but the flaws of the story are too evident to be easily compensated.\"\n",
-      "Label : 0 (neg)\n",
-      "Review: b'Great documentary about the lives of NY firefighters during the worst terrorist attack of all time.. That reason alone is why this should be a must see collectors item.. What shocked me was not only the attacks, but the\"High Fat Diet\" and physical appearance of some of these firefighters. I think a lot of Doctors would agree with me that,in the physical shape they were in, some of these firefighters would NOT of made it to the 79th floor carrying over 60 lbs of gear. Having said that i now have a greater respect for firefighters and i realize becoming a firefighter is a life altering job. The French have a history of making great documentary\\'s and that is what this is, a Great Documentary.....'\n",
-      "Label : 1 (pos)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-04-07 15:35:21.799976: W tensorflow/core/kernels/data/cache_dataset_ops.cc:768] The calling iterator did not fully read the dataset being cached. In order to avoid unexpected truncation of the dataset, the partially cached contents of the dataset  will be discarded. This can happen if you have an input pipeline similar to `dataset.cache().take(k).repeat()`. You should use `dataset.take(k).cache().repeat()` instead.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for text_batch, label_batch in train_ds.take(1):\n",
     "    for i in range(3):\n",
@@ -471,22 +258,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "id": "y8_ctG55-uTX",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BERT model selected           : https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-4_H-512_A-8/1\n",
-      "Preprocess model auto-selected: https://tfhub.dev/tensorflow/bert_en_uncased_preprocess/3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# defining the URL of the smallBERT model to use\n",
     "tfhub_handle_encoder = (\n",
@@ -526,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,24 +329,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {
     "id": "r9-zCzJpnuwS",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Keys       : ['input_word_ids', 'input_type_ids', 'input_mask']\n",
-      "Shape      : (1, 128)\n",
-      "Word Ids   : [ 101 2023 2003 2107 2019 6429 3185  999  102    0    0    0]\n",
-      "Input Mask : [1 1 1 1 1 1 1 1 1 0 0 0]\n",
-      "Type Ids   : [0 0 0 0 0 0 0 0 0 0 0 0]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "text_test = [\"this is such an amazing movie!\"]\n",
     "text_preprocessed = bert_preprocess_model(text_test)\n",
@@ -615,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {
     "id": "tXxYpK8ixL34",
     "tags": []
@@ -627,37 +393,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {
     "id": "_OoF9mebuSZc",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded BERT: https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-4_H-512_A-8/1\n",
-      "Pooled Outputs Shape:(1, 512)\n",
-      "Pooled Outputs Values:[ 0.76262903  0.99280983 -0.18611847  0.3667386   0.15233745  0.6550445\n",
-      "  0.9681154  -0.94862705  0.00216164 -0.9877732   0.0684273  -0.97630596]\n",
-      "Sequence Outputs Shape:(1, 128, 512)\n",
-      "Sequence Outputs Values:[[-0.28946295  0.34321263  0.33231527 ...  0.2130087   0.71020836\n",
-      "  -0.05771071]\n",
-      " [-0.2874208   0.31981027 -0.23018518 ...  0.5845508  -0.21329744\n",
-      "   0.7269212 ]\n",
-      " [-0.66157013  0.6887687  -0.8743292  ...  0.10877226 -0.26173285\n",
-      "   0.47855547]\n",
-      " ...\n",
-      " [-0.22561097 -0.2892568  -0.07064426 ...  0.47566074  0.83277184\n",
-      "   0.40025318]\n",
-      " [-0.29824227 -0.27473107 -0.05450526 ...  0.488498    1.0955358\n",
-      "   0.18163362]\n",
-      " [-0.4437815   0.00930744  0.07223801 ...  0.17290124  1.1833242\n",
-      "   0.07898009]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "bert_results = bert_model(text_preprocessed)\n",
     "\n",
@@ -706,25 +447,17 @@
     "3. Encoder Layer\n",
     "4. From the BERT output map, use pooled_output\n",
     "5. Dropout layer\n",
-    "6. Dense layer "
+    "6. Dense layer with sigmoid activation"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {
     "id": "aksj743St9ga",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "tf.Tensor([[0.59120435]], shape=(1, 1), dtype=float32)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def build_classifier_model(dropout_rate=0.1):\n",
     "    text_input = tf.keras.layers.Input(shape=(), dtype=tf.string, name=\"text\")\n",
@@ -762,20 +495,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {
     "id": "0EmzyHZXKIpm",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You must install pydot (`pip install pydot`) and install graphviz (see instructions at https://graphviz.gitlab.io/download/) for plot_model/model_to_dot to work.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tf.keras.utils.plot_model(classifier_model)"
    ]
@@ -811,14 +536,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {
     "id": "OWPOZE-L3AgE",
     "tags": []
    },
    "outputs": [],
    "source": [
-    "loss = tf.keras.losses.BinaryCrossentropy(from_logits=True)\n",
+    "loss = tf.keras.losses.BinaryCrossentropy()\n",
     "metrics = tf.metrics.BinaryAccuracy()"
    ]
   },
@@ -839,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {
     "id": "P9eP2y9dbw32",
     "tags": []
@@ -880,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {
     "id": "-7GPDhR98jsD",
     "tags": []
@@ -908,43 +633,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
     "id": "HtfDFAnN_Neu"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training model with https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-4_H-512_A-8/1\n",
-      "Epoch 1/5\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jupyter/asl-ml-immersion/notebooks/text_models/bert_kernel/lib/python3.7/site-packages/tensorflow/python/util/dispatch.py:1082: UserWarning: \"`binary_crossentropy` received `from_logits=True`, but the `output` argument was produced by a sigmoid or softmax activation and thus does not represent logits. Was this intended?\"\n",
-      "  return dispatch_target(*args, **kwargs)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "625/625 [==============================] - 162s 250ms/step - loss: 0.4973 - binary_accuracy: 0.7471 - val_loss: 0.3778 - val_binary_accuracy: 0.8380\n",
-      "Epoch 2/5\n",
-      "625/625 [==============================] - 155s 248ms/step - loss: 0.3372 - binary_accuracy: 0.8547 - val_loss: 0.3639 - val_binary_accuracy: 0.8502\n",
-      "Epoch 3/5\n",
-      "625/625 [==============================] - 155s 248ms/step - loss: 0.2582 - binary_accuracy: 0.8946 - val_loss: 0.3802 - val_binary_accuracy: 0.8518\n",
-      "Epoch 4/5\n",
-      "625/625 [==============================] - 155s 248ms/step - loss: 0.1959 - binary_accuracy: 0.9269 - val_loss: 0.4276 - val_binary_accuracy: 0.8504\n",
-      "Epoch 5/5\n",
-      "625/625 [==============================] - 155s 248ms/step - loss: 0.1599 - binary_accuracy: 0.9425 - val_loss: 0.4620 - val_binary_accuracy: 0.8528\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"Training model with {tfhub_handle_encoder}\")\n",
     "history = classifier_model.fit(\n",
@@ -965,21 +658,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {
     "id": "slqB-urBV9sP"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "782/782 [==============================] - 83s 106ms/step - loss: 0.4442 - binary_accuracy: 0.8608\n",
-      "Loss: 0.4441617429256439\n",
-      "Accuracy: 0.86080002784729\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "loss, accuracy = classifier_model.evaluate(test_ds)\n",
     "\n",
@@ -1000,39 +683,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {
     "id": "fiythcODf0xo"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "dict_keys(['loss', 'binary_accuracy', 'val_loss', 'val_binary_accuracy'])\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.legend.Legend at 0x7efe967c8190>"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1cAAAIjCAYAAADvBuGTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAA9hAAAPYQGoP6dpAACunklEQVR4nOzdeVwU9f8H8Ndy7YKcAnIogqCCJ954H4XhEaaWoh2CWpblFVlqXqAlpWaYmlbfPPIKzaMsNZU888wrNcULxQsQFRCQa5nfH/PbhZUFdmGXXeD1fDzmITs7O/OZYVRefD7z/kgEQRBAREREREREFWJi6AYQERERERFVBwxXREREREREOsBwRUREREREpAMMV0RERERERDrAcEVERERERKQDDFdEREREREQ6wHBFRERERESkAwxXREREREREOsBwRUREREREpAMMV0REVVxYWBi8vLzK9dmIiAhIJBLdNsjI3Lp1CxKJBKtXr67U4x44cAASiQQHDhxQrtP0e6WvNnt5eSEsLEyn+9TE6tWrIZFIcOvWrUo/NhFRZWK4IiLSE4lEotFS9Idvooo6evQoIiIikJqaauimEBHVOGaGbgARUXW1du1aldc//fQT9u7dW2x9kyZNKnScH374AQUFBeX67IwZMzB16tQKHZ80V5HvlaaOHj2KyMhIhIWFwd7eXuW9uLg4mJjw96pERPrCcEVEpCdvvvmmyuvjx49j7969xdY/LysrC1ZWVhofx9zcvFztAwAzMzOYmfG/gspSke+VLkilUoMen4iouuOvr4iIDKhnz55o3rw5Tp8+je7du8PKygqffvopAODXX39F//794e7uDqlUCh8fH8ydOxdyuVxlH88/x6N4XmfhwoX4/vvv4ePjA6lUivbt2+PUqVMqn1X3zJVEIsG4ceOwfft2NG/eHFKpFM2aNcPu3buLtf/AgQNo164dZDIZfHx88N1332n8HNfhw4cxZMgQ1K9fH1KpFB4eHvjwww/x7NmzYudnbW2Ne/fuYeDAgbC2toazszMmT55c7FqkpqYiLCwMdnZ2sLe3R2hoqEbD4/755x9IJBKsWbOm2Ht//vknJBIJfv/9dwDA7du38f7778PX1xeWlpZwdHTEkCFDNHqeSN0zV5q2+d9//0VYWBi8vb0hk8ng6uqKUaNG4dGjR8ptIiIi8PHHHwMAGjRooBx6qmibumeubt68iSFDhqB27dqwsrJCx44d8ccff6hso3h+bNOmTfj8889Rr149yGQyvPjii7h+/XqZ512Sb7/9Fs2aNYNUKoW7uzs++OCDYud+7do1vPrqq3B1dYVMJkO9evUwbNgwpKWlKbfZu3cvunbtCnt7e1hbW8PX11f594iIqDLx15VERAb26NEj9O3bF8OGDcObb74JFxcXAGIRAGtra4SHh8Pa2hp//fUXZs2ahfT0dCxYsKDM/W7YsAFPnz7Fu+++C4lEgvnz52Pw4MG4efNmmT0oR44cwdatW/H+++/DxsYG33zzDV599VUkJCTA0dERAHD27Fn06dMHbm5uiIyMhFwux5w5c+Ds7KzReW/evBlZWVkYO3YsHB0dcfLkSSxZsgR3797F5s2bVbaVy+UICgpCQEAAFi5ciH379uGrr76Cj48Pxo4dCwAQBAGvvPIKjhw5gvfeew9NmjTBtm3bEBoaWmZb2rVrB29vb2zatKnY9jExMXBwcEBQUBAA4NSpUzh69CiGDRuGevXq4datW1i+fDl69uyJ//77T6teR23avHfvXty8eRMjR46Eq6srLl26hO+//x6XLl3C8ePHIZFIMHjwYFy9ehUbN27E119/DScnJwAo8XuSlJSEzp07IysrCxMmTICjoyPWrFmDAQMG4JdffsGgQYNUtv/iiy9gYmKCyZMnIy0tDfPnz8cbb7yBEydOaHzOChEREYiMjERgYCDGjh2LuLg4LF++HKdOncLff/8Nc3Nz5ObmIigoCDk5ORg/fjxcXV1x7949/P7770hNTYWdnR0uXbqEl19+GS1btsScOXMglUpx/fp1/P3331q3iYiowgQiIqoUH3zwgfD8P7s9evQQAAgrVqwotn1WVlaxde+++65gZWUlZGdnK9eFhoYKnp6eytfx8fECAMHR0VF4/Pixcv2vv/4qABB27NihXDd79uxibQIgWFhYCNevX1euO3/+vABAWLJkiXJdcHCwYGVlJdy7d0+57tq1a4KZmVmxfaqj7vyioqIEiUQi3L59W+X8AAhz5sxR2bZ169ZC27Ztla+3b98uABDmz5+vXJefny9069ZNACCsWrWq1PZMmzZNMDc3V7lmOTk5gr29vTBq1KhS233s2DEBgPDTTz8p1+3fv18AIOzfv1/lXIp+r7Rps7rjbty4UQAgHDp0SLluwYIFAgAhPj6+2Paenp5CaGio8vWkSZMEAMLhw4eV654+fSo0aNBA8PLyEuRyucq5NGnSRMjJyVFuu3jxYgGAcOHChWLHKmrVqlUqbUpOThYsLCyEl156SXkMQRCEpUuXCgCElStXCoIgCGfPnhUACJs3by5x319//bUAQHj48GGpbSAiqgwcFkhEZGBSqRQjR44stt7S0lL59dOnT5GSkoJu3bohKysLV65cKXO/ISEhcHBwUL7u1q0bAHEYWFkCAwPh4+OjfN2yZUvY2toqPyuXy7Fv3z4MHDgQ7u7uyu0aNmyIvn37lrl/QPX8MjMzkZKSgs6dO0MQBJw9e7bY9u+9957K627duqmcy86dO2FmZqbsyQIAU1NTjB8/XqP2hISEIC8vD1u3blWu27NnD1JTUxESEqK23Xl5eXj06BEaNmwIe3t7nDlzRqNjlafNRY+bnZ2NlJQUdOzYEQC0Pm7R43fo0AFdu3ZVrrO2tsaYMWNw69Yt/Pfffyrbjxw5EhYWFsrX2txTRe3btw+5ubmYNGmSSoGNd955B7a2tsphiXZ2dgDEoZlZWVlq96Uo2vHrr7/qvVgIEVFZGK6IiAysbt26Kj+wKly6dAmDBg2CnZ0dbG1t4ezsrCyGUfR5k5LUr19f5bUiaD158kTrzyo+r/hscnIynj17hoYNGxbbTt06dRISEhAWFobatWsrn6Pq0aMHgOLnJ5PJig1tK9oeQHwWys3NDdbW1irb+fr6atQef39/+Pn5ISYmRrkuJiYGTk5OeOGFF5Trnj17hlmzZsHDwwNSqRROTk5wdnZGamqqRt+XorRp8+PHjzFx4kS4uLjA0tISzs7OaNCgAQDN7oeSjq/uWIoKlrdv31ZZX5F76vnjAsXP08LCAt7e3sr3GzRogPDwcPzvf/+Dk5MTgoKCsGzZMpXzDQkJQZcuXfD222/DxcUFw4YNw6ZNmxi0iMgg+MwVEZGBFe2RUEhNTUWPHj1ga2uLOXPmwMfHBzKZDGfOnMGUKVM0+sHR1NRU7XpBEPT6WU3I5XL07t0bjx8/xpQpU+Dn54datWrh3r17CAsLK3Z+JbVH10JCQvD5558jJSUFNjY2+O233zB8+HCViorjx4/HqlWrMGnSJHTq1Al2dnaQSCQYNmyYXn+gHzp0KI4ePYqPP/4YrVq1grW1NQoKCtCnT59KCxL6vi/U+eqrrxAWFoZff/0Ve/bswYQJExAVFYXjx4+jXr16sLS0xKFDh7B//3788ccf2L17N2JiYvDCCy9gz549lXbvEBEBDFdEREbpwIEDePToEbZu3Yru3bsr18fHxxuwVYXq1KkDmUymtlKcJtXjLly4gKtXr2LNmjUYMWKEcv3evXvL3SZPT0/ExsYiIyNDpScoLi5O432EhIQgMjISW7ZsgYuLC9LT0zFs2DCVbX755ReEhobiq6++Uq7Lzs4u16S9mrb5yZMniI2NRWRkJGbNmqVcf+3atWL71KRSY9Hjq7s+imGnnp6eGu9LG4r9xsXFwdvbW7k+NzcX8fHxCAwMVNm+RYsWaNGiBWbMmIGjR4+iS5cuWLFiBT777DMAgImJCV588UW8+OKLWLRoEebNm4fp06dj//79xfZFRKRPHBZIRGSEFL9tL9ojkJubi2+//dZQTVJhamqKwMBAbN++Hffv31euv379Onbt2qXR5wHV8xMEAYsXLy53m/r164f8/HwsX75cuU4ul2PJkiUa76NJkyZo0aIFYmJiEBMTAzc3N5Vwq2j78z01S5YsKVYWXpdtVne9ACA6OrrYPmvVqgUAGoW9fv364eTJkzh27JhyXWZmJr7//nt4eXmhadOmmp6KVgIDA2FhYYFvvvlG5Zx+/PFHpKWloX///gCA9PR05Ofnq3y2RYsWMDExQU5ODgBxuOTzWrVqBQDKbYiIKgt7roiIjFDnzp3h4OCA0NBQTJgwARKJBGvXrtXr8CttRUREYM+ePejSpQvGjh0LuVyOpUuXonnz5jh37lypn/Xz84OPjw8mT56Me/fuwdbWFlu2bNH62Z2igoOD0aVLF0ydOhW3bt1C06ZNsXXrVq2fRwoJCcGsWbMgk8kwevRolYILAPDyyy9j7dq1sLOzQ9OmTXHs2DHs27dPWaJeH222tbVF9+7dMX/+fOTl5aFu3brYs2eP2p7Mtm3bAgCmT5+OYcOGwdzcHMHBwcrQVdTUqVOxceNG9O3bFxMmTEDt2rWxZs0axMfHY8uWLcXOXVecnZ0xbdo0REZGok+fPhgwYADi4uLw7bffon379spnC//66y+MGzcOQ4YMQePGjZGfn4+1a9fC1NQUr776KgBgzpw5OHToEPr37w9PT08kJyfj22+/Rb169VQKdRARVQaGKyIiI+To6Ijff/8dH330EWbMmAEHBwe8+eabePHFF5XzLRla27ZtsWvXLkyePBkzZ86Eh4cH5syZg8uXL5dZzdDc3Bw7duxQPj8jk8kwaNAgjBs3Dv7+/uVqj4mJCX777TdMmjQJ69atg0QiwYABA/DVV1+hdevWGu8nJCQEM2bMQFZWlkqVQIXFixfD1NQU69evR3Z2Nrp06YJ9+/aV6/uiTZs3bNiA8ePHY9myZRAEAS+99BJ27dqlUq0RANq3b4+5c+dixYoV2L17NwoKChAfH682XLm4uODo0aOYMmUKlixZguzsbLRs2RI7duxQ9h7pS0REBJydnbF06VJ8+OGHqF27NsaMGYN58+Yp52Hz9/dHUFAQduzYgXv37sHKygr+/v7YtWuXslLigAEDcOvWLaxcuRIpKSlwcnJCjx49EBkZqaw2SERUWSSCMf0alIiIqryBAwfi0qVLap8HIiIiqs74zBUREZXbs2fPVF5fu3YNO3fuRM+ePQ3TICIiIgNizxUREZWbm5sbwsLClHMTLV++HDk5OTh79iwaNWpk6OYRERFVKj5zRURE5danTx9s3LgRiYmJkEql6NSpE+bNm8dgRURENRJ7roiIiIiIiHSAz1wRERERERHpAMMVERERERGRDvCZKzUKCgpw//592NjYQCKRGLo5RERERERkIIIg4OnTp3B3dy9zcnWGKzXu378PDw8PQzeDiIiIiIiMxJ07d1CvXr1St2G4UsPGxgaAeAFtbW0N3BoiIiIiIjKU9PR0eHh4KDNCaRiu1FAMBbS1tWW4IiIiIiIijR4XYkELIiIiIiIiHagS4WrZsmXw8vKCTCZDQEAATp48WeK2q1evhkQiUVlkMlkltpaIiIiIiGoiow9XMTExCA8Px+zZs3HmzBn4+/sjKCgIycnJJX7G1tYWDx48UC63b9+uxBYTEREREVFNZPThatGiRXjnnXcwcuRING3aFCtWrICVlRVWrlxZ4mckEglcXV2Vi4uLSyW2mIiIiIiIaiKjDle5ubk4ffo0AgMDletMTEwQGBiIY8eOlfi5jIwMeHp6wsPDA6+88gouXbpU6nFycnKQnp6ushiN3FxAEAzdCiIiIiIiKoNRh6uUlBTI5fJiPU8uLi5ITExU+xlfX1+sXLkSv/76K9atW4eCggJ07twZd+/eLfE4UVFRsLOzUy5GNcdVRATQqROwbx9DFhERERGRETPqcFUenTp1wogRI9CqVSv06NEDW7duhbOzM7777rsSPzNt2jSkpaUplzt37lRii0uRkwP873/AiRNA795Ar17A4cOGbhUREREREalh1OHKyckJpqamSEpKUlmflJQEV1dXjfZhbm6O1q1b4/r16yVuI5VKlXNaGdXcVlIp8O+/wIQJgIUFcPAg0L07EBQElFIxkYiIiIiIKp9RhysLCwu0bdsWsbGxynUFBQWIjY1Fp06dNNqHXC7HhQsX4Obmpq9m6perK7B4MXD9OvDuu4CZGbBnDxAQAAwYAJw7Z+gWEhERERERjDxcAUB4eDh++OEHrFmzBpcvX8bYsWORmZmJkSNHAgBGjBiBadOmKbefM2cO9uzZg5s3b+LMmTN48803cfv2bbz99tuGOgXd8PAAVqwA4uKA0FDAxATYsQNo3RoYOhT47z9Dt5CIiIiIqEYz+nAVEhKChQsXYtasWWjVqhXOnTuH3bt3K4tcJCQk4MGDB8rtnzx5gnfeeQdNmjRBv379kJ6ejqNHj6Jp06aGOgXd8vYGVq8GLl0Chg0T123eDDRvDrz1ltjDRURERERElU4iCCxB97z09HTY2dkhLS3NeJ6/KsmFC8Ds2cC2beJrU1Ng5EhgxgzA09OwbSMiIiIiquK0yQZG33NFZWjRAti6FTh1CujbF5DLxQqDjRoB48YB9+8buoVERERERDUCw1V10a4dsHMn8PffwAsvAHl5wLJlgI8P8NFHQHKyoVtIRERERFStMVxVN507A7Gx4tK5M5CdDSxaJD6rNX068PixoVtIRERERFQtMVxVVy+8ABw5IvZmtW0LZGYC8+YBDRoAc+YA6emGbiERERERUbXCcFWdSSTic1inTokFL1q0EEPV7NliyJo/XwxdRERERERUYQxXNYFEAgwcKE44/PPPgK+vODxwyhRxuODixeLwQSIiIiIiKjeGq5rExAQICQEuXhTnymrQQCx0MWkS0LChOElxbq6hW0lEREREVCUxXNVEZmZAaCgQFwd89x1Qrx5w7x4wdqzYq7V6NZCfb+hWEhERERFVKQxXNZm5OTBmDHDtmjg00MUFuHVLnIS4WTNg40agoMDQrSQiIiIiqhIYrgiQyYAJE4CbN8UiF46OwNWrwOuvA/7+YjEMQTB0K4mIiIiIjBrDFRWysgI+/hiIjwfmzgXs7MTnswYPLpykmCGLiIiIiEgthisqzsYGmDFDDFnTpwPW1sCZM0D//kCXLsBffxm6hURERERERofhikrm4AB89pk4XHDyZHH44LFjwIsvAr16iZMUExERERERAEAiCBzn9bz09HTY2dkhLS0Ntra2hm6O8XjwAIiKEisMKkq29+kjDiFs186wbSMiIiKiKkUuB5KSgLt3gTt3xD+Lfu3mBmzebOhWapcNGK7UYLgqQ0KC2KO1cqX4twIAXnkFmDMHaNnSsG0jIiIiIoOTy4HExOKBqWiIun+/9Nl/PD3FQtaGxnBVQQxXGrpxQwxU69YVlmwPCQEiIgA/P4M2jYiIiIj0Qy4XBzQ9H5yKfn3/fuHv4Etjagq4u4vTrtarB3h4FH7t6Ql06KD/8ykLw1UFMVxp6fJlMVBt2iS+NjEB3nwTmDUL8PExaNOIiIiISHP5+WKPk7qeJsXXDx5oF5yKBqbnv3ZxAczM9H9eFcFwVUEMV+V0/jwwezbw66/iazMzcULiGTOA+vUN2zYiIiKiGi4/XwxG6gKT4usHDwoHJJXG1BSoW1c1MKkLTqam+j8vfWO4qiCGqwo6dUrstdq9W3xtYQG8+y4wbZr4ZCIRERER6VReXuFQPXXh6c4dsUdKk+BkZlY8OD3/dXUJTppguKoghisdOXJE7LU6eFB8bWkJfPAB8MkngLOzYdtGREREVEXk5YnPMJUUnO7e1Tw4mZsXBqeSwpOLi/iUB4kYriqI4UqHBEGcdHjmTHGOLECclHjSJOCjjwB7e0O2joiIiMigcnMLg1NJ4SkxUfyRqizm5oVBqaTgVKcOg5O2GK4qiOFKDwQB2LVL7Mk6e1ZcZ2cnTk48cSJgY2PY9hERERHpWG4ucO9e6cEpKUm74FRacQhnZwYnfWC4qiCGKz0SBGD7drEn69IlcZ2jIzBlijhk0MrKoM0jIiIi0kROjtjjVNLzTYrgpAkLi7KDk5MTg5OhMFxVEMNVJZDLxdLts2cD166J61xcgOnTgTFjAKnUsO0jIiKiGisnR+xxKq2qXnKyZvuSSksfplevntjjJJHo95yo/BiuKojhqhLl54uTEEdGFk7BXa+e2LM1cqTYB05ERESkI9nZhUP1Sup1evhQs33JZOqfcSoanJycGJyqOoarCmK4MoDcXGDlSuCzz8R/8QDA21vs2XrjjZpT65OIiIjKLTu79Oeb7t7VLjiVNkyvXj3xyQYGp+qP4aqCGK4MKDsb+O47YN68wv52X1+xZ2vIEA42JiIiqqGePSsMSCWFp5QUzfZlaVn2M061azM4kYjhqoIYroxAZiawbBnw5ZfA48fiuhYtgDlzgFde4b92RERE1UhWluozTuqC06NHmu3L0lIMR6UFJwcH/ihBmmO4qiCGKyOSng5ERwNffSV+DQDt2gFz5wJBQfyXkYiIyMhlZZU+TO/OncLfo5bFykr9c01Fv2ZwIl1juKoghisj9PixGLAWLxZ7tQCgc2fxGa1evQzbNiIiohoqM7PkMuSKr5880WxftWqVHZzs7RmcqPIxXFUQw5URS04Whwp++634fBYAvPCC2JPVubNh20ZERFSNZGSUXRxC0+BkbV12cQg7OwYnMk4MVxXEcFUF3L8vFr34/nsgL09c17evGLLatjVs24iIiIxcRkbpk9/evQukpmq2L0VwUheYFH/a2jI4UdXFcFVBDFdVyO3b4tDAVavEiYkBYNAgsbpgixaGbRsREZEBFBSIIenqVfFPdSEqLU2zfdnall1Vjz8qUXXHcFVBDFdV0PXrYqBavx4QBPHXYyEhQESEWMqdiIiomklPB+Liii/Xrolly8tiZ1f6MD1FjxNRTcdwVUEMV1XYf/+JgWrzZvG1iQnw1lvArFnipMRERERVSH4+cOuW+hCVmFjy58zNAR8fwMur5OBkY1NZZ0FUtTFcVRDDVTVw7pwYqHbsEF+bmQGjRwMzZoj/oxARERmRlBQxMF29qhqgrl8vfLRYHVdXcYBG48bin4qlQQPxvz4iqjiGqwpiuKpGTp4EZs4E9uwRX0ulwLvvAtOmif8jERERVZLcXDEsqeuFKm2eJ5mseHhSBCo7u8prP1FNxXBVQQxX1dDhw2Kv1aFD4mtLS2D8eODjjwEnJ8O2jYiIqg1BEIfrqQtQ8fFisYmSeHgUD1C+vuJ6E5PKOwciUsVwVUEMV9WUIACxsWLIOnFCXGdtDXz4IRAeLs5MSEREpIGsLLFwxPMB6upVsdBESayt1QeoRo3ESXSJyPgwXFUQw1U1JwjAzp1iyDp3Tlxnbw9MngxMmMAnfImICIDYy3T3rvpeqISEkj9nYiIWklAXotzcON8TUVXDcFVBDFc1REEBsG2bWPjiv//EdU5OwNSpwPvvi0MHiYio2ktPL15IQtELVVpJcwcH9QGqYUPxEV8iqh4YriqI4aqGkcuBmBhg9mzxSWNA/NXip58C77zD/yGJiKoBubzkkuYPHpT8OTMzMSypq8jn5MReKKKagOGqghiuaqj8fGDtWnEy4tu3xXUeHmLPVmioOGkIEREZtUeP1PdCXb8uVusriYuL+l4oljQnIoarCmK4quFyc4EffwQ++wy4f19c5+0tTk78+uuAqalBm0dEVNPl5gI3bqjvhXr0qOTPyWRi4Qh1Jc1Z04iISsJwVUEMVwRAHGj/3XfAvHnAw4fiuiZNxJD12musi0tEpEeCACQllVzSXC4v+bP16qnvhapfn/90E5H2ql24WrZsGRYsWIDExET4+/tjyZIl6NChQ5mf+/nnnzF8+HC88sor2L59u8bHY7giFRkZwNKlwPz5wJMn4rqWLYG5c4HgYA64JyKqgGfP1Jc0j4sru6R5SRPrsqQ5EelStQpXMTExGDFiBFasWIGAgABER0dj8+bNiIuLQ506dUr83K1bt9C1a1d4e3ujdu3aDFdUcWlpQHQ0sGhR4f/47duLIeullxiyiIhKUFAA3LtXcknzkn4SkUhKLmnu7s5/domoclSrcBUQEID27dtj6dKlAICCggJ4eHhg/PjxmDp1qtrPyOVydO/eHaNGjcLhw4eRmprKcEW68+gRsHAh8M034iySANC1q/iMVo8ehm0bEZEBPX1acklzxT+X6qgrad64sVilTyarvPYTEamjTTYw6vo3ubm5OH36NKZNm6ZcZ2JigsDAQBw7dqzEz82ZMwd16tTB6NGjcfjw4TKPk5OTg5ycHOXr9NLGIRA5OgJRUcCkScCXXwLffgscOQL07Am8+KIYsjp2NHQriYj0Qi4XC6qq64VS1ABSx8wM8PFR3wvFkuZEVF0YdbhKSUmBXC6Hi4uLynoXFxdcuXJF7WeOHDmCH3/8EefOndP4OFFRUYiMjKxIU6kmcnERhwh+9JFY9OKHH4DYWHHp3x+YMwdo08bQrSQiKpfHj9UHqLJKmtepU3JJc85oQUTVnVGHK209ffoUb731Fn744Qc4OTlp/Llp06YhPDxc+To9PR0eHh76aCJVR3XrAsuWAR9/LD5/tWYN8Mcf4jJ4sDhvVvPmhm4lEVExeXkllzRPSSn5c1Kp+pLmvr4saU5ENZtRhysnJyeYmpoiKSlJZX1SUhJcXV2LbX/jxg3cunULwcHBynUFBQUAADMzM8TFxcHHx6fY56RSKaRSqY5bTzWOl5c4P9bUqWKg2rAB2LoV2LYNGD4cmD1bfIiAiKgSCQKQnKw+QN28WXpJ87p1Sy5pzin/iIiKqxIFLTp06IAlS5YAEMNS/fr1MW7cuGIFLbKzs3H9+nWVdTNmzMDTp0+xePFiNG7cGBYWFmUekwUtSCcuXRID1ZYt4mtTU2DECGDWLDGIERHpUHZ2ySXN09JK/lytWiWXNLe2rrz2ExEZq2pT0AIAwsPDERoainbt2qFDhw6Ijo5GZmYmRo4cCQAYMWIE6tati6ioKMhkMjR/bviV/f+PT3h+PZHeNWsG/PILcPasGKh+/x1YtQpYtw54+21g+nTx18JERBoShJJLmt++rX1J88aNxX+GWEyCiEg3jD5chYSE4OHDh5g1axYSExPRqlUr7N69W1nkIiEhASacbp2MWevWwI4dwPHjYsjauxdYvhxYuRIYO1YcRvhc0RYiqtkyMkouaZ6ZWfLn7O3VD+NjSXMiosph9MMCDYHDAkmvDh4EZs4EFNMEWFkB48eLBTEcHQ3bNiKqNEVLmj8fpO7dK/lzZmaAt7f6EOXszF4oIiJdq1aTCBsCwxXpnSCIPVgzZwInT4rrbGyA8HDgww8BOzvDto+IdObJk5JLmheZYrEYZ2f1AcrbmyXNiYgqE8NVBTFcUaURBPFZrJkzgfPnxXUODmIv1vjxfJqcqIrIyxMr76kLUQ8flvw5C4uSS5o7OFRe+4mIqGQMVxXEcEWVrqBArCo4ezZw+bK4ztkZmDYNeO89wNLSsO0jIgiCGJRKKmmen1/yZ93d1QcoT0+WNCciMnYMVxXEcEUGI5cDGzcCERHizJ6A+FPZ9OnA6NHizJ1EpBMFBWJxiPR04OlTcXn+6ydPVMubp6aWvD8rK/XV+Bo3Fkf9EhFR1cRwVUHGFK5u3BB/ALC2FuciqVWLv+WsEfLygJ9+AubMARISxHWenmK1wREjxCfaiWogubww/KgLQ5p+nZ4uBitt/weUSMS/iup6oVjSnIioemK4qiBjCledOwPHjqmuk8lUw5bi69LWafKehQV/MDA6OTnA//4HfP458OCBuK5hQ7Fna9gwJm2qEvLyKhaEin6dlaX79pmaij1LNjaAra3q13Z2qpX5GjbkKF0iopqG4aqCjClcBQYCp06Jc54UFOj3WKam5QtlZb1nZQVwKrIKevZMnBvriy8Kn45v2hSIjAQGD+YFJp0SBDHXVzQIKb4urSJeeZmbFw9C5f3a0pK/WCIiopIxXFWQMYUrBcUPO5mZYtBS92d539PHDz7Ps7LSbWBTfF3jyhFnZABLlgDz5xc+/NGqFTB3LtC/P39CrMEEQczgzw99K28oysvTfRtlsvIFIHXr+PghERFVFoarCjLGcKVP+fkVC2elvadvFha6D2zW1uIPgUadU1JTga+/FpenT8V1AQFiyAoMNPLGk4KioIIueoiePhWfR9I1Kyvd9RDVuF+GEBFRtcBwVUE1LVzpi+I36SUFr4oEt9JKHuuCiUlh6NI2sJW1vU4fk3r0CFiwAPjmG/FiA0D37mLI6t5dhwciBblcvAd18fxQRob2BRU0oQgzFe0hsrbmY31EREQMVxXEcGX8cnNLD2XlDW6KfKJPMpnun2uzzkiExaIvIPluReE4z969xZAVEKD/kzJyioIKunh+SB8FFUxMKt4rpPi6Vi0+gkdERKRLDFcVxHBVc8nl4g/P+ghulVKQpFYBauWnwzorCbWQiVrIhLWzFWq19IZ1PYdyhTlDFSRRFFSoSKltxbrsbN23z8ys/AHo+XUsqEBERGS8tMkGnCyHqIiiJZl1SRDEH/DLCmXlCW65ueIx5HIgLd0EabAHYF948IcAYivW/qIFSbTtYZNKxXZqG5D0UVBBKtVdD5FUykBEREREqhiuiCqBRCL2TlhaAk5Out13Xl7x0KX8+uo9ZGzcgcwTF5Eh9mMh068tMvy7INPMrtTgVrQgSVaWfobDacLSUjc9RDY2YgEUIiIiIn3hsEA1OCyQqp2LF4HZs4GtW8XXpqZAWBgwcybg6an2IwUF6guSaNvjlp0t9mKVJyBZW4vD74iIiIgMhc9cVRDDFVVbp08Ds2YBO3eKr83NgXfeAaZPB9zdDds2IiIiIiOkTTZgTSmimqRtW+CPP4CjR4EXXxTHFH77LeDjA3z0EZCcbOgWEhEREVVZDFdENVGnTsC+fcD+/UCXLuLYvUWLAG9v4NNPgcePDd1CIiIioiqH4YqoJuvZEzh8GNi9G2jXTnxIKioKaNAAiIwUy/YRERERkUYYrohqOokECAoCTp4Efv0VaNlSDFUREWLI+vJL1dKBRERERKQWwxURiSQSYMAA4OxZICYG8PMThwdOnSoOF4yO1s9svERERETVBMMVEakyMQGGDhXLt//0kxiskpOBDz8EGjYEVqwonLmYiIiIiJT0Fq7u3LmDu3fvKl+fPHkSkyZNwvfff6+vQxKRLpmaAm+9BVy5Anz/PeDhAdy7B4wdC/j6AqtWAfn5hm4lERERkdHQW7h6/fXXsX//fgBAYmIievfujZMnT2L69OmYM2eOvg5LRLqmmAvr2jVgyRLA1RW4dQsYNQpo2hTYsAGQyw3dSiIiIiKD01u4unjxIjp06AAA2LRpE5o3b46jR49i/fr1WL16tb4OS0T6IpUC48YBN24ACxcCTk5i4HrjDcDfH9i6FeCc5ERERFSD6S1c5eXlQSqVAgD27duHAQMGAAD8/Pzw4MEDfR2WiPTNykqccPjmTeCzzwB7e+DSJeDVV8Vy7n/8wZBFRERENZLewlWzZs2wYsUKHD58GHv37kWfPn0AAPfv34ejo6O+DktElcXGBpg+HYiPB2bOBKytgTNngJdfBjp3BmJjGbKIiIioRtFbuPryyy/x3XffoWfPnhg+fDj8/f0BAL/99ptyuCARVQP29sCcOWLI+uQTwNISOH4cCAwEevUCDh1iyCIiIqIaQSII+vupRy6XIz09HQ4ODsp1t27dgpWVFerUqaOvw1ZYeno67OzskJaWBltbW0M3h6hqSUwEoqJUS7bXqQP07CmGrV69gMaNxXm1iIiIiIycNtlAb+Hq2bNnEAQBVlZWAIDbt29j27ZtaNKkCYKCgvRxSJ1huCLSgTt3xGey1q4Fnj1Tfc/NrTBo9eolzqXFsEVERERGyCjC1UsvvYTBgwfjvffeQ2pqKvz8/GBubo6UlBQsWrQIY8eO1cdhdYLhikiHcnKAkyeB/fvF5dgxcV1RHh6qYcvT0zBtJSIiInqOUYQrJycnHDx4EM2aNcP//vc/LFmyBGfPnsWWLVswa9YsXL58WR+H1QmGKyI9ys4WA5YibJ04AeTlqW7ToIFq2Kpb1zBtJSIiohpPm2xgpq9GZGVlwcbGBgCwZ88eDB48GCYmJujYsSNu376tr8MSkbGTyQpDEwBkZQFHjxaGrVOnxOIY8fHAypXiNo0aidsrnttydTVY84mIiIhKordw1bBhQ2zfvh2DBg3Cn3/+iQ8//BAAkJyczN4gIipkZSVWFgwMFF9nZABHjhSGrdOnxcmKr10Dvv9e3MbPrzCg9ewJODsbrPlERERECnobFvjLL7/g9ddfh1wuxwsvvIC9e/cCAKKionDo0CHs2rVLH4fVCQ4LJDIiaWnA4cOFYevcueKl3Zs3LwxbPXoAtWsbpKlERERU/RjFM1cAkJiYiAcPHsDf3x8mJuKUWidPnoStrS38/Pz0ddgKY7giMmKPH4tzZynC1oULqu9LJIC/f2HY6t4dsLMzTFuJiIioyjOacKVw9+5dAEC9evX0fSidYLgiqkIePgQOHiwMW88XyzExAdq0KQxbXbsC//88KBEREVFZjCJcFRQU4LPPPsNXX32FjIwMAICNjQ0++ugjTJ8+XdmTZYwYroiqsMRE4MCBwrB17Zrq+6amQPv2hWGrSxfxuS8iIiIiNYwiXE2bNg0//vgjIiMj0aVLFwDAkSNHEBERgXfeeQeff/65Pg6rEwxXRNXIvXuFQevAAeDmTdX3zc2BgIDCsNWpk1jRkIiIiAhGEq7c3d2xYsUKDBgwQGX9r7/+ivfffx/37t3Tx2F1guGKqBq7fVu1ZyshQfV9qRTo2LEwbAUEiOuIiIioRjKKcCWTyfDvv/+icePGKuvj4uLQqlUrPHv2TB+H1QmGK6IaQhDE+bQUQWv/fuD+fdVtLC2Bzp0Lw1b79mJvFxEREdUIRhGuAgICEBAQgG+++UZl/fjx43Hy5EmcOHFCH4fVCYYrohpKEMRntIqGreRk1W1q1RKLYijCVps2gJnepgwkIiIiAzOKcHXw4EH0798f9evXR6dOnQAAx44dw507d7Bz505069ZNH4fVCYYrIgIghq3Ll1Wf2Xr0SHUbW1ugW7fCsOXvLxbNICIiomrBKMIVANy/fx/Lli3DlStXAABNmjTBmDFj8Nlnn+H777/X12ErjOGKiNQqKAAuXiwMWwcPAqmpqtvY24sTGSvCVvPmYjl4IiIiqpKMJlypc/78ebRp0wZyubwyD6sVhisi0ohcDpw/Xxi2Dh0Cnj5V3cbREejZszBsNWkiTnRMREREVQLDVQUxXBFRueTnA2fOFFYjPHwYyMxU3cbFpTBs9ewJNG7MsEVERGTEtMkGVWKsyrJly+Dl5QWZTIaAgACcPHmyxG23bt2Kdu3awd7eHrVq1UKrVq2wdu3aSmwtEdVYZmZAhw7AJ58Au3YBT54AR48Cn38OBAaKlQeTkoCYGOC99wA/P6BePeCNN4D//Q+4cUN8zouIiIiqJKPvuYqJicGIESOwYsUKBAQEIDo6Gps3b0ZcXBzq1KlTbPsDBw7gyZMn8PPzg4WFBX7//Xd89NFH+OOPPxAUFKTRMdlzRUR6kZMDnDxZOIzw2DFxXVEeHoVDCHv1Ajw9DdNWIiIiAmDgYYGDBw8u9f3U1FQcPHhQ43AVEBCA9u3bY+nSpQCAgoICeHh4YPz48Zg6dapG+2jTpg369++PuXPnarQ9wxURVYpnz4DjxwvD1okTQF6e6jYNGqiGrbp1DdNWIiKiGkqbbKDzyVns7OzKfH/EiBEa7Ss3NxenT5/GtGnTlOtMTEwQGBiIY8eOlfl5QRDw119/IS4uDl9++WWJ2+Xk5CCnyG+P09PTNWofEVGFWFoWhiZAfD7r6NHCsHXqlDjJcXw8sHKluE2jRoWf6dkTcHU1WPOJiIhIlc7D1apVq3S2r5SUFMjlcri4uKisd3FxUZZ3VyctLQ1169ZFTk4OTE1N8e2336J3794lbh8VFYXIyEidtZuIqFxq1QJ69xYXQKw8eORIYdg6c0ac5PjaNUAxnUWTJqphy8nJYM0nIiKq6XQeroyBjY0Nzp07h4yMDMTGxiI8PBze3t7o2bOn2u2nTZuG8PBw5ev09HR4eHhUUmuJiEpgYwP07SsuAJCWJpZ7V4St8+fFSY4vXwa+/VbcpkWLwrDVowfg4GC49hMREdUwRh2unJycYGpqiqSkJJX1SUlJcC1lKIyJiQkaNmwIAGjVqhUuX76MqKioEsOVVCqFVCrVWbuJiPTCzg4IDhYXAHj8WJzIWBG2Ll4ELlwQl2++EUu8t2pVWPq9e3dxH0RERKQXRl2K3cLCAm3btkVsbKxyXUFBAWJjY9GpUyeN91NQUKDyTBURUbVQuzYwaJAYpC5cAJKTgc2bgfffF4cLCgJw9izw9dfAgAHi9u3bF5aKf37CYyIiIqoQo+65AoDw8HCEhoaiXbt26NChA6Kjo5GZmYmRI0cCAEaMGIG6desiKioKgPj8VLt27eDj44OcnBzs3LkTa9euxfLlyw15GkRE+ufsDLz2mrgAQGJi4YTG+/eLz2r984+4LFgAmJqKYUsxjLBLF8DKyqCnQEREVJUZfbgKCQnBw4cPMWvWLCQmJqJVq1bYvXu3sshFQkICTEwKO+AyMzPx/vvv4+7du7C0tISfnx/WrVuHkJAQQ50CEZFhuLoCw4aJCwDcvasatuLjxVLwx48DUVGAuTkQEFAYtjp1AmQyg54CERFRVVLpkwhXBZzniohqhNu3C4PW/v3AnTuq70ulYsBShK2AAMDCwjBtJSIiMhCDTiJcHTBcEVGNIwjAzZuqYevBA9VtLC3FoYOKsNWundjbRUREVI0xXFUQwxUR1XiCAFy9Whi0DhwQC2YUVasW0K1bYdhq3RowM/rR5kRERFphuKoghisioucIAvDff4Vh6+BB4NEj1W1sbVXDlr+/WDSDiIioCmO4qiCGKyKiMhQUiPNqFQ1bqamq2zg4iHNrKcJW8+aAiVHPAEJERFQMw1UFMVwREWlJLgfOny8MW4cOFZ9Hy8kJ6NGjMGw1aSJOdExERGTEGK4qiOGKiKiC8vOBM2cKw9aRI0Bmpuo2Li5Az56FYatRI4YtIiIyOgxXFcRwRUSkY3l5wKlThWHr77+B7GzVbdzdC4NWr15AgwYMW0REZHAMVxXEcEVEpGc5OcCJE4Vh69gxIDdXdZv69VXDVv36hmkrERHVaAxXFcRwRURUyZ49EwOWImydPCn2dhXl7a06jLBuXYM0lYiIahaGqwpiuCIiMrDMTODo0cKwdeqUWDSjqEaNVHu2XFwM01YiIqrWGK4qiOGKiMjIPH0qFsVQhK0zZ8Ry8EU1aVIYtHr2FKsTEhERVRDDVQUxXBERGbnUVODw4cKwdf68ONFxUS1aFIatHj3EebeIiIi0xHBVQQxXRERVzOPH4kTGirB18aLq+xIJ0KpVYdjq1g2wszNIU4mIqGphuKoghisioiouOVk1bF25ovq+iQnQtm1h2OraFbC2NkxbiYjIqDFcVRDDFRFRNfPgAXDgQGHYun5d9X0zM6B9+8Kw1bkzYGVlkKYSEZFxYbiqIIYrIqJq7u7dwqB14AAQH6/6vrk5EBAgBq2AALGXy9XVIE0lIiLDYriqIIYrIqIa5tYt1Z6tO3eKb1O3rhiyii4MXERE1R7DVQUxXBER1WCCANy8KYasQ4eAf/4Rn9lS998lAxcRUbXHcFVBDFdERKQiIwM4dw44fVoMW6dPax642rXjBMdERFUYw1UFMVwREVGZyhu42rUT/2TgIiKqEhiuKojhioiIyoWBi4io2mG4qiCGKyIi0hlF4FKELQYuIqIqheGqghiuiIhIr8oTuBRhi4GLiKhSMVxVEMMVERFVOgYuIiKjxHBVQQxXRERkFDIygLNnC8MWAxcRUaVjuKoghisiIjJaDFxERJWK4aqCGK6IiKhK0TZwFQ1bDFxERKViuKoghisiIqrynj4tLAvPwEVEVG4MVxWk6QWUy+XIy8urxJZRdWRubg5TU1NDN4OIagIGLiIirTFcVVBZF1AQBCQmJiI1NbXyG0fVkr29PVxdXSGRSAzdFCKqabQJXPXqqYYtBi4iqgEYriqorAv44MEDpKamok6dOrCysuIPxFRugiAgKysLycnJsLe3h5ubm6GbRERUPHD98w8QF8fARUQ1EsNVBZV2AeVyOa5evYo6derA0dHRQC2k6ubRo0dITk5G48aNOUSQiIwTAxcR1VDahCuzSmpTtaF4xsrKysrALaHqRHE/5eXlMVwRkXGysQG6dRMXhZIC19274vLrr4XbMnARUQ3AcFVOHApIusT7iYiqpLIC1z//iH8ycBFRDcFwRURERLrDwEVENRjDFZWbl5cXJk2ahEmTJmm0/YEDB9CrVy88efIE9vb2emvX6tWrMWnSJFZzJCIyFroMXIry8HXqVPppEBGVheGqBihryNns2bMRERGh9X5PnTqFWrVqabx9586d8eDBA9jZ2Wl9LCIiqmZKC1yKsMXARURVDMNVDfDgwQPl1zExMZg1axbi4uKU66ytrZVfC4IAuVwOM7Oybw1nZ2et2mFhYQFXV1etPkNERDUIAxcRVXEmhm5AtSAIQGZm5S8aVtF3dXVVLnZ2dpBIJMrXV65cgY2NDXbt2oW2bdtCKpXiyJEjuHHjBl555RW4uLjA2toa7du3x759+1T26+XlhejoaOVriUSC//3vfxg0aBCsrKzQqFEj/Pbbb8r3Dxw4AIlEohyut3r1atjb2+PPP/9EkyZNYG1tjT59+qiEwfz8fEyYMAH29vZwdHTElClTEBoaioEDB2r1LVq+fDl8fHxgYWEBX19frF27tsi3T0BERATq168PqVQKd3d3TJgwQfn+t99+i0aNGkEmk8HFxQWvvfaaVscmIqIKUASuDz8E1q0DLl8G0tKAQ4eARYuAN94A/PwAiaQwbM2aBfTrJz6r5eEBDBwIfPYZsGsXkJxs6DMiomqMPVe6kJUFFOn9qTQZGYAWw/JKM3XqVCxcuBDe3t5wcHDAnTt30K9fP3z++eeQSqX46aefEBwcjLi4ONSvX7/E/URGRmL+/PlYsGABlixZgjfeeAO3b99G7dq11W6flZWFhQsXYu3atTAxMcGbb76JyZMnY/369QCAL7/8EuvXr8eqVavQpEkTLF68GNu3b0evXr00Prdt27Zh4sSJiI6ORmBgIH7//XeMHDkS9erVQ69evbBlyxZ8/fXX+Pnnn9GsWTMkJibi/PnzAIB//vkHEyZMwNq1a9G5c2c8fvwYhw8f1uLKEhGRzpXUw3X2bGHvliY9XIreLfZwEZGOMFwRAGDOnDno3bu38nXt2rXh7++vfD137lxs27YNv/32G8aNG1fifsLCwjB8+HAAwLx58/DNN9/g5MmT6NOnj9rt8/LysGLFCvj4+AAAxo0bhzlz5ijfX7JkCaZNm4ZBgwYBAJYuXYqdO3dqdW4LFy5EWFgY3n//fQBAeHg4jh8/joULF6JXr15ISEiAq6srAgMDYW5ujvr166NDhw4AgISEBNSqVQsvv/wybGxs4OnpidatW2t1fCIiqgQ2NkD37uKiwMBFRJWM4UoXrKzEXiRDHFdH2rVrp/I6IyMDERER+OOPP/DgwQPk5+fj2bNnSEhIKHU/LVu2VH5dq1Yt2NraIrmUIRhWVlbKYAUAbm5uyu3T0tKQlJSkDDoAYGpqirZt26KgoEDjc7t8+TLGjBmjsq5Lly5YvHgxAGDIkCGIjo6Gt7c3+vTpg379+iE4OBhmZmbo3bs3PD09le/16dNHOeyRiIiMHAMXEVUyhitdkEh0NjzPUJ6v+jd58mTs3bsXCxcuRMOGDWFpaYnXXnsNubm5pe7H3Nxc5bVEIik1CKnbXtDwWTJd8fDwQFxcHPbt24e9e/fi/fffx4IFC3Dw4EHY2NjgzJkzOHDgAPbs2YNZs2YhIiICp06d0ms5eSIi0hNdBK6iYYuBi4iKYLgitf7++2+EhYUph+NlZGTg1q1bldoGOzs7uLi44NSpU+j+//8JyuVynDlzBq1atdJ4P02aNMHff/+N0NBQ5bq///4bTZs2Vb62tLREcHAwgoOD8cEHH8DPzw8XLlxAmzZtYGZmhsDAQAQGBmL27Nmwt7fHX3/9hcGDB+vsXImIyIDKE7i2by/cloGLiP4fwxWp1ahRI2zduhXBwcGQSCSYOXOmVkPxdGX8+PGIiopCw4YN4efnhyVLluDJkydlzt1V1Mcff4yhQ4eidevWCAwMxI4dO7B161Zl9cPVq1dDLpcjICAAVlZWWLduHSwtLeHp6Ynff/8dN2/eRPfu3eHg4ICdO3eioKAAvr6++jplIiIyBgxcRFQODFek1qJFizBq1Ch07twZTk5OmDJlCtLT0yu9HVOmTEFiYiJGjBgBU1NTjBkzBkFBQTA1NdV4HwMHDsTixYuxcOFCTJw4EQ0aNMCqVavQs2dPAIC9vT2++OILhIeHQy6Xo0WLFtixYwccHR1hb2+PrVu3IiIiAtnZ2WjUqBE2btyIZs2a6emMiYjIaGkSuP75B7h6VX3g8vBQDVsMXETVjkSo7AdcymHZsmVYsGABEhMT4e/vjyVLlqgUOSjqhx9+wE8//YSLFy8CANq2bYt58+aVuL066enpsLOzQ1paGmxtbVXey87ORnx8PBo0aACZTFb+k6JyKSgoQJMmTTB06FDMnTvX0M3RGd5XRETVSEmBS92PXAxcREavtGzwPKPvuYqJiUF4eDhWrFiBgIAAREdHIygoCHFxcaij5h+fAwcOYPjw4ejcuTNkMhm+/PJLvPTSS7h06RLq1q1rgDOgirh9+zb27NmDHj16ICcnB0uXLkV8fDxef/11QzeNiIhIvbJ6uP75R/zz6lXgzh1xYQ8XUbVg9D1XAQEBaN++PZYuXQpA7Lnw8PDA+PHjMXXq1DI/L5fL4eDggKVLl2LEiBEaHZM9V8bjzp07GDZsGC5evAhBENC8eXN88cUXygIX1QXvKyKiGqikwMUeLiKjUm16rnJzc3H69GlMmzZNuc7ExASBgYE4duyYRvvIyspCXl4eateuXeI2OTk5yMnJUb42xLNFpJ6Hhwf+/vtvQzeDiIhI99jDRVTtGHW4SklJgVwuh4uLi8p6FxcXXLlyRaN9TJkyBe7u7ggMDCxxm6ioKERGRlaorUREREQVVlrgUoQtbQJXo0Zi5UKOiiCqFEYdrirqiy++wM8//4wDBw6UOtRq2rRpCA8PV75OT0+Hh4dHZTSRiIiIqHQVDVyA2KNVv764eHio/lm/PuDiApiYVOppEVVHRh2unJycYGpqiqSkJJX1SUlJcHV1LfWzCxcuxBdffIF9+/ahZcuWpW4rlUohlUor3F4iIiKiSqFJ4Dp3Drh1C8jKApKTxeWff9Tvz9xc7OEqGrieD2F2dpVxZkRVmlGHKwsLC7Rt2xaxsbEYOHAgALGgRWxsLMaNG1fi5+bPn4/PP/8cf/75J9q1a1dJrSUiIiIyIHWBSxCAx4+BhASxR6von4qv790D8vKA+HhxKYmtbfHAVTSM1a0L8JfVVMMZdbgCgPDwcISGhqJdu3bo0KEDoqOjkZmZiZEjRwIARowYgbp16yIqKgoA8OWXX2LWrFnYsGEDvLy8kJiYCACwtraGtbW1wc6DiIiIqNJJJICjo7i0bq1+m/x84MED1cD1fAh7/BhITwcuXRKXkri6lt77VacOhx9StWb04SokJAQPHz7ErFmzkJiYiFatWmH37t3KIhcJCQkwKfKXdPny5cjNzcVrr72msp/Zs2cjIiKiMptOREREZPzMzMTw4+EBdOmifpvMzMLnuUoKYdnZQGKiuJw6pX4/Fhbi8MPne72KhrAySl0TGTOjn+fKEDjPlXo9e/ZEq1atEB0dDQDw8vLCpEmTMGnSpBI/I5FIsG3bNuWwzvLS1X5KExERge3bt+PcuXN6O0ZJavJ9RURE1YAgACkpxQNX0TD24AFQUFD2vuzsSh566OEhDj+0sND/ORH9v2ozzxXpRnBwMPLy8rB79+5i7x0+fBjdu3fH+fPnyyz88bxTp06hVq1aumomgJIDzoMHD+Dg4KDTYxEREZGOSCSAs7O4tGmjfpu8POD+/dJ7v548AdLSgAsXxKWkY7m6ll790NlZ3I6okjFc1QCjR4/Gq6++irt376JevXoq761atQrt2rXTOlgBgLOzs66aWKayqkMSERGRkTM3Bzw9xaUkGRklF95Q/JmTI/aCPXgAnDihfj9SaeFQx5JCGJ/FJz3gE4U6IAjiUOTKXjQd0Pnyyy/D2dkZq1evVlmfkZGBzZs3Y/To0Xj06BGGDx+OunXrwsrKCi1atMDGjRtL3a+Xl5dyiCAAXLt2Dd27d4dMJkPTpk2xd+/eYp+ZMmUKGjduDCsrK3h7e2PmzJnIy8sDAKxevRqRkZE4f/48JBIJJBKJss0SiQTbi8zZceHCBbzwwguwtLSEo6MjxowZg4yMDOX7YWFhGDhwIBYuXAg3Nzc4Ojrigw8+UB5LEwUFBZgzZw7q1asHqVSqfN5PITc3F+PGjYObmxtkMhk8PT2VhVUEQUBERATq168PqVQKd3d3TJgwQeNjExER1UjW1kCTJkBQEPD228CcOcDq1UBsLHDtGvDsGZCUJD7TtXUrEB0NfPQRMGQIEBAAuLuLPVY5OcD168D+/cCaNcDcucCYMUCfPkCzZmJlRQcHwN8fCA4G3n8f+OILYP164PBh4PZtsaeNSEvsudKBrCzD/PIjIwPQZFSemZkZRowYgdWrV2P69OmQ/H83+ebNmyGXyzF8+HBkZGSgbdu2mDJlCmxtbfHHH3/grbfego+PDzp06FDmMQoKCjB48GC4uLjgxIkTSEtLU/sslo2NDVavXg13d3dcuHAB77zzDmxsbPDJJ58gJCQEFy9exO7du7Fv3z4AgJ2aOTUyMzMRFBSETp064dSpU0hOTsbbb7+NcePGqQTI/fv3w83NDfv378f169cREhKCVq1a4Z133in7ogFYvHgxvvrqK3z33Xdo3bo1Vq5ciQEDBuDSpUto1KgRvvnmG/z222/YtGkT6tevjzt37uDOnTsAgC1btuDrr7/Gzz//jGbNmiExMRHnz5/X6LhERERUAolErDhYpw5Q0nQ7ubni8MPSqh+mpQGpqeLy77/q92NiAri5ld775eTE4YekguGqhhg1ahQWLFiAgwcPomfPngDEIYGvvvoq7OzsYGdnh8mTJyu3Hz9+PP78809s2rRJo3C1b98+XLlyBX/++Sfc3d0BAPPmzUPfvn1VtpsxY4byay8vL0yePBk///wzPvnkE1haWsLa2hpmZmalDgPcsGEDsrOz8dNPPymf+Vq6dCmCg4Px5ZdfKitJOjg4YOnSpTA1NYWfnx/69++P2NhYjcPVwoULMWXKFAwbNgyAWOZ///79iI6OxrJly5CQkIBGjRqha9eukEgk8CwyzCEhIQGurq4IDAyEubk56tevr9F1JCIiogqysAC8vMSlJOnppVc/vHNHDGn37onL8ePq9yOTlVx4Q/Gnjp9PJ+PGcKUDVlZiL5IhjqspPz8/dO7cGStXrkTPnj1x/fp1HD58GHPmzAEAyOVyzJs3D5s2bcK9e/eQm5uLnJwcWGl4kMuXL8PDw0MZrACgU6dOxbaLiYnBN998gxs3biAjIwP5+fllVl1Rdyx/f3+VYhpdunRBQUEB4uLilOGqWbNmMDU1VW7j5uaGCyU9HPuc9PR03L9/H12eK0nbpUsXZQ9UWFgYevfuDV9fX/Tp0wcvv/wyXnrpJQDAkCFDEB0dDW9vb/Tp0wf9+vVDcHAwzMz4V46IiMjgbG3F4YHNmql/v6AASE4u/fmvxESx/Py1a+JSktq1S69+6O4ulsOnaoHfSR2QSKrGLyVGjx6N8ePHY9myZVi1ahV8fHzQo0cPAMCCBQuwePFiREdHo0WLFqhVqxYmTZqE3NxcnR3/2LFjeOONNxAZGYmgoCDY2dnh559/xldffaWzYxRlbm6u8loikaBAkxKwGmrTpg3i4+Oxa9cu7Nu3D0OHDkVgYCB++eUXeHh4IC4uDvv27cPevXvx/vvvK3sOn28XERERGRkTE7Eioasr0L69+m1ycsReLXVDD+/cEZ/bevpUnID58WOgpKleTEzEgFXS0EMPD3ESaA4/rBIYrmqQoUOHYuLEidiwYQN++uknjB07Vvn81d9//41XXnkFb775JgDxGaqrV6+iadOmGu27SZMmuHPnDh48eAA3NzcAwPHnutCPHj0KT09PTJ8+Xbnu9u3bKttYWFhALpeXeazVq1cjMzNT2Xv1999/w8TEBL6+vhq1tyy2trZwd3fH33//rQygiuMUHd5na2uLkJAQhISE4LXXXkOfPn3w+PFj1K5dG5aWlggODkZwcDA++OAD+Pn54cKFC2hTUolaIiIiqjqkUsDbW1xKkpZWeu/X3bti4Yy7d8Xl6FH1+7G0LL33y8NDuyFNpDcMVzWItbU1QkJCMG3aNKSnpyMsLEz5XqNGjfDLL7/g6NGjcHBwwKJFi5CUlKRxuAoMDETjxo0RGhqKBQsWID09XSVEKY6RkJCAn3/+Ge3bt8cff/yBbdu2qWzj5eWF+Ph4nDt3DvXq1YONjQ2kUqnKNm+88QZmz56N0NBQRERE4OHDhxg/fjzeeust5ZBAXfj4448xe/Zs+Pj4oFWrVli1ahXOnTuH9evXAwAWLVoENzc3tG7dGiYmJti8eTNcXV1hb2+P1atXQy6XIyAgAFZWVli3bh0sLS1VnssiIiKias7OTlyaN1f/fkGBWP2wpMIbd+6I7z97BsTFiUtJHB1Ln/vLzQ0o8rgE6QfDVQ0zevRo/Pjjj+jXr5/K81EzZszAzZs3ERQUBCsrK4wZMwYDBw5EWlqaRvs1MTHBtm3bMHr0aHTo0AFeXl745ptv0KdPH+U2AwYMwIcffohx48YhJycH/fv3x8yZMxEREaHc5tVXX8XWrVvRq1cvpKamYtWqVSohEACsrKzw559/YuLEiWjfvj2srKzw6quvYtGiRRW6Ns+bMGEC0tLS8NFHHyE5ORlNmzbFb7/9hkaNGgEQKx/Onz8f165dg6mpKdq3b4+dO3fCxMQE9vb2+OKLLxAeHg65XI4WLVpgx44dcHR01GkbiYiIqApTVCR0cxNLyauTnV04/LCkEJaRATx6JC5nz6rfj6kpULdu6dUPHRw4/LCCJIKg6WxJNUd6ejrs7OyQlpZWrNhCdnY24uPj0aBBA8hkMgO1kKob3ldERERULoIgDj8sbeLlu3eB/Pyy91WrlvpnvhRhrF49cYhiDVNaNngee66IiIiIiKoqiQSwtxeXli3VbyOXi9UNS3v+6+FDIDMTuHJFXEri7Fx675era40efshwRURERERUnSmGBNatC3TsqH6bZ8/EHq7Snv/KzBRD2MOHwJkz6vdjZiYep7S5v+ztq+3wQ4YrIiIiIqKaztISaNRIXNQRBODJk9J7v+7dE4cf3r4tLiWxti69+mG9euIEzVUQwxUREREREZVOIhEnRK5dG/D3V7+NXA48eFB671dKiliA47//xKUkdeqIx9mzRz/noycMV+XEOiCkS7yfiIiIqMozNRV7nerVK3mbrKzC4YclhbBnz4DkZHH4YRXDcKUlc3NzAEBWVhYsa2C1FNKPrKwsAIX3FxEREVG1ZGUFNG4sLuoIAvD4sRiycnMrt206wHClJVNTU9jb2yM5ORmAOOeSpJo+kEf6JwgCsrKykJycDHt7e5jW4Oo6RERERJBIxAmRq+jcoAxX5eDq6goAyoBFVFH29vbK+4qIiIiIqiaGq3KQSCRwc3NDnTp1kJeXZ+jmUBVnbm7OHisiIiKiaoDhqgJMTU35QzEREREREQEATAzdACIiIiIiouqA4YqIiIiIiEgHGK6IiIiIiIh0gM9cqaGY0DU9Pd3ALSEiIiIiIkNSZAJFRigNw5UaT58+BQB4eHgYuCVERERERGQMnj59Cjs7u1K3kQiaRLAapqCgAPfv34eNjY3BJwhOT0+Hh4cH7ty5A1tbW4O2pTri9dUvXl/94vXVP15j/eL11S9eX/3i9dUvY7q+giDg6dOncHd3h4lJ6U9VsedKDRMTE9SrV8/QzVBha2tr8BurOuP11S9eX/3i9dU/XmP94vXVL15f/eL11S9jub5l9VgpsKAFERERERGRDjBcERERERER6QDDlZGTSqWYPXs2pFKpoZtSLfH66hevr37x+uofr7F+8frqF6+vfvH66ldVvb4saEFERERERKQD7LkiIiIiIiLSAYYrIiIiIiIiHWC4IiIiIiIi0gGGKyIiIiIiIh1guDKwQ4cOITg4GO7u7pBIJNi+fXuZnzlw4ADatGkDqVSKhg0bYvXq1XpvZ1Wl7fU9cOAAJBJJsSUxMbFyGlyFREVFoX379rCxsUGdOnUwcOBAxMXFlfm5zZs3w8/PDzKZDC1atMDOnTsrobVVU3mu8erVq4vdvzKZrJJaXLUsX74cLVu2VE5Q2alTJ+zatavUz/D+1Zy215f3bvl98cUXkEgkmDRpUqnb8f4tH02uL+9f7URERBS7Xn5+fqV+pqrcvwxXBpaZmQl/f38sW7ZMo+3j4+PRv39/9OrVC+fOncOkSZPw9ttv488//9RzS6smba+vQlxcHB48eKBc6tSpo6cWVl0HDx7EBx98gOPHj2Pv3r3Iy8vDSy+9hMzMzBI/c/ToUQwfPhyjR4/G2bNnMXDgQAwcOBAXL16sxJZXHeW5xoA4m33R+/f27duV1OKqpV69evjiiy9w+vRp/PPPP3jhhRfwyiuv4NKlS2q35/2rHW2vL8B7tzxOnTqF7777Di1btix1O96/5aPp9QV4/2qrWbNmKtfryJEjJW5bpe5fgYwGAGHbtm2lbvPJJ58IzZo1U1kXEhIiBAUF6bFl1YMm13f//v0CAOHJkyeV0qbqJDk5WQAgHDx4sMRthg4dKvTv319lXUBAgPDuu+/qu3nVgibXeNWqVYKdnV3lNaqacXBwEP73v/+pfY/3b8WVdn1572rv6dOnQqNGjYS9e/cKPXr0ECZOnFjitrx/tafN9eX9q53Zs2cL/v7+Gm9fle5f9lxVMceOHUNgYKDKuqCgIBw7dsxALaqeWrVqBTc3N/Tu3Rt///23oZtTJaSlpQEAateuXeI2vH8rRpNrDAAZGRnw9PSEh4dHmT0FJJLL5fj555+RmZmJTp06qd2G92/5aXJ9Ad672vrggw/Qv3//YvelOrx/tafN9QV4/2rr2rVrcHd3h7e3N9544w0kJCSUuG1Vun/NDN0A0k5iYiJcXFxU1rm4uCA9PR3Pnj2DpaWlgVpWPbi5uWHFihVo164dcnJy8L///Q89e/bEiRMn0KZNG0M3z2gVFBRg0qRJ6NKlC5o3b17idiXdv3ymrWyaXmNfX1+sXLkSLVu2RFpaGhYuXIjOnTvj0qVLqFevXiW2uGq4cOECOnXqhOzsbFhbW2Pbtm1o2rSp2m15/2pPm+vLe1c7P//8M86cOYNTp05ptD3vX+1oe315/2onICAAq1evhq+vLx48eIDIyEh069YNFy9ehI2NTbHtq9L9y3BFVISvry98fX2Vrzt37owbN27g66+/xtq1aw3YMuP2wQcf4OLFi6WOl6aK0fQad+rUSaVnoHPnzmjSpAm+++47zJ07V9/NrHJ8fX1x7tw5pKWl4ZdffkFoaCgOHjxYYgAg7WhzfXnvau7OnTuYOHEi9u7dy6IJelCe68v7Vzt9+/ZVft2yZUsEBATA09MTmzZtwujRow3YsopjuKpiXF1dkZSUpLIuKSkJtra27LXSkw4dOjA0lGLcuHH4/fffcejQoTJ/O1fS/evq6qrPJlZ52lzj55mbm6N169a4fv26nlpXtVlYWKBhw4YAgLZt2+LUqVNYvHgxvvvuu2Lb8v7VnjbX93m8d0t2+vRpJCcnq4yokMvlOHToEJYuXYqcnByYmpqqfIb3r+bKc32fx/tXO/b29mjcuHGJ16sq3b985qqK6dSpE2JjY1XW7d27t9Qx7FQx586dg5ubm6GbYXQEQcC4ceOwbds2/PXXX2jQoEGZn+H9q53yXOPnyeVyXLhwgfewhgoKCpCTk6P2Pd6/FVfa9X0e792Svfjii7hw4QLOnTunXNq1a4c33ngD586dU/uDP+9fzZXn+j6P9692MjIycOPGjRKvV5W6fw1dUaOme/r0qXD27Fnh7NmzAgBh0aJFwtmzZ4Xbt28LgiAIU6dOFd566y3l9jdv3hSsrKyEjz/+WLh8+bKwbNkywdTUVNi9e7ehTsGoaXt9v/76a2H79u3CtWvXhAsXLggTJ04UTExMhH379hnqFIzW2LFjBTs7O+HAgQPCgwcPlEtWVpZym7feekuYOnWq8vXff/8tmJmZCQsXLhQuX74szJ49WzA3NxcuXLhgiFMweuW5xpGRkcKff/4p3LhxQzh9+rQwbNgwQSaTCZcuXTLEKRi1qVOnCgcPHhTi4+OFf//9V5g6daogkUiEPXv2CILA+7eitL2+vHcr5vlqdrx/daus68v7VzsfffSRcODAASE+Pl74+++/hcDAQMHJyUlITk4WBKFq378MVwamKP39/BIaGioIgiCEhoYKPXr0KPaZVq1aCRYWFoK3t7ewatWqSm93VaHt9f3yyy8FHx8fQSaTCbVr1xZ69uwp/PXXX4ZpvJFTd10BqNyPPXr0UF5rhU2bNgmNGzcWLCwshGbNmgl//PFH5TbcwEJDQwVPT0+Nti3PNZ40aZJQv359wcLCQnBxcRH69esnnDlzRrcnoUfx8fHFzlFfRo0aJXh6egoWFhaCnZ2dAEBYsGCB8n0XFxehVq1aKp9Rd//qq82enp7F/v5UJUWvr7Ozs/Diiy8qg5UgVL9719Ce/+Gf//7qVlnXl/evdkJCQgQ3NzfBwsJCqFu3rhASEiJcv35d+X5Vvn8lgiAIldRJRkRktCQSiUbb7d+/Hz179iz3ccLCwnDgwAHcunVL689GREQgMjIS1fmf7Vu3bqFBgwZYtWoVwsLCKu24Bw4cQK9evVS+v5p+ryrS5qNHj2LPnj2YNGkS7O3tVd7z8vJCz549sXr1aq32SUREhsOCFkREQLFqkD/99BP27t1bbH2TJk0qdJwffvgBBQUF5frsjBkzMHXq1AodnzRXke+Vpo4ePYrIyEiEhYUVC1dxcXEwMeGj0UREVQnDFRERgDfffFPl9fHjx7F3795i65+XlZUFKysrjY9jbm5ervYBgJmZGczM+M92ZanI90oXpFKpQY9fVWRmZqJWrVqGbgYREQBWCyQi0ljPnj3RvHlznD59Gt27d4eVlRU+/fRTAMCvv/6K/v37w93dHVKpFD4+Ppg7dy7kcrnKPsLCwuDl5aV8fevWLUgkEixcuBDff/89fHx8IJVK0b59+2KTV0ZERBQbviiRSDBu3Dhs374dzZs3h1QqRbNmzbB79+5i7T9w4ADatWsHmUwGHx8ffPfdd2r3qc7hw4cxZMgQ1K9fH1KpFB4eHvjwww/x7NmzYudnbW2Ne/fuYeDAgbC2toazszMmT55c7FqkpqYiLCwMdnZ2sLe3R2hoKFJTU8tsyz///AOJRII1a9YUe+/PP/+ERCLB77//DgC4ffs23n//ffj6+sLS0hKOjo4YMmSIRsMyn/9eadPmf//9F2FhYfD29oZMJoOrqytGjRqFR48eKbeJiIjAxx9/DABo0KABJBIJJBKJsm1eXl7FhhnevHkTQ4YMQe3atWFlZYWOHTvijz/+UNnmwIEDkEgk2LRpEz7//HPUq1cPMpkML774okZlobW5Zqmpqfjwww/h5eUFqVSKevXqYcSIEUhJSVFuk52djYiICDRu3BgymQxubm4YPHgwbty4odLeAwcOqOxb8Xej6LBIxf1148YN9OvXDzY2NnjjjTcAaH6PAsCVK1cwdOhQODs7w9LSEr6+vpg+fToAceivRCLBtm3bin1uw4YNkEgkOHbsWJnXkYhqJv4KlIhIC48ePULfvn0xbNgwvPnmm8oZ41evXg1ra2uEh4fD2toaf/31F2bNmoX09HQsWLCgzP1u2LABT58+xbvvvguJRIL58+dj8ODBuHnzZpk9KEeOHMHWrVvx/vvvw8bGBt988w1effVVJCQkwNHREQBw9uxZ9OnTB25uboiMjIRcLsecOXPg7Oys0Xlv3rwZWVlZGDt2LBwdHXHy5EksWbIEd+/exebNm1W2lcvlCAoKQkBAABYuXIh9+/bhq6++go+PD8aOHQtALDP/yiuv4MiRI3jvvffQpEkTbNu2DaGhoWW2pV27dvD29samTZuKbR8TEwMHBwcEBQUBAE6dOoWjR49i2LBhqFevHm7duoXly5ejZ8+e+O+//7TqddSmzXv37sXNmzcxcuRIuLq64tKlS/j+++9x6dIlHD9+HBKJBIMHD8bVq1exceNGfP3113BycgKAEr8nSUlJ6Ny5M7KysjBhwgQ4OjpizZo1GDBgAH755RcMGjRIZfsvvvgCJiYmmDx5MtLS0jB//ny88cYbOHHiRKnnqek1y8jIQLdu3XD58mWMGjUKbdq0QUpKCn777TfcvXsXTk5OkMvlePnllxEbG4thw4Zh4sSJePr0Kfbu3YuLFy/Cx8dH4+uvkJ+fj6CgIHTt2hULFy5UtkfTe/Tff/9Ft27dYG5ujjFjxsDLyws3btzAjh078Pnnn6Nnz57w8PDA+vXri13T9evXw8fHxzjLPxORcTBoOQ0iIiP1wQcfCM//E9mjRw8BgLBixYpi2xctj67w7rvvClZWVkJ2drZy3fPVAhWV5hwdHYXHjx8r1//6668CAGHHjh3KdbNnzy7WJgCChYWFSpWl8+fPCwCEJUuWKNcFBwcLVlZWwr1795Trrl27JpiZmRXbpzrqzi8qKkqQSCTKqQ0U5wdAmDNnjsq2rVu3Ftq2bat8vX37dgGAMH/+fOW6/Px8oVu3bhpV3ps2bZpgbm6ucs1ycnIEe3t7YdSoUaW2+9ixYwIA4aefflKuU1QW3b9/v8q5FP1eadNmdcfduHGjAEA4dOiQct2CBQsEAEJ8fHyx7Z+vFjhp0iQBgHD48GHluqdPnwoNGjQQvLy8BLlcrnIuTZo0EXJycpTbLl68WABQZuliTa/ZrFmzBADC1q1bi21fUFAgCIIgrFy5UjkNRknbqLv2gqC+cqTi/ipaorm0dqu7R7t37y7Y2NiorCvaHkEQ7y+pVCqkpqYq1yUnJwtmZmbC7Nmzix2HiEiBwwKJiLQglUoxcuTIYustLS2VXz99+hQpKSno1q0bsrKycOXKlTL3GxISAgcHB+Xrbt26ARCHgZUlMDBQpQegZcuWsLW1VX5WLpdj3759GDhwINzd3ZXbNWzYEH379i1z/4Dq+WVmZiIlJQWdO3eGIAg4e/Zsse3fe+89ldfdunVTOZedO3fCzMxM2ZMFAKamphg/frxG7QkJCUFeXh62bt2qXLdnzx6kpqYiJCREbbvz8vLw6NEjNGzYEPb29jhz5oxGxypPm4seNzs7GykpKejYsSMAaH3cosfv0KEDunbtqlxnbW2NMWPG4NatW/jvv/9Uth85ciQsLCyUrzW9pzS9Zlu2bIG/v3+x3h2gsPrmli1b4OTkpPYaaVqhU52i3wN17S7pHn348CEOHTqEUaNGoX79+iW2Z8SIEcjJycEvv/yiXBcTE4P8/Pwyn8MkopqN4YqISAt169ZV+YFV4dKlSxg0aBDs7Oxga2sLZ2dn5Q9haWlpZe73+R/0FEHryZMnWn9W8XnFZ5OTk/Hs2TM0bNiw2Hbq1qmTkJCAsLAw1K5dW/kcVY8ePQAUPz+ZTFZsaFvR9gDicz1ubm6wtrZW2c7X11ej9vj7+8PPzw8xMTHKdTExMXBycsILL7ygXPfs2TPMmjULHh4ekEqlcHJygrOzM1JTUzX6vhSlTZsfP36MiRMnwsXFBZaWlnB2dkaDBg0AaHY/lHR8dcdSVLC8ffu2yvry3lOaXrMbN26gefPmpe7rxo0b8PX11WkhFjMzM9SrV6/Yek3uUUWwLKvdfn5+aN++PdavX69ct379enTs2FHjvzNEVDPxmSsiIi0U/e24QmpqKnr06AFbW1vMmTMHPj4+kMlkOHPmDKZMmaJROW9TU1O16wUN5rSqyGc1IZfL0bt3bzx+/BhTpkyBn58fatWqhXv37iEsLKzY+ZXUHl0LCQnB559/jpSUFNjY2OC3337D8OHDVX6QHz9+PFatWoVJkyahU6dOsLOzg0QiwbBhw/RaZn3o0KE4evQoPv74Y7Rq1QrW1tYoKChAnz599F7eXaG890VlX7OSerCeL4CiIJVKi5Wo1/Ye1cSIESMwceJE3L17Fzk5OTh+/DiWLl2q9X6IqGZhuCIiqqADBw7g0aNH2Lp1K7p3765cHx8fb8BWFapTpw5kMpnaSnGaVI+7cOECrl69ijVr1mDEiBHK9Xv37i13mzw9PREbG4uMjAyVnqC4uDiN9xESEoLIyEhs2bIFLi4uSE9Px7Bhw1S2+eWXXxAaGoqvvvpKuS47O1ujqoTlbfOTJ08QGxuLyMhIzJo1S7n+2rVrxfapzdA4T09PtddHMezU09NT432VRtNr5uPjg4sXL5a6Lx8fH5w4cQJ5eXklFmZR9Kg9v//ne+JKo+k96u3tDQBlthsAhg0bhvDwcGzcuBHPnj2Dubm5ypBTIiJ1OCyQiKiCFD0ERXsEcnNz8e233xqqSSpMTU0RGBiI7du34/79+8r1169fx65duzT6PKB6foIgYPHixeVuU79+/ZCfn4/ly5cr18nlcixZskTjfTRp0gQtWrRATEwMYmJi4ObmphJuFW1/vqdmyZIlJfaK6KLN6q4XAERHRxfbp2J+Jk3CXr9+/XDy5EmVMuCZmZn4/vvv4eXlhaZNm2p6KqXS9Jq9+uqrOH/+vNqS5YrPv/rqq0hJSVHb46PYxtPTE6ampjh06JDK+9r8/dH0HnV2dkb37t2xcuVKJCQkqG2PgpOTE/r27Yt169Zh/fr16NOnj7KiIxFRSdhzRURUQZ07d4aDgwNCQ0MxYcIESCQSrF27VmfD8nQhIiICe/bsQZcuXTB27FjI5XIsXboUzZs3x7lz50r9rJ+fH3x8fDB58mTcu3cPtra22LJli0bPg5UkODgYXbp0wdSpU3Hr1i00bdoUW7du1fp5pJCQEMyaNQsymQyjR48uNlzs5Zdfxtq1a2FnZ4emTZvi2LFj2Ldvn7JEvT7abGtri+7du2P+/PnIy8tD3bp1sWfPHrU9mW3btgUATJ8+HcOGDYO5uTmCg4PVToo7depUbNy4EX379sWECRNQu3ZtrFmzBvHx8diyZUuxcy8vTa/Zxx9/jF9++QVDhgzBqFGj0LZtWzx+/Bi//fYbVqxYAX9/f4wYMQI//fQTwsPDcfLkSXTr1g2ZmZnYt28f3n//fbzyyiuws7PDkCFDsGTJEkgkEvj4+OD3339HcnKyxm3W5h795ptv0LVrV7Rp0wZjxoxBgwYNcOvWLfzxxx/F/i6MGDECr732GgBg7ty52l9MIqpxGK6IiCrI0dERv//+Oz766CPMmDEDDg4OePPNN/Hiiy8q51sytLZt22LXrl2YPHkyZs6cCQ8PD8yZMweXL18us5qhubk5duzYgQkTJiAqKgoymQyDBg3CuHHj4O/vX672mJiY4LfffsOkSZOwbt06SCQSDBgwAF999RVat26t8X5CQkIwY8YMZGVlqR2ytXjxYpiammL9+vXIzs5Gly5dsG/fvnJ9X7Rp84YNGzB+/HgsW7YMgiDgpZdewq5du1SqNQJA+/btMXfuXKxYsQK7d+9GQUEB4uPj1YYrFxcXHD16FFOmTMGSJUuQnZ2Nli1bYseOHejfv7/W51MSTa+ZtbU1Dh8+jNmzZ2Pbtm1Ys2YN6tSpgxdffFFZcMLU1BQ7d+7E559/jg0bNmDLli1wdHRE165d0aJFC+W+lixZgry8PKxYsQJSqRRDhw7FggULyiw8oaDNPerv74/jx49j5syZWL58ObKzs+Hp6YmhQ4cW229wcDAcHBxQUFCAAQMGaHspiagGkgjG9KtVIiKqVAMHDsSlS5fUPg9EVNPl5+fD3d0dwcHB+PHHHw3dHCKqAvjMFRFRDfHs2TOV19euXcPOnTvRs2dPwzSIyMht374dDx8+VCmSQURUGvZcERHVEG5ubggLC4O3tzdu376N5cuXIycnB2fPnkWjRo0M3Twio3HixAn8+++/mDt3LpycnMo98TMR1Tx85oqIqIbo06cPNm7ciMTEREilUnTq1Anz5s1jsCJ6zvLly7Fu3Tq0atUKq1evNnRziKgKYc8VERERERGRDvCZKyIiIiIiIh0weLhatmwZvLy8IJPJEBAQgJMnT5a4bV5eHubMmQMfHx/IZDL4+/tj9+7dKttERERAIpGoLH5+fvo+DSIiIiIiquEM+sxVTEwMwsPDsWLFCgQEBCA6OhpBQUGIi4tDnTp1im0/Y8YMrFu3Dj/88AP8/Pzw559/YtCgQTh69KjKHCPNmjXDvn37lK/NzLQ7zYKCAty/fx82NjaQSCTlP0EiIiIiIqrSBEHA06dP4e7uXvaE7YIBdejQQfjggw+Ur+VyueDu7i5ERUWp3d7NzU1YunSpyrrBgwcLb7zxhvL17NmzBX9//wq1686dOwIALly4cOHChQsXLly4cBEACHfu3CkzRxis5yo3NxenT5/GtGnTlOtMTEwQGBiIY8eOqf1MTk4OZDKZyjpLS0scOXJEZd21a9fg7u4OmUyGTp06ISoqCvXr1y+xLTk5OcjJyVG+Fv6/xsedO3dga2ur9bkREREREVH1kJ6eDg8PD9jY2JS5rcHCVUpKCuRyOVxcXFTWu7i44MqVK2o/ExQUhEWLFqF79+7w8fFBbGwstm7dCrlcrtwmICAAq1evhq+vLx48eIDIyEh069YNFy9eLPGCREVFITIysth6W1tbhisiIiIiItLocSGDF7TQxuLFi9GoUSP4+fnBwsIC48aNw8iRI1XGPvbt2xdDhgxBy5YtERQUhJ07dyI1NRWbNm0qcb/Tpk1DWlqacrlz505lnA4REREREVUjBgtXTk5OMDU1RVJSksr6pKQkuLq6qv2Ms7Mztm/fjszMTNy+fRtXrlyBtbU1vL29SzyOvb09GjdujOvXr5e4jVQqVfZSsbeKiIiIiIjKw2DhysLCAm3btkVsbKxyXUFBAWJjY9GpU6dSPyuTyVC3bl3k5+djy5YteOWVV0rcNiMjAzdu3ICbm5vO2k5ERERERPQ8gw4LDA8Pxw8//IA1a9bg8uXLGDt2LDIzMzFy5EgAwIgRI1QKXpw4cQJbt27FzZs3cfjwYfTp0wcFBQX45JNPlNtMnjwZBw8exK1bt3D06FEMGjQIpqamGD58eKWfHxERERER1RwGnecqJCQEDx8+xKxZs5CYmIhWrVph9+7dyiIXCQkJKs9TZWdnY8aMGbh58yasra3Rr18/rF27Fvb29spt7t69i+HDh+PRo0dwdnZG165dcfz4cTg7O1f26RERERERUQ0iERR1x0kpPT0ddnZ2SEtL4/NXRERERES6JAhAWhqQnCwuSUmFXxdd3NyAn382dGu1ygYG7bkiIiIiIqJqIDsbePiw5KD0/JKXV/Y+GzTQf7t1jOGKiIiIiIhUFRQAjx5pFpSSk4H0dO2PYWsL1KkDuLiIfz6/uLvr/rz0jOGKiIiIiKgmyMjQPCw9fCgGLG2Ym5celoouzs6ATKaf8zQghisiIiIioqooLw9ISdE8MGVlaX8MR8eyg5JisbMDJBLdn2cVwnBFRERERGQMni/0UNqSlAQ8fqz9MSwtNetZqlMHcHISe6NIYwxXRERERET6oij0oElY0rTQQ1EmJuIQO017l6yt9XOeBIDhioiIiIhIcwUFYo+RJkGpooUeylpcXAAHB8DUVPfnSeXCcEVERERENVtmpuZhKSUFkMu127+i0ENZQakaF3qoKRiuiIiIiKh6yc8vudCDunmYylPooXZtzcISCz3UKAxXRERERGTcBEEcXqdJUEpOFudn0pZMVnKhh+fXs9ADlYDhioiIiIgqX05O8UIPJYWl5GQgN1e7/ZuYiCFIk7BUpw5QqxZ7l6jCGK6IiIiIqOIKCoAnTzQPS2lp2h/DxkbzsFS7Ngs9UKVjuCIiIiIi9bKyNAtKycliL5S2hR7MzDQLSopCD5aW+jlPIh1huCIiIiKqKfLzxeeRNAlLycliFT1tOThoFpbq1AHs7TkUj6oVhisiIiKi6iIzE7h4EbhwQfzzwYPihR4EQbt9ymSaBSVFoQcLC/2cG1EVwHBFREREVNUUFADx8cC//6ouN26UHZ4kEjEElRWUFIu1NXuXiDTEcEVERERkzFJTxZ6ooiHqwoWSh+y5ugItWwItWgD16xcPS46OLPRApCcMV0RERETGID8fuHq1MDwpglRCgvrtpVKgWTMxSCmWFi3EAEVEBsFwRURERFTZkpOLD+n77z9x7id16tdXDVEtWwKNGonV9ojIaPBvJBEREZG+5OQAly8XD1JJSeq3t7YWe5+KhqjmzcWqekRk9BiuiIiIiCpKEIC7d4s/G3Xlivq5nyQSoGHD4r1RXl6AiUmlN5+IdIPhioiIiEgbinLnz/dGpaaq397BoXiIatYMqFWrUptNRPrHcEVERESkjrblzs3MAD+/4gUm6tZlKXOiGoLhioiIiOjJE3FIX9FhfZqUOy+6+PmJFfyIqMZiuCIiIqKao2i586LLnTvqt2e5cyLSAsMVERERVU/aljv39CzeG9WwIcudE5HG+K8FERERVW0sd05ERoLhioiIiKoGRbnz50NUXBzLnRORUWC4IiIiIuNTnnLn/v6qz0Wx3DkRVTKGKyIiIjKcggLg5s3ik+9qU+68ZUvA3Z3lzonI4BiuiIiIqHIoyp0XDVEXL7LcORFVGwxXREREpFvlKXfevHnxcufOzpXbbiKiCmK4IiIiovJjuXMiIiX+S0ZERERly84uXu78wgWWOyciKoLhioiIiAqVp9x5o0aqw/lY7pyIaiiGKyIiopoqIwO4dKn85c5btgSaNmW5cyKi/8dwRUREVN0pyp0/H6Ju3mS5cyIiHWK4IiIiqk60LXfu5lZ8SB/LnRMRlYvBw9WyZcuwYMECJCYmwt/fH0uWLEGHDh3UbpuXl4eoqCisWbMG9+7dg6+vL7788kv06dOn3PskIiKqkrQtdy6TAc2asdw5EZEeGTRcxcTEIDw8HCtWrEBAQACio6MRFBSEuLg41KlTp9j2M2bMwLp16/DDDz/Az88Pf/75JwYNGoSjR4+idevW5donERGR0UtKKl6l79IlIDdX/fYsd05EZBASQVA32LpyBAQEoH379li6dCkAoKCgAB4eHhg/fjymTp1abHt3d3dMnz4dH3zwgXLdq6++CktLS6xbt65c+1QnPT0ddnZ2SEtLg62tbUVPk4iISDPqyp3/+684l5Q61tbFh/S1aAHY2VVuu4mIqjFtsoHBfoWVm5uL06dPY9q0acp1JiYmCAwMxLFjx9R+JicnBzKZTGWdpaUljhw5Uu59KvabU2Syw/T09HKdExERkUYqWu5csXh6stw5EZERMVi4SklJgVwuh4uLi8p6FxcXXLlyRe1ngoKCsGjRInTv3h0+Pj6IjY3F1q1bIf///4jKs08AiIqKQmRkZAXPiIiISI2MDLGgxPPD+koqd167dvEQ1awZYGVVqc0mIiLtVanB14sXL8Y777wDPz8/SCQS+Pj4YOTIkVi5cmWF9jtt2jSEh4crX6enp8PDw6OizSUiopqkpHLnN26o397MDGjSpHA4H8udExFVeQYLV05OTjA1NUVSUpLK+qSkJLi6uqr9jLOzM7Zv347s7Gw8evQI7u7umDp1Kry9vcu9TwCQSqWQsuQsERFpSl258wsXgKws9dsXLXeuWPz8AAuLym03ERHplcHClYWFBdq2bYvY2FgMHDgQgFh8IjY2FuPGjSv1szKZDHXr1kVeXh62bNmCoUOHVnifRERExeTlqZY7VwQqljsnIiI1DDosMDw8HKGhoWjXrh06dOiA6OhoZGZmYuTIkQCAESNGoG7duoiKigIAnDhxAvfu3UOrVq1w7949REREoKCgAJ988onG+yQiIirR3bvAsWPicvw4cOYMUKTgkQovL9UqfSx3TkRU4xn0f4CQkBA8fPgQs2bNQmJiIlq1aoXdu3crC1IkJCTApEgVpOzsbMyYMQM3b96EtbU1+vXrh7Vr18Le3l7jfRIREQEQy56fOVMYpI4dA+7dK75d0XLniqV5c5Y7JyKiYgw6z5Wx4jxXRETVjCAACQmqQersWXHYX1GmpoC/P9CxI9CpExAQAPj4sNw5EVENViXmuSIiItKbZ8+Af/5RDVOJicW3q1NHDFGdOomBql07oFatym8vERFVCwxXRERUtQkCEB+vGqTOnwfy81W3MzMDWrUqDFKdOonPTbHsORER6QjDFRERVS2ZmcCpU4VB6vhxIDm5+HZubqpBqm1bwNKy8ttLREQ1BsMVEREZL0EArl9XDVL//gvI5arbmZsDbdqohikPD/ZKERFRpWK4IiIi4/H0qdgrpQhSx48DKSnFt6tXTzVItW4tzjFFRERkQAxXRERkGAUFwLVrqvNKXbwori9KKhWH9CmCVMeOYrgiIiIyMgxXRERUOdLSgJMnVXulnjwpvp2nZ2GQ6tRJLI0ulVZ+e4mIiLTEcEVERLpXUABcuaJawe+//8RnqIqSycTy50XLobu5GabNREREFcRwRUREFffkCXDiRGGQOnFC7Kl6XoMGqkHK318sRkFERFQNMFwREZF25HKxF0oRpI4dE3upnmdlBbRvXxikOnYEXFwqv71ERESVhOGKiIhK9+hR4TNSx46Jz009fVp8u4YNVXulWrQQJ+4lIiKqIfi/HhERFcrPFyv2FZ1X6urV4ttZWwMdOqj2Sjk5VX57iYiIjAjDFRFRTfbwoWqQOnkSyMwsvp2vr+q8Us2aAaamld9eIiIiI8ZwRURUU+TlARcuqM4rdeNG8e1sbYGAgMIgFRAA1K5d+e0lIiKqYhiuiIiqq6Qk1SB16hTw7Fnx7Zo2VZ2gt0kT9koRERGVA8MVEVF1kJsLnD+vOq/UrVvFt7O3F3uiFIUnOnQQ1xEREVGFMVwREVVF9++rBqnTp4HsbNVtJBKgeXPVXilfX8DExDBtJiIiquYYroiIjF1ODnD2rGrhiYSE4tvVrq0apDp0EJ+fIiIiokqhdbjy8vLCqFGjEBYWhvr16+ujTURENdudO6oT9J45Iw77K8rERJxHqmgFv0aNxN4qIiIiMgitw9WkSZOwevVqzJkzB7169cLo0aMxaNAgSKVSfbSPiKh6y84Ww1PRwhP37hXfzslJdYLe9u3FuaaIiIjIaEgEQRDK88EzZ85g9erV2LhxI+RyOV5//XWMGjUKbdq00XUbK116ejrs7OyQlpYGWw6pISJdEQTg9m3V4X1nz4ol0osyNQX8/VV7pby92StFRERkANpkg3KHK4W8vDx8++23mDJlCvLy8tCiRQtMmDABI0eOhKSK/iDAcEVEOpGVJRaaKFp4IjGx+HYuLqpBqm1boFatym8vERERFaNNNih3QYu8vDxs27YNq1atwt69e9GxY0eMHj0ad+/exaeffop9+/Zhw4YN5d09EVHVIghAfLxqkDp/HsjPV93OzAxo3Vq18ISXF3uliIiIqgGtw9WZM2ewatUqbNy4ESYmJhgxYgS+/vpr+Pn5KbcZNGgQ2rdvr9OGEhEZlcxMcVLeokP8kpOLb+fmVvisVKdOQJs2gKVl5beXiIiI9E7rcNW+fXv07t0by5cvx8CBA2Fubl5smwYNGmDYsGE6aSARkcEJAnD9umqv1IULgFyuup2FhRieivZKeXiwV4qIiKiG0Dpc3bx5E56enqVuU6tWLaxatarcjSIiMqinT4GTJ1V7pR49Kr6dh4dqkGrdGpDJKr+9REREZBS0DlfJyclITExEQECAyvoTJ07A1NQU7dq101njiIj0rqAAuHpVNUhdvCiuL0oqFQtNFC08UbeuYdpMRERERknrcPXBBx/gk08+KRau7t27hy+//BInTpzQWeOIiHQuLU3slVLMK3XiBPDkSfHtPD1Vg1SrVuKwPyIiIqISaB2u/vvvP7VzWbVu3Rr//fefThpFRKQTBQXAlSuqE/T+95/4DFVRlpZAu3aqQ/zc3AzTZiIiIqqytA5XUqkUSUlJ8Pb2Vln/4MEDmJmVu7I7EVHFPXki9kQpgtSJE2JP1fO8vVV7pVq2BNQU5yEiIiLShtZp6KWXXsK0adPw66+/ws7ODgCQmpqKTz/9FL1799Z5A4mI1JLLxV6oohX8rlwpvp2VFdChg2qvVJ06ld9eIiIiqva0DlcLFy5E9+7d4enpidatWwMAzp07BxcXF6xdu1bnDSQiAiBW6zt+vDBInTwpVvV7XqNGhUGqUyegeXNx4l4iIiIiPdP6J466devi33//xfr163H+/HlYWlpi5MiRGD58uNo5r4iItJafL1bsUwSpY8eAa9eKb2dtLfZKKYJUQADg5FT57SUiIiJCOcIVIM5jNWbMGF23hYhqqocPVYf3nToFZGYW387XtzBIdewINGsGmJpWfnuJiIiI1Cj3WJn//vsPCQkJyM3NVVk/YMCACjeKiKqxvDzg339V55W6caP4dra2Yk+UIkgFBAC1a1d+e4mIiIg0pHW4unnzJgYNGoQLFy5AIpFA+P+SxhKJBAAgl8t120IiqtoSE1WD1KlTwLNnxbdr2lS1gl+TJoCJSeW3l4iIiKictA5XEydORIMGDRAbG4sGDRrg5MmTePToET766CMsXLhQH20koqro1i3gww+B7duLv2dvr1q9r0MHcR0RERFRFaZ1uDp27Bj++usvODk5wcTEBCYmJujatSuioqIwYcIEnD17Vh/tJKKqIjsbmD8fiIoSv5ZIxIp9RSv4NW7MXikiIqIaSBDE2VQUS36+6p9FvzY1BTw9Dd1i7WgdruRyOWxsbAAATk5OuH//Pnx9feHp6Ym4uDitG7Bs2TIsWLAAiYmJ8Pf3x5IlS9ChQ4cSt4+Ojsby5cuRkJAAJycnvPbaa4iKioJMJgMAREREIDIyUuUzvr6+uKJu/hsi0q3ffwcmTgRu3hRf9+oFLFkiFp4gqkSCABQUFC5yufqvNXktkYi/C9DVIpGICxFVH0UDQ2lhQRfrqvp+Cwo0v65NmohTWlYlWoer5s2b4/z582jQoAECAgIwf/58WFhY4Pvvv4e3t7dW+4qJiUF4eDhWrFiBgIAAREdHIygoCHFxcaijZpLPDRs2YOrUqVi5ciU6d+6Mq1evIiwsDBKJBIsWLVJu16xZM+zbt6/wJDnHDZF+3bgBTJokhisAcHcHFi0Chg6tsj9FavPDd3l/cK+M/dSUYz7/3v8/Dmy0dB3YuFTOoqvvW1X5Z1ERGIz1h3Rj2q82gYFKJpGIU1Oamop/WlkZukXa0zp1zJgxA5n/XyJ5zpw5ePnll9GtWzc4OjoiJiZGq30tWrQI77zzDkaOHAkAWLFiBf744w+sXLkSU6dOLbb90aNH0aVLF7z++usAAC8vLwwfPhwnTpxQPSkzM7i6ump7akSkpYKMLKRFRuPJN2vxOLcWnpgE4cnLb+HJi6/i8U0ZnkwB0tML/zOqSj+4U81hYiL+R170h1/Fa8UPwUXvDXWLtmGu6G+5qWaqrECouM/KEyr4b6FuKP5NUYSGol/rYl112m9V+cVDabQOV0FBQcqvGzZsiCtXruDx48dwcHBQVgzURG5uLk6fPo1p06Yp15mYmCAwMBDHjh1T+5nOnTtj3bp1OHnyJDp06ICbN29i586deOutt1S2u3btGtzd3SGTydCpUydERUWhfv36JbYlJycHOTk5ytfp6ekanwdRVScIQEYG8OQJ8Pix+GfZXwt4kpyH1AwZBHwK4FNxZwUAfvv/pYZQ9wO5Jq+NYVtjbFNlb6ur/8gFofhQxJq01ORzVyzaKu/njMXzgcHYfkg3pv1Wh8BAmtMqXOXl5cHS0hLnzp1D8+bNletrl2PumZSUFMjlcri4uKisd3FxKfH5qNdffx0pKSno2rUrBEFAfn4+3nvvPXz66afKbQICArB69Wr4+vriwYMHiIyMRLdu3XDx4kXls2LPi4qKKvacFlFV8+yZtgGpcMnP1/ZoEgAWyldW0nw4OJmidm0JHBwABwdxSioHB8DOTvwPpjoGAz47QwqKe8HExNAtIUPRNmBWViDVRwhiYCAqmVbhytzcHPXr14eh5rI6cOAA5s2bh2+//RYBAQG4fv06Jk6ciLlz52LmzJkAgL59+yq3b9myJQICAuDp6YlNmzZh9OjRavc7bdo0hIeHK1+np6fDw8NDvydDpEZurmroKS0QPf9ekc7XcrGwKAxERcOR8murHDgc/g21d62HQ34yHMwy4DB2GBwiJkJau5ZuLgARURUlkRQGDyKqubQeFjh9+nR8+umnWLt2bbl6rBScnJxgamqKpKQklfVJSUklPi81c+ZMvPXWW3j77bcBAC1atEBmZibGjBmD6dOnw0TNrwzt7e3RuHFjXL9+vcS2SKVSSKXScp8LUVFyOZCaql3vkeLr/3+csdxMTQsDkdqAVMrXlpYl/CZSEIAtW4DwcODOHXFdnz7A4tViSXUiIiIiAlCOcLV06VJcv34d7u7u8PT0RK1aqr+xPnPmjEb7sbCwQNu2bREbG4uBAwcCAAoKChAbG4tx48ap/UxWVlaxAGX6/78iEkp4mjgjIwM3btwo9lwWUWkEQSzEUJ6AlJZWsWNLJOJQuudDkCYBycZGx0M1rlwBxo8HFNU3PT2B6GjglVc4JoSIiIjoOVqHK0UQ0oXw8HCEhoaiXbt26NChA6Kjo5GZmamsHjhixAjUrVsXUVFRAIDg4GAsWrQIrVu3Vg4LnDlzJoKDg5Uha/LkyQgODoanpyfu37+P2bNnw9TUFMOHD9dZu6lqEAQgK6v8zyFV9EFja2vte48UzygZfFhJRgYwdy7w9ddAXh4glQKffAJMnVo166ISERERVQKtw9Xs2bN1dvCQkBA8fPgQs2bNQmJiIlq1aoXdu3cri1wkJCSo9FTNmDEDEokEM2bMwL179+Ds7Izg4GB8/vnnym3u3r2L4cOH49GjR3B2dkbXrl1x/PhxODs766zdVLlycsoXkB4/FnNBRchk5QtIDg6Aubluzr9SCQKwaRPw0UfAvXviuv79gcWLAR8fw7aNiIiIyMhJhJLG09Vg6enpsLOzQ1paGmxtbQ3dnGohP1+zQg3qijY8e1axY5uZaR6Inn9taamb868SLl0ShwDu3y++9vYWQ9XLLxu2XUREREQGpE020LrnysTEpNT5rAxVSZD0r6BAfJ6oPM8hPX1asWNLJOUv1FCrFh8PKlV6OhAZCXzzjZiCZTJg2jRxGKBMZujWEREREVUZWoerbdu2qbzOy8vD2bNnsWbNGs4VVQUUnTBW24CUmip+viJsbcsXkGxtOX+MzgkCsGED8PHHwIMH4rpXXhGfs2rQwLBtIyIiIqqCdDYscMOGDYiJicGvv/6qi90ZVFUYFli5E8aqsrLS7tkjxWt7e3GIHhmBCxeAceOAQ4fE1w0bij1XReaJIyIiIiI9DwssSceOHTFmzBhd7Y7+39SpwH//6WfC2PIWauCUYFVYWhowezawdKk4IZelJTBjhljAgt9YIiIiogrRSbh69uwZvvnmG9StW1cXu6Mi9u8HTp5U/15pE8aWFZZKnDCWqqeCAmDtWvE5quRkcd2rrwKLFgH16xu2bURERETVhNbhysHBQaWghSAIePr0KaysrLBu3TqdNo6AyZPFZ50qZcJYqp7OnQM++AA4elR87esrDgF86SWDNouIiIioutE6XH399dcq4crExATOzs4ICAiAg4ODThtHwJAhhm4BVVlPngAzZwLLl4s9V7Vqia8//FAcF0pEREREOqV1uAoLC9NDM4hIZwoKgNWrxQf2Hj4U1w0dCnz1FVCvnkGbRkRERFSdaV3cetWqVdi8eXOx9Zs3b8aaNWt00igiKqfTp4HOnYHRo8Vg1aQJsG8fEBPDYEVERESkZ1qHq6ioKDg5ORVbX6dOHcybN08njSIiLT16BLz3HtC+PXDiBGBtDSxcCJw/D7z4oqFbR0RERFQjaD0sMCEhAQ3UTDDq6emJhIQEnTSKiDQklwM//ghMmybW6AeA118HFiwA3N0N2zYiIiKiGkbrnqs6derg33//Lbb+/PnzcHR01EmjiEgDJ08CHTsC774rBqvmzYEDB4D16xmsiIiIiAxA63A1fPhwTJgwAfv374dcLodcLsdff/2FiRMnYtiwYfpoIxEV9fAh8M47YrD65x/A1haIjgbOnAF69DB064iIiIhqLK2HBc6dOxe3bt3Ciy++CDMz8eMFBQUYMWIEn7ki0ie5HPjuO2DGDLHMOgCMGAF8+SXg6mrYthERERERJIIgCOX54LVr13Du3DlYWlqiRYsW8PT01HXbDCY9PR12dnZIS0uDra2toZtDBBw7Jk4EfPas+NrfH1i2DOjSxbDtIiIiIqrmtMkGWvdcKTRq1AiNGjUq78eJSBPJycCUKeK8VQBgZwd89plYGdCs3H99iYiIiEgPtH7m6tVXX8WXX35ZbP38+fMxZMgQnTSKqMbLzweWLAEaNy4MVqNGAVevAuPGMVgRERERGSGtw9WhQ4fQr1+/Yuv79u2LQ4cO6aRRRDXakSNA27bAhAlAWhrQpo04LPDHH4E6dQzdOiIiIiIqgdbhKiMjAxYWFsXWm5ubIz09XSeNIqqRHjwA3noL6NYN+PdfwMEBWL68sOQ6ERERERk1rcNVixYtEBMTU2z9zz//jKZNm+qkUUQ1Sl4e8PXXgK8vsG4dIJGIpdavXhWfrTI1NXQLiYiIiEgDWj+4MXPmTAwePBg3btzACy+8AACIjY3Fhg0b8Msvv+i8gUTV2sGDYhXAS5fE1+3bi1UA27c3bLuIiIiISGtah6vg4GBs374d8+bNwy+//AJLS0v4+/vjr7/+Qu3atfXRRqLq5/59YPJkYONG8bWjI/DFF2LRChOtO5SJiIiIyAiUe54rhfT0dGzcuBE//vgjTp8+Dblcrqu2GQznuSK9yc0FFi8G5swBMjLEIYDvvSeWV+cvJ4iIiIiMjjbZoNy/Ij906BBCQ0Ph7u6Or776Ci+88AKOHz9e3t0RVX+xseLkv598Igarjh2Bf/4Bvv2WwYqIiIioGtBqWGBiYiJWr16NH3/8Eenp6Rg6dChycnKwfft2FrMgKsmdO8BHHwGbN4uvnZ2BL78EQkM5BJCIiIioGtH4J7vg4GD4+vri33//RXR0NO7fv48lS5bos21EVVtOjvgclZ+fGKxMTIDx48UqgCNHMlgRERERVTMa91zt2rULEyZMwNixY9GoUSN9tomo6vvzT3ES4KtXxddduwJLl4rDAomIiIioWtL4V+dHjhzB06dP0bZtWwQEBGDp0qVISUnRZ9uIqp7bt4HBg4E+fcRg5eIC/PQTcOgQgxURERFRNadxuOrYsSN++OEHPHjwAO+++y5+/vlnuLu7o6CgAHv37sXTp0/12U4i45adLVb8a9IE2LZNnPh30iQgLg546y2xKiARERERVWsVKsUeFxeHH3/8EWvXrkVqaip69+6N3377TZftMwiWYiet7NwpDgG8cUN83b27OASwRQvDtouIiIiIKqxSSrEDgK+vL+bPn4+7d+9io2IyVKKaIj4eeOUVoH9/MVi5uQEbNgAHDjBYEREREdVAFZ5EuDpizxWV6tkzYP58sRJgdjZgZiYOAZw1C7CxMXTriIiIiEiHtMkGWs1zRVSjCQKwY4cYpOLjxXUvvAAsWQJwnjciIiKiGo8T7RBp4vp14OWXxWGA8fFA3bpATAywbx+DFREREREBYLgiKl1WFjBzJtCsmVi4wtwcmDoVuHIFGDqUVQCJiIiISInDAonUEQRg+3bgww/FuasA4KWXgG++AXx9Ddo0IiIiIjJODFdEz7t6FRg/HtizR3xdvz7w9dfAoEHsqSIiIiKiEnFYIJFCZiYwbRrQvLkYrCwsgOnTgcuXgcGDGayIiIiIqFQGD1fLli2Dl5cXZDIZAgICcPLkyVK3j46Ohq+vLywtLeHh4YEPP/wQ2dnZFdon1XCCAGzeDPj5ieXV8/KAvn2BixeBzz4DrKwM3UIiIiIiqgIMGq5iYmIQHh6O2bNn48yZM/D390dQUBCSk5PVbr9hwwZMnToVs2fPxuXLl/Hjjz8iJiYGn376abn3STXc5ctA795icYq7dwEvL+DXX4E//gAaNTJ064iIiIioCjHoJMIBAQFo3749li5dCgAoKCiAh4cHxo8fj6lTpxbbfty4cbh8+TJiY2OV6z766COcOHECR44cKdc+ASAnJwc5OTnK1+np6fDw8OAkwtXZ06fAnDlAdDSQnw9IpWIVwClTAEtLQ7eOiIiIiIyENpMIG6znKjc3F6dPn0ZgYGBhY0xMEBgYiGPHjqn9TOfOnXH69GnlML+bN29i586d6NevX7n3CQBRUVGws7NTLh4eHro4RTJGggBs3CgOAVy4UAxWwcHAf/8BEREMVkRERERUbgYLVykpKZDL5XBxcVFZ7+LigsTERLWfef311zFnzhx07doV5ubm8PHxQc+ePZXDAsuzTwCYNm0a0tLSlMudO3cqeHZklC5eBF54AXj9deD+fcDbG/j9d+C338SviYiIiIgqwOAFLbRx4MABzJs3D99++y3OnDmDrVu34o8//sDcuXMrtF+pVApbW1uVhaqRtDQgPBxo1Qo4cACQycQhgZcuAf37G7p1RERERFRNGGyeKycnJ5iamiIpKUllfVJSElxdXdV+ZubMmXjrrbfw9ttvAwBatGiBzMxMjBkzBtOnTy/XPqkaEwRg/Xpg8mRAcU8MGgQsWiQWriAiIiIi0iGD9VxZWFigbdu2KsUpCgoKEBsbi06dOqn9TFZWFkxMVJtsamoKABAEoVz7pGrq/Hmge3fgrbfEYNWoEbB7N7B1K4MVEREREemFwXquACA8PByhoaFo164dOnTogOjoaGRmZmLkyJEAgBH/1969R1VRrn8A/24QNmyuXhDQEC8gIgEqqAf6eSD1BGokHk1UVEiMLmBy1ETzyvGYluYl9ZiVyrGLppUeV+YFL6ihJqkgKJESqSlImoIbEIX9/v7YuU9brhs2DBu/n7VmLWbmnZlnHt/l4uGdeWfiRHTs2BFLliwBAISEhGDFihXo3bs3+vfvj8uXL2PevHkICQnRFFm1nZNauLt3gfnzgXXrAJVK/Y2quXPVjwXK5VJHR0REREQtmKTFVVhYGH777TfMnz8f+fn56NWrF/bt26eZkOLq1ataI1Vz586FTCbD3Llzcf36ddjZ2SEkJASLFy+u8zmphVKpgC1b1FOpP/qm2ahRwHvvAZ06SRsbERERET0RJP3OVXOly1z21AycOwfExACPptvv0QNYswb405T8RERERET1oUttIOnIFVGD/P47MG8e8MEH6pErCwtgwQJg6lTA1FTq6IiIiKgJVVRU4OHDh1KHQQbIxMRE84pRQ7G4IsOjUgGbNgGzZwO3bqm3jRmj/ihwx47SxkZERERNSgiB/Px83L17V+pQyIDZ2trCwcEBMpmsQedhcUWG5Ycf1I8Anj6tXu/ZE1i7Fnj2WWnjIiIiIkk8Kqzat28PhULR4F+O6ckihEBJSQkK/nhn39HRsUHnY3FFhuH2beCtt4CPPlJ/v8rKCkhIAGJjARMTqaMjIiIiCVRUVGgKq7Zt20odDhkoc3NzAEBBQQHat2/foEcEWVxR81ZRoS6o5sxRv2MFAOPHA+++CzTwLwtERERk2B69Y6VQKCSOhAzdoz708OFDFlfUQn3/vfoRwDNn1OuenurvVw0YIG1cRERE1KzwUUBqKH31IaPamxA1sd9+A6KigL/8RV1YWVsDq1cDZ8+ysCIiIiKiZovFFTUfFRXqkanu3dWzAQJARATw00/AG28ArTjQSkRERFSVzp07Y9WqVXVun5ycDJlMxlkW9YzFFTUPJ04Avr7qCSru3gV69QJSUoDERMDeXuLgiIiIiPRDJpPVuCxcuLBe501NTUV0dHSd2/v7+yMvLw82Njb1uh5VjUMBJK2bN4H4eOA//1Gv29oCixcDr7wC6OljbkRERETNRV5enubnL774AvPnz0d2drZmm6WlpeZnIQQqKirQqg5P79jZ2ekUh6mpKRwcHHQ6hmrHkSuSRnm5+j2q7t3/V1hFRakfAXz9dRZWREREVD9CAMXFTb8IUafwHBwcNIuNjQ1kMplm/ccff4SVlRX27t0LHx8fyOVyfPfdd8jJycHw4cNhb28PS0tL9O3bFwcPHtQ67+OPBcpkMnz88ccYMWIEFAoFXF1dsXv3bs3+xx8LTExMhK2tLfbv3w93d3dYWloiODhYqxgsLy/HG2+8AVtbW7Rt2xbx8fGIiIhAaGhotfd7+/ZtjB07Fh07doRCoYCnpye2bt2q1UalUuHdd9+Fi4sL5HI5OnXqhMWLF2v2//rrrxg7dizatGkDCwsL+Pr64vvvv69TvpsaiytqeseOAX36AHFxQFER4OMDnDoFfPwxoONfXYiIiIi0lJQAlpZNv5SU6O0WZs2ahaVLlyIrKwteXl5QKpUYOnQoDh06hHPnziE4OBghISG4evVqjedJSEjA6NGjcf78eQwdOhTh4eH4/dGnbapMXQmWL1+OTz75BMeOHcPVq1cxY8YMzf533nkHn332GTZv3oyUlBQUFRVh165dNcZw//59+Pj4YM+ePcjMzER0dDQmTJiA06dPa9rMnj0bS5cuxbx583Dx4kV8/vnnsP/jtRClUomAgABcv34du3fvRnp6OmbOnAmVSlWHTEpAUCWFhYUCgCgsLJQ6lJblxg0hwsOFUP9tR4g2bYT44AMhysuljoyIiIgMUGlpqbh48aIoLS3930al8n+/azTlolTqHP/mzZuFjY2NZv3IkSMCgNi1a1etx3p4eIg1a9Zo1p2dncXKlSs16wDE3Llz/5QWpQAg9u7dq3WtO3fuaGIBIC5fvqw5Zt26dcLe3l6zbm9vL5YtW6ZZLy8vF506dRLDhw+v6y0LIYQYNmyYmD59uhBCiKKiIiGXy8VHH31UZdsNGzYIKysrcfv2bZ2uoasq+9IfdKkN+M4VNb6HD4E1a4CFC4F79wCZDIiOVr9bxa+pExERkT4pFIBSKc119cTX11drXalUYuHChdizZw/y8vJQXl6O0tLSWkeuvLy8ND9bWFjA2toaBQUF1bZXKBTo1q2bZt3R0VHTvrCwEDdv3kS/fv00+42NjeHj41PjKFJFRQXefvttbN++HdevX8eDBw9QVlam+WhvVlYWysrKMGjQoCqPT0tLQ+/evdGmTZsa77W5YHFFjevIEfUMgBcvqtf79VNPt/7YfxpEREREeiGTARYWUkfRIBaPxT9jxgwkJSVh+fLlcHFxgbm5OUaNGoUHDx7UeB4TExOtdZlMVmMhVFV7Ucd3yaqzbNkyrF69GqtWrYKnpycsLCwQFxenid3c3LzG42vb39zwnStqHNevA2PGAAMHqgurdu3U71SdPMnCioiIiEgHKSkpiIyMxIgRI+Dp6QkHBwf88ssvTRqDjY0N7O3tkZqaqtlWUVGBs2fP1nhcSkoKhg8fjvHjx8Pb2xtdu3bFTz/9pNnv6uoKc3NzHDp0qMrjvby8kJaWVuO7Ys0JiyvSrwcPgHffBdzcgC++AIyMgJgYIDtbPRugEbscERERkS5cXV3x9ddfIy0tDenp6Rg3bpwkEzpMmTIFS5YswX//+19kZ2dj6tSpuHPnDmQyWbXHuLq6IikpCSdOnEBWVhZeeeUV3Lx5U7PfzMwM8fHxmDlzJrZs2YKcnBycOnUKGzduBACMHTsWDg4OCA0NRUpKCn7++Wd89dVXOHnyZKPfb33wsUDSn4MHgSlTgB9/VK/7+wNr1wK9e0sbFxEREZEBW7FiBSZNmgR/f3+0a9cO8fHxKCoqavI44uPjkZ+fj4kTJ8LY2BjR0dEICgqCcQ2f0Jk7dy5+/vlnBAUFQaFQIDo6GqGhoSgsLNS0mTdvHlq1aoX58+fjxo0bcHR0xKuvvgpA/T2uAwcOYPr06Rg6dCjKy8vRs2dPrFu3rtHvtz5koqEPUrZARUVFsLGxQWFhIaytraUOp/m7ehWYNg346iv1evv26tGrCRM4UkVERESN5v79+8jNzUWXLl1gZmYmdThPHJVKBXd3d4wePRqLFi2SOpwGqakv6VIbcOSK6q+sDHjvPfWsfyUl6kIqNhZISABsbaWOjoiIiIj06MqVKzhw4AACAgJQVlaGtWvXIjc3F+PGjZM6tGaDxRXVz759wBtvAJcuqdcHDFA/AvinKT+JiIiIqOUwMjJCYmIiZsyYASEEnn76aRw8eBDu7u5Sh9ZssLgi3fzyC/CPfwCPvsbt4AAsXw6MG6ee+pSIiIiIWiQnJyekpKRIHUazxhdiqG7u3wcWLQLc3dWFlbGx+j2r7GwgPJyFFRERERE98ThyRbXbsweYOhXIyVGvBwaqHwH08JA0LCIiIiKi5oQjV1S9n38GQkKA559XF1YdOgBbtwKHD7OwIiIiIiJ6DIsrqqy0FFiwAOjZE/jmG6BVK+DNN9Xfrxozho8AEhERERFVgY8F0v8IAezeDcTFqSeuAIDBg4E1a4AePaSMjIiIiIio2ePIFaldugQMGwaEhqoLKycnYMcO4MABFlZERERERHXA4upJV1wMzJkDPP00sHcvYGICzJ4NZGUBo0bxEUAiIiKiZigwMBBxcXGa9c6dO2PVqlU1HiOTybDr0ed0GkBf52mJWFw9qYQAvvpKPbX6228DDx4AQUFAZqZ63cJC6giJiIiIWpyQkBAEBwdXue/48eOQyWQ4f/68zudNTU1FdHR0Q8PTsnDhQvTq1avS9ry8PAwZMkSv12opWFw9ibKz1YXUqFHAtWuAszOwc6d65Kp7d6mjIyIiImqxoqKikJSUhF9//bXSvs2bN8PX1xdeXl46n9fOzg4KhUIfIdbKwcEBcrm8Sa5laFhcPUmUSmDWLMDTE0hKAuRyYN484OJF9btWfASQiIiIDJwQ6rcemnoRom7xPf/887Czs0NiYqLWdqVSiR07diAqKgq3b9/G2LFj0bFjRygUCnh6emLr1q01nvfxxwIvXbqEv/71rzAzM0PPnj2RlJRU6Zj4+Hh0794dCoUCXbt2xbx58/Dw4UMAQGJiIhISEpCeng6ZTAaZTKaJ+fHHAjMyMjBw4ECYm5ujbdu2iI6OhlKp1OyPjIxEaGgoli9fDkdHR7Rt2xYxMTGaa1UlJycHw4cPh729PSwtLdG3b18cPHhQq01ZWRni4+Ph5OQEuVwOFxcXbNy4UbP/woULeP7552FtbQ0rKysMGDAAOY++29pIOFvgk0AI9eQU06YB16+rtw0bBqxeDXTrJm1sRERERHpUUgJYWjb9dZXKur1V0apVK0ycOBGJiYmYM2cOZH/8cXvHjh2oqKjA2LFjoVQq4ePjg/j4eFhbW2PPnj2YMGECunXrhn79+tV6DZVKhb///e+wt7fH999/j8LCQq33sx6xsrJCYmIiOnTogIyMDLz88suwsrLCzJkzERYWhszMTOzbt09T1NjY2FQ6R3FxMYKCguDn54fU1FQUFBRg8uTJiI2N1Sogjxw5AkdHRxw5cgSXL19GWFgYevXqhZdffrmafCoxdOhQLF68GHK5HFu2bEFISAiys7PRqVMnAMDEiRNx8uRJvP/++/D29kZubi5u3boFALh+/Tr++te/IjAwEIcPH4a1tTVSUlJQXl5ea/4aRFAlhYWFAoAoLCyUOpSGu3BBiIEDhVCXWEJ06SLE7t1SR0VERETUYKWlpeLixYuitLRUs02p/N+vPU25KJV1jzsrK0sAEEeOHNFsGzBggBg/fny1xwwbNkxMnz5dsx4QECCmTp2qWXd2dhYrV64UQgixf/9+0apVK3H9+nXN/r179woAYufOndVeY9myZcLHx0ezvmDBAuHt7V2p3Z/P8+GHH4rWrVsL5Z8SsGfPHmFkZCTy8/OFEEJEREQIZ2dnUV5ermnz4osvirCwsGpjqYqHh4dYs2aNEEKI7OxsAUAkJSVV2Xb27NmiS5cu4sGDB3U6d1V96RFdagOOXLVU9+4BCQnq0anycsDMTD0L4JtvAubmUkdHRERE1CgUCvUokhTXrasePXrA398fmzZtQmBgIC5fvozjx4/jn//8JwCgoqICb7/9NrZv347r16/jwYMHKCsrq/M7VVlZWXByckKHDh002/z8/Cq1++KLL/D+++8jJycHSqUS5eXlsLa2rvuN/HEtb29vWPxp2O6ZZ56BSqVCdnY27O3tAQAeHh4wNjbWtHF0dERGRka151UqlVi4cCH27NmDvLw8lJeXo7S0FFevXgUApKWlwdjYGAEBAVUen5aWhgEDBsDExESn+2koFlctjRDA1q3AjBlAXp562/DhwMqVQJcu0sZGRERE1MhkMsOY9DgqKgpTpkzBunXrsHnzZnTr1k1TKCxbtgyrV6/GqlWr4OnpCQsLC8TFxeHBgwd6u/7JkycRHh6OhIQEBAUFwcbGBtu2bcN7772nt2v82eNFjkwmg0qlqrb9jBkzkJSUhOXLl8PFxQXm5uYYNWqUJgfmtQwW1La/sXBCi5YkIwMIDATCw9WFlYsLsGcPsGsXCysiIiKiZmT06NEwMjLC559/ji1btmDSpEma969SUlIwfPhwjB8/Ht7e3ujatSt++umnOp/b3d0d165dQ96jP7QDOHXqlFabEydOwNnZGXPmzIGvry9cXV1x5coVrTampqaoqKio9Vrp6ekoLi7WbEtJSYGRkRHc3NzqHPPjUlJSEBkZiREjRsDT0xMODg745ZdfNPs9PT2hUqlw9OjRKo/38vLC8ePHa5w0ozE0i+Jq3bp16Ny5M8zMzNC/f3+cPn262raBgYGaGUv+vAwbNkzTJjIystL+6r4n0CIUFgJxcUDv3sCxY+rH/v71L3WxNXSo1NERERER0WMsLS0RFhaG2bNnIy8vD5GRkZp9rq6uSEpKwokTJ5CVlYVXXnkFN2/erPO5Bw8ejO7duyMiIgLp6ek4fvw45syZo9XG1dUVV69exbZt25CTk4P3338fO3fu1GrTuXNn5ObmIi0tDbdu3UJZWVmla4WHh8PMzAwRERHIzMzEkSNHMGXKFEyYMEHzSGB9uLq64uuvv0ZaWhrS09Mxbtw4rZGuzp07IyIiApMmTcKuXbuQm5uL5ORkbN++HQAQGxuLoqIijBkzBj/88AMuXbqETz75BNnZ2fWOqS4kL66++OILTJs2DQsWLMDZs2fh7e2NoKAgFBQUVNn+66+/Rl5enmbJzMyEsbExXnzxRa12wcHBWu1qm77SIAkBbNkCuLmp362qqABGjgSysoA5c9TvWRERERFRsxQVFYU7d+4gKChI6/2ouXPnok+fPggKCkJgYCAcHBwQGhpa5/MaGRlh586dKC0tRb9+/TB58mQsXrxYq80LL7yAf/zjH4iNjUWvXr1w4sQJzJs3T6vNyJEjERwcjGeffRZ2dnZV/j6tUCiwf/9+/P777+jbty9GjRqFQYMGYe3atbol4zErVqxA69at4e/vj5CQEAQFBaFPnz5abdavX49Ro0bh9ddfR48ePfDyyy9rRtDatm2Lw4cPQ6lUIiAgAD4+Pvjoo48a/R0smRB1nZW/cfTv3x99+/bV/AOoVCo4OTlhypQpmDVrVq3Hr1q1CvPnz0deXp7mRbrIyEjcvXtXa/59XRQVFcHGxgaFhYU6v9TXZNLTgZgYICVFvd69O7BmDfDcc9LGRURERNRE7t+/j9zcXHTp0gVm/KMyNUBNfUmX2kDSkasHDx7gzJkzGDx4sGabkZERBg8ejJMnT9bpHBs3bsSYMWO0ZigBgOTkZLRv3x5ubm547bXXcPv27WrPUVZWhqKiIq2l2bp7F5gyBejTR11YWVgAS5eqHwFkYUVEREREJBlJi6tbt26hoqKi0vOY9vb2yM/Pr/X406dPIzMzE5MnT9baHhwcjC1btuDQoUN45513cPToUQwZMqTaF/KWLFkCGxsbzeLk5FT/m2osKhWwaZN6hGrtWvX66NHAjz8C8fGAqanUERIRERERPdEMeir2jRs3wtPTs9KXqseMGaP52dPTE15eXujWrRuSk5MxaNCgSueZPXs2pk2bplkvKipqXgXWmTNAbCzwaJYXd3f1I4BV3AsREREREUlD0pGrdu3awdjYuNLsJzdv3oSDg0ONxxYXF2Pbtm2Iioqq9Tpdu3ZFu3btcPny5Sr3y+VyWFtbay3Nwv37wGuvAX37qgsrS0tg2TIgLY2FFRERERFRMyNpcWVqagofHx8cOnRIs02lUuHQoUNVfkX6z3bs2IGysjKMHz++1uv8+uuvuH37NhwdHRscc5OSy4HMTPWsgOPGAdnZ6o8D8xFAIiIiIg2J52ejFkBffUjyxwKnTZuGiIgI+Pr6ol+/fli1ahWKi4vx0ksvAQAmTpyIjh07YsmSJVrHbdy4EaGhoWjbtq3WdqVSiYSEBIwcORIODg7IycnBzJkz4eLigqCgoCa7L72QyYD164Hbt4E/vthNRERERGqPptUuKSmBubm5xNGQISspKQGABk/VLnlxFRYWht9++w3z589Hfn4+evXqhX379mkmubh69SqMjLQH2LKzs/Hdd9/hwIEDlc5nbGyM8+fP4z//+Q/u3r2LDh064LnnnsOiRYsgl8ub5J706umnpY6AiIiIqFkyNjaGra2t5vuoCoUCMplM4qjIkAghUFJSgoKCAtja2sLY2LhB55P8O1fNkUF854qIiIiIIIRAfn4+7t69K3UoZMBsbW3h4OBQZXGuS20g+cgVEREREVF9yWQyODo6on379nj48KHU4ZABMjExafCI1SMsroiIiIjI4BkbG+vtF2Si+pJ0tkAiIiIiIqKWgsUVERERERGRHrC4IiIiIiIi0gO+c1WFRxMoFhUVSRwJERERERFJ6VFNUJdJ1llcVeHevXsAACcnJ4kjISIiIiKi5uDevXuwsbGpsQ2/c1UFlUqFGzduwMrKSvIP0RUVFcHJyQnXrl3jN7caAfPbuJjfxsX8Nj7muHExv42L+W1czG/jak75FULg3r176NChA4yMan6riiNXVTAyMsJTTz0ldRharK2tJe9YLRnz27iY38bF/DY+5rhxMb+Ni/ltXMxv42ou+a1txOoRTmhBRERERESkByyuiIiIiIiI9IDFVTMnl8uxYMECyOVyqUNpkZjfxsX8Ni7mt/Exx42L+W1czG/jYn4bl6HmlxNaEBERERER6QFHroiIiIiIiPSAxRUREREREZEesLgiIiIiIiLSAxZXREREREREesDiSmLHjh1DSEgIOnToAJlMhl27dtV6THJyMvr06QO5XA4XFxckJiY2epyGStf8JicnQyaTVVry8/ObJmADsmTJEvTt2xdWVlZo3749QkNDkZ2dXetxO3bsQI8ePWBmZgZPT098++23TRCtYapPjhMTEyv1XzMzsyaK2LCsX78eXl5emg9U+vn5Ye/evTUew/5bd7rml323/pYuXQqZTIa4uLga27H/1k9d8sv+q5uFCxdWylePHj1qPMZQ+i+LK4kVFxfD29sb69atq1P73NxcDBs2DM8++yzS0tIQFxeHyZMnY//+/Y0cqWHSNb+PZGdnIy8vT7O0b9++kSI0XEePHkVMTAxOnTqFpKQkPHz4EM899xyKi4urPebEiRMYO3YsoqKicO7cOYSGhiI0NBSZmZlNGLnhqE+OAfXX7P/cf69cudJEERuWp556CkuXLsWZM2fwww8/YODAgRg+fDguXLhQZXv2X93oml+Afbc+UlNTsWHDBnh5edXYjv23fuqaX4D9V1ceHh5a+fruu++qbWtQ/VdQswFA7Ny5s8Y2M2fOFB4eHlrbwsLCRFBQUCNG1jLUJb9HjhwRAMSdO3eaJKaWpKCgQAAQR48erbbN6NGjxbBhw7S29e/fX7zyyiuNHV6LUJccb968WdjY2DRdUC1M69atxccff1zlPvbfhqspv+y7urt3755wdXUVSUlJIiAgQEydOrXatuy/utMlv+y/ulmwYIHw9vauc3tD6r8cuTIwJ0+exODBg7W2BQUF4eTJkxJF1DL16tULjo6O+Nvf/oaUlBSpwzEIhYWFAIA2bdpU24b9t2HqkmMAUCqVcHZ2hpOTU60jBaRWUVGBbdu2obi4GH5+flW2Yf+tv7rkF2Df1VVMTAyGDRtWqV9Whf1Xd7rkF2D/1dWlS5fQoUMHdO3aFeHh4bh69Wq1bQ2p/7aSOgDSTX5+Puzt7bW22dvbo6ioCKWlpTA3N5cospbB0dERH3zwAXx9fVFWVoaPP/4YgYGB+P7779GnTx+pw2u2VCoV4uLi8Mwzz+Dpp5+utl11/ZfvtNWurjl2c3PDpk2b4OXlhcLCQixfvhz+/v64cOECnnrqqSaM2DBkZGTAz88P9+/fh6WlJXbu3ImePXtW2Zb9V3e65Jd9Vzfbtm3D2bNnkZqaWqf27L+60TW/7L+66d+/PxITE+Hm5oa8vDwkJCRgwIAByMzMhJWVVaX2htR/WVwR/Ymbmxvc3Nw06/7+/sjJycHKlSvxySefSBhZ8xYTE4PMzMwan5emhqlrjv38/LRGBvz9/eHu7o4NGzZg0aJFjR2mwXFzc0NaWhoKCwvx5ZdfIiIiAkePHq22ACDd6JJf9t26u3btGqZOnYqkpCROmtAI6pNf9l/dDBkyRPOzl5cX+vfvD2dnZ2zfvh1RUVESRtZwLK4MjIODA27evKm17ebNm7C2tuaoVSPp168fi4YaxMbG4ptvvsGxY8dq/etcdf3XwcGhMUM0eLrk+HEmJibo3bs3Ll++3EjRGTZTU1O4uLgAAHx8fJCamorVq1djw4YNldqy/+pOl/w+jn23emfOnEFBQYHWExUVFRU4duwY1q5di7KyMhgbG2sdw/5bd/XJ7+PYf3Vja2uL7t27V5svQ+q/fOfKwPj5+eHQoUNa25KSkmp8hp0aJi0tDY6OjlKH0ewIIRAbG4udO3fi8OHD6NKlS63HsP/qpj45flxFRQUyMjLYh+tIpVKhrKysyn3svw1XU34fx75bvUGDBiEjIwNpaWmaxdfXF+Hh4UhLS6vyF3/237qrT34fx/6rG6VSiZycnGrzZVD9V+oZNZ509+7dE+fOnRPnzp0TAMSKFSvEuXPnxJUrV4QQQsyaNUtMmDBB0/7nn38WCoVCvPnmmyIrK0usW7dOGBsbi3379kl1C82arvlduXKl2LVrl7h06ZLIyMgQU6dOFUZGRuLgwYNS3UKz9dprrwkbGxuRnJws8vLyNEtJSYmmzYQJE8SsWbM06ykpKaJVq1Zi+fLlIisrSyxYsECYmJiIjIwMKW6h2atPjhMSEsT+/ftFTk6OOHPmjBgzZowwMzMTFy5ckOIWmrVZs2aJo0ePitzcXHH+/Hkxa9YsIZPJxIEDB4QQ7L8NpWt+2Xcb5vHZ7Nh/9au2/LL/6mb69OkiOTlZ5ObmipSUFDF48GDRrl07UVBQIIQw7P7L4kpij6b+fnyJiIgQQggREREhAgICKh3Tq1cvYWpqKrp27So2b97c5HEbCl3z+84774hu3boJMzMz0aZNGxEYGCgOHz4sTfDNXFV5BaDVHwMCAjS5fmT79u2ie/fuwtTUVHh4eIg9e/Y0beAGpD45jouLE506dRKmpqbC3t5eDB06VJw9e7bpgzcAkyZNEs7OzsLU1FTY2dmJQYMGaX7xF4L9t6F0zS/7bsM8/ss/+69+1ZZf9l/dhIWFCUdHR2Fqaio6duwowsLCxOXLlzX7Dbn/yoQQounGyYiIiIiIiFomvnNFRERERESkByyuiIiIiIiI9IDFFRERERERkR6wuCIiIiIiItIDFldERERERER6wOKKiIiIiIhID1hcERERERER6QGLKyIiIiIiIj1gcUVERNRAMpkMu3btkjoMIiKSGIsrIiIyaJGRkZDJZJWW4OBgqUMjIqInTCupAyAiImqo4OBgbN68WWubXC6XKBoiInpSceSKiIgMnlwuh4ODg9bSunVrAOpH9tavX48hQ4bA3NwcXbt2xZdffql1fEZGBgYOHAhzc3O0bdsW0dHRUCqVWm02bdoEDw8PyOVyODo6IjY2Vmv/rVu3MGLECCgUCri6umL37t2afXfu3EF4eDjs7Oxgbm4OV1fXSsUgEREZPhZXRETU4s2bNw8jR45Eeno6wsPDMWbMGGRlZQEAiouLERQUhNatWyM1NRU7duzAwYMHtYqn9evXIyYmBtHR0cjIyMDu3bvh4uKidY2EhASMHj0a58+fx9ChQxEeHo7ff/9dc/2LFy9i7969yMrKwvr169GuXbumSwARETUJmRBCSB0EERFRfUVGRuLTTz+FmZmZ1va33noLb731FmQyGV599VWsX79es+8vf/kL+vTpg3//+9/46KOPEB8fj2vXrsHCwgIA8O233yIkJAQ3btyAvb09OnbsiJdeegn/+te/qoxBJpNh7ty5WLRoEQB1wWZpaYm9e/ciODgYL7zwAtq1a4dNmzY1UhaIiKg54DtXRERk8J599lmt4gkA2rRpo/nZz89Pa5+fnx/S0tIAAFlZWfD29tYUVgDwzDPPQKVSITs7GzKZDDdu3MCgQYNqjMHLy0vzs4WFBaytrVFQUAAAeO211zBy5EicPXsWzz33HEJDQ+Hv71+veyUiouaLxRURERk8CwuLSo/p6Yu5uXmd2pmYmGity2QyqFQqAMCQIUNw5coVfPvtt0hKSsKgQYMQExOD5cuX6z1eIiKSDt+5IiKiFu/UqVOV1t3d3QEA7u7uSE9PR3FxsWZ/SkoKjIyM4ObmBisrK3Tu3BmHDh1qUAx2dnaIiIjAp59+ilWrVuHDDz9s0PmIiKj54cgVEREZvLKyMuTn52tta9WqlWbSiB07dsDX1xf/93//h88++wynT5/Gxo0bAQDh4eFYsGABIiIisHDhQvz222+YMmUKJkyYAHt7ewDAwoUL8eqrr6J9+/YYMmQI7t27h5SUFEyZMqVO8c2fPx8+Pj7w8PBAWVkZvvnmG01xR0RELQeLKyIiMnj79u2Do6Oj1jY3Nzf8+OOPANQz+W3btg2vv/46HB0dsXXrVvTs2RMAoFAosH//fkydOhV9+/aFQqHAyJEjsWLFCs25IiIicP/+faxcuRIzZsxAu3btMGrUqDrHZ2pqitmzZ+OXX36Bubk5BgwYgG3btunhzomIqDnhbIFERNSiyWQy7Ny5E6GhoVKHQkRELRzfuSIiIiIiItIDFldERERERER6wHeuiIioRePT70RE1FQ4ckVERERERKQHLK6IiIiIiIj0gMUVERERERGRHrC4IiIiIiIi0gMWV0RERERERHrA4oqIiIiIiEgPWFwRERERERHpAYsrIiIiIiIiPfh/PsYyS02mBEUAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 1000x600 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "history_dict = history.history\n",
     "print(history_dict.keys())\n",
@@ -1094,19 +749,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {
     "id": "ShcvqJAgVera"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:Found untraced functions such as restored_function_body, restored_function_body, restored_function_body, restored_function_body, restored_function_body while saving (showing 5 of 124). These functions will not be directly callable after loading.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dataset_name = \"imdb\"\n",
     "saved_model_path = \"./{}_bert\".format(dataset_name.replace(\"/\", \"_\"))\n",
@@ -1128,7 +775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {
     "id": "gUEWVskZjEF0"
    },
@@ -1148,32 +795,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {
     "id": "VBWzH6exlCPS"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results from the saved model:\n",
-      "input: this is such an amazing movie! : score: 0.999055\n",
-      "input: The movie was great!           : score: 0.994220\n",
-      "input: The movie was meh.             : score: 0.921660\n",
-      "input: The movie was okish.           : score: 0.013223\n",
-      "input: The movie was terrible...      : score: 0.001282\n",
-      "\n",
-      "Results from the model in memory:\n",
-      "input: this is such an amazing movie! : score: 0.999055\n",
-      "input: The movie was great!           : score: 0.994220\n",
-      "input: The movie was meh.             : score: 0.921660\n",
-      "input: The movie was okish.           : score: 0.013223\n",
-      "input: The movie was terrible...      : score: 0.001282\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def print_my_examples(inputs, results):\n",
     "    result_for_printing = [\n",
@@ -1203,7 +829,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## (Optional) Deploy your model on Vertex AI to get online predictions"
    ]
@@ -1219,24 +847,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {
     "id": "0FdVD3973S-O"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "input: this is such an amazing movie! : score: 0.999055\n",
-      "input: The movie was great!           : score: 0.994220\n",
-      "input: The movie was meh.             : score: 0.921660\n",
-      "input: The movie was okish.           : score: 0.013223\n",
-      "input: The movie was terrible...      : score: 0.001282\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "serving_results = reloaded_model.signatures[\"serving_default\"](\n",
     "    tf.constant(examples)\n",
@@ -1258,35 +873,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The given SavedModel SignatureDef contains the following input(s):\n",
-      "  inputs['text'] tensor_info:\n",
-      "      dtype: DT_STRING\n",
-      "      shape: (-1)\n",
-      "      name: serving_default_text:0\n",
-      "The given SavedModel SignatureDef contains the following output(s):\n",
-      "  outputs['classifier'] tensor_info:\n",
-      "      dtype: DT_FLOAT\n",
-      "      shape: (-1, 1)\n",
-      "      name: StatefulPartitionedCall_2:0\n",
-      "Method name is: tensorflow/serving/predict\n",
-      "./imdb_bert/20230407154959\n",
-      "./imdb_bert/20230407154959/variables\n",
-      "./imdb_bert/20230407154959/variables/variables.index\n",
-      "./imdb_bert/20230407154959/variables/variables.data-00000-of-00001\n",
-      "./imdb_bert/20230407154959/assets\n",
-      "./imdb_bert/20230407154959/assets/vocab.txt\n",
-      "./imdb_bert/20230407154959/saved_model.pb\n",
-      "./imdb_bert/20230407154959/keras_metadata.pb\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!saved_model_cli show \\\n",
     "    --tag_set serve \\\n",
@@ -1299,17 +888,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MODEL_DISPLAYNAME: classification-bert-20230407163903\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "TIMESTAMP = datetime.datetime.now().strftime(\"%Y%m%d%H%M%S\")\n",
     "PROJECT = !gcloud config list --format 'value(core.project)' 2>/dev/null\n",
@@ -1331,17 +912,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bucket exists, let's not recreate it.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
@@ -1359,109 +932,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Copying file://./imdb_bert/20230407154959/saved_model.pb [Content-Type=application/octet-stream]...\n",
-      "Copying file://./imdb_bert/20230407154959/keras_metadata.pb [Content-Type=application/octet-stream]...\n",
-      "Copying file://./imdb_bert/20230407154959/variables/variables.index [Content-Type=application/octet-stream]...\n",
-      "Copying file://./imdb_bert/20230407154959/variables/variables.data-00000-of-00001 [Content-Type=application/octet-stream]...\n",
-      "| [4 files][117.6 MiB/117.6 MiB]                                                \n",
-      "==> NOTE: You are performing a sequence of gsutil operations that may\n",
-      "run significantly faster if you instead use gsutil -m cp ... Please\n",
-      "see the -m section under \"gsutil help options\" for further information\n",
-      "about when gsutil -m can be advantageous.\n",
-      "\n",
-      "Copying file://./imdb_bert/20230407154959/assets/vocab.txt [Content-Type=text/plain]...\n",
-      "/ [5 files][117.8 MiB/117.8 MiB]                                                \n",
-      "Operation completed over 5 objects/117.8 MiB.                                    \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!gsutil cp -r $EXPORT_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating Model\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Creating Model\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Create Model backing LRO: projects/550642080325/locations/us-central1/models/241798000110731264/operations/4462402919542554624\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Create Model backing LRO: projects/550642080325/locations/us-central1/models/241798000110731264/operations/4462402919542554624\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model created. Resource name: projects/550642080325/locations/us-central1/models/241798000110731264@1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Model created. Resource name: projects/550642080325/locations/us-central1/models/241798000110731264@1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "To use this Model in another session:\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:To use this Model in another session:\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "model = aiplatform.Model('projects/550642080325/locations/us-central1/models/241798000110731264@1')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:model = aiplatform.Model('projects/550642080325/locations/us-central1/models/241798000110731264@1')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "uploaded_model = aiplatform.Model.upload(\n",
     "    display_name=MODEL_DISPLAYNAME,\n",
@@ -1472,122 +954,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating Endpoint\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Creating Endpoint\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Create Endpoint backing LRO: projects/550642080325/locations/us-central1/endpoints/8775206699326767104/operations/769099381377859584\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Create Endpoint backing LRO: projects/550642080325/locations/us-central1/endpoints/8775206699326767104/operations/769099381377859584\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Endpoint created. Resource name: projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Endpoint created. Resource name: projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "To use this Endpoint in another session:\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:To use this Endpoint in another session:\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "endpoint = aiplatform.Endpoint('projects/550642080325/locations/us-central1/endpoints/8775206699326767104')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:endpoint = aiplatform.Endpoint('projects/550642080325/locations/us-central1/endpoints/8775206699326767104')\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploying model to Endpoint : projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Deploying model to Endpoint : projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploy Endpoint model backing LRO: projects/550642080325/locations/us-central1/endpoints/8775206699326767104/operations/2185481464185880576\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Deploy Endpoint model backing LRO: projects/550642080325/locations/us-central1/endpoints/8775206699326767104/operations/2185481464185880576\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Endpoint model deployed. Resource name: projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.models:Endpoint model deployed. Resource name: projects/550642080325/locations/us-central1/endpoints/8775206699326767104\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "MACHINE_TYPE = \"n1-standard-4\"\n",
     "\n",
@@ -1607,7 +976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1620,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1629,17 +998,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " prediction: [[0.998149872], [0.83823961], [0.00687500834]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\" prediction:\", response.predictions)"
    ]


### PR DESCRIPTION
This PR adds an optional section to the BERT notebook to deploy a saved TF model to Vertex and get online predictions from the model. 

To test this lab, please follow the instructions to create a new `bert_kernel`.