### PR TITLE
Minor Fix: added graphviz instlation command to setup step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ install:
 	@pip install --user -r requirements.txt
 	@./scripts/setup_on_jupyterlab.sh
 	@pre-commit install
+	@sudo apt-get -y install graphviz
 
 .PHONY: precommit
 precommit:


### PR DESCRIPTION
Now Vertex AI workbench environment returns keras plotting error because of a dependency issue.
<img width="894" alt="image" src="https://github.com/GoogleCloudPlatform/asl-ml-immersion/assets/6895245/575d4afa-06e0-4a50-a3f0-99393c81134b">

To avoid this, added `sudo apt-get install graphviz` command to installation step in README.md.
(Since this requires `sudo` permission, it can't be run in `make` process.)