### PR TITLE
fix typos and wrong variable in code

### DIFF
--- a/notebooks/introduction_to_tensorflow/labs/1_core_tensorflow.ipynb
+++ b/notebooks/introduction_to_tensorflow/labs/1_core_tensorflow.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "* `x.assign(new_value)`\n",
     "* `x.assign_add(value_to_be_added)`\n",
-    "* `x.assign_sub(value_to_be_subtracted`\n",
+    "* `x.assign_sub(value_to_be_subtracted)`\n",
     "\n"
    ]
   },
@@ -152,7 +152,7 @@
     "* `tf.math.*` contains the usual math operations to be applied on the components of a tensor\n",
     "* and many more...\n",
     "\n",
-    "Most of the standard aritmetic operations (`tf.add`, `tf.substrac`, etc.) are overloaded by the usual corresponding arithmetic symbols (`+`, `-`, etc.)"
+    "Most of the standard aritmetic operations (`tf.add`, `tf.substract`, etc.) are overloaded by the usual corresponding arithmetic symbols (`+`, `-`, etc.)"
    ]
   },
   {
@@ -425,7 +425,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "errors = (Y_hat - Y) ** 2\n",
+    "errors = (Y_hat - Y_test) ** 2\n",
     "loss = tf.reduce_mean(errors)\n",
     "loss.numpy()"
    ]
@@ -742,12 +742,12 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-8.m97",
+   "name": "tf2-gpu.2-8.m108",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m97"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m108"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/introduction_to_tensorflow/solutions/1_core_tensorflow.ipynb
+++ b/notebooks/introduction_to_tensorflow/solutions/1_core_tensorflow.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "* `x.assign(new_value)`\n",
     "* `x.assign_add(value_to_be_added)`\n",
-    "* `x.assign_sub(value_to_be_subtracted`\n",
+    "* `x.assign_sub(value_to_be_subtracted)`\n",
     "\n"
    ]
   },
@@ -145,7 +145,7 @@
     "* `tf.math.*` contains the usual math operations to be applied on the components of a tensor\n",
     "* and many more...\n",
     "\n",
-    "Most of the standard aritmetic operations (`tf.add`, `tf.substrac`, etc.) are overloaded by the usual corresponding arithmetic symbols (`+`, `-`, etc.)"
+    "Most of the standard aritmetic operations (`tf.add`, `tf.substract`, etc.) are overloaded by the usual corresponding arithmetic symbols (`+`, `-`, etc.)"
    ]
   },
   {
@@ -353,7 +353,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y_mean = Y.numpy().mean()\n",
+    "# calculate the sample mean of the training data\n",
+    "y_mean = Y_test.numpy().mean()\n",
     "\n",
     "\n",
     "def predict_mean(X):\n",
@@ -361,6 +362,7 @@
     "    return y_hat\n",
     "\n",
     "\n",
+    "# calculate the y_hat of test data\n",
     "Y_hat = predict_mean(X_test)"
    ]
   },
@@ -387,7 +389,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "errors = (Y_hat - Y) ** 2\n",
+    "errors = (Y_hat - Y_test) ** 2\n",
     "loss = tf.reduce_mean(errors)\n",
     "loss.numpy()"
    ]
@@ -523,6 +525,7 @@
     "\n",
     "for step in range(1, STEPS + 1):\n",
     "    dw0, dw1 = compute_gradients(X, Y, w0, w1)\n",
+    "\n",
     "    w0.assign_sub(dw0 * LEARNING_RATE)\n",
     "    w1.assign_sub(dw1 * LEARNING_RATE)\n",
     "\n",
@@ -690,12 +693,12 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-8.m97",
+   "name": "tf2-gpu.2-8.m108",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m97"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m108"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Fixed minor typos and also changed `error = (Y_hat-Y)**2` to `error = (Y_hat-Y_test)**2`