### PR TITLE
Temporarily disabling ScaNN in TF Recommenders Lab

### DIFF
--- a/kernels/tf_recommenders.sh
+++ b/kernels/tf_recommenders.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# To build the kernel:  ./kernels/reinforcement_learning.sh
-# To remove the kernel: ./kernels/reinforcement_learning.sh remove
+# To build the kernel:  ./kernels/tf_recommenders.sh
+# To remove the kernel: ./kernels/tf_recommenders.sh remove
 #
 # This scripts will create a ipython kernel named $MODULE
 # populated with the reqs in ./notebooks/$MODULE/requirements.txt
@@ -34,6 +34,11 @@ python -m ipykernel install --user --name=$ENVNAME
 # Install TF Recommenders, TF-Datasets, and scann and its dependencies
 pip install tensorflow-recommenders==0.7.2
 pip install -U tensorflow-datasets==4.7.0
-pip install scann==1.2.9
+
+# Disabling scann until it become compatible with Python 3.10
+# pip install scann==1.2.9
+
+# Downgrading protobuf for compatibility.
+pip install -U protobuf==3.20.3
 
 deactivate

--- a/notebooks/recommendation_systems/labs/tfrs_basic_retrieval.ipynb
+++ b/notebooks/recommendation_systems/labs/tfrs_basic_retrieval.ipynb
@@ -120,6 +120,20 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Importing necessary modules\n",
+    "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 3,
    "metadata": {
     "execution": {
@@ -132,8 +146,6 @@
    },
    "outputs": [],
    "source": [
-    "# Importing necessary modules\n",
-    "import os\n",
     "import pprint\n",
     "import tempfile\n",
     "from typing import Dict, Text\n",
@@ -1136,163 +1148,14 @@
     "id": "nBBGodbE5ENC"
    },
    "source": [
-    "We can also export an approximate retrieval index to speed up predictions. This will make it possible to efficiently surface recommendations from sets of tens of millions of candidates.\n",
-    "\n",
-    "To do so, we can use the `scann` package. This is an optional dependency of TFRS, and we installed it separately at the beginning of this notebook by calling `!pip install -q scann`."
+    "We can also export an approximate retrieval index to speed up predictions. This will make it possible to efficiently surface recommendations from sets of tens of millions of candidates."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "15PtZqoO5k_k"
-   },
+   "metadata": {},
    "source": [
-    "Once installed we can use the TFRS `ScaNN` layer:\n",
-    "\n",
-    "**Disabling this section, since ScaNN library is not compatible with Python 3.10 currently.**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:50.871341Z",
-     "iopub.status.busy": "2020-11-19T23:55:50.870436Z",
-     "iopub.status.idle": "2020-11-19T23:55:51.206268Z",
-     "shell.execute_reply": "2020-11-19T23:55:51.206720Z"
-    },
-    "id": "rTz8yxyp5uwU"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<tensorflow_recommenders.layers.factorized_top_k.ScaNN at 0x7f04c6617dd8>"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# scann_index = tfrs.layers.factorized_top_k.ScaNN(model.user_model)\n",
-    "# scann_index.index_from_dataset(\n",
-    "#     tf.data.Dataset.zip(\n",
-    "#         (movies.batch(100), movies.batch(100).map(model.movie_model))\n",
-    "#     )\n",
-    "# )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "UpLnoUv256bS"
-   },
-   "source": [
-    "This layer will perform _approximate_ lookups: this makes retrieval slightly less accurate, but orders of magnitude faster on large candidate sets."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:51.216049Z",
-     "iopub.status.busy": "2020-11-19T23:55:51.215339Z",
-     "iopub.status.idle": "2020-11-19T23:55:51.274544Z",
-     "shell.execute_reply": "2020-11-19T23:55:51.275002Z"
-    },
-    "id": "Te_MGu1Q6JrU"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Recommendations for user 42: [b'Bridges of Madison County, The (1995)'\n",
-      " b'Father of the Bride Part II (1995)' b'Rudy (1993)']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# # Get recommendations.\n",
-    "# _, titles = scann_index(tf.constant([\"42\"]))\n",
-    "# print(f\"Recommendations for user 42: {titles[0, :3]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Izo0IUMA6TQm"
-   },
-   "source": [
-    "Exporting it for serving is as easy as exporting the `BruteForce` layer:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:51.281935Z",
-     "iopub.status.busy": "2020-11-19T23:55:51.281218Z",
-     "iopub.status.idle": "2020-11-19T23:55:52.228819Z",
-     "shell.execute_reply": "2020-11-19T23:55:52.229297Z"
-    },
-    "id": "K7NUqgxU6W_T"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:Found untraced functions such as query_with_exclusions while saving (showing 1 of 1). These functions will not be directly callable after loading.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: /tmp/tmpnw8jix65/model/assets\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: /tmp/tmpnw8jix65/model/assets\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Recommendations: [b'Bridges of Madison County, The (1995)'\n",
-      " b'Father of the Bride Part II (1995)' b'Rudy (1993)']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# # Export the query model.\n",
-    "# with tempfile.TemporaryDirectory() as tmp:\n",
-    "#     path = os.path.join(tmp, \"model\")\n",
-    "\n",
-    "#     # Save the index.\n",
-    "#     tf.saved_model.save(\n",
-    "#         scann_index,\n",
-    "#         path,\n",
-    "#         options=tf.saved_model.SaveOptions(namespace_whitelist=[\"Scann\"]),\n",
-    "#     )\n",
-    "\n",
-    "#     # Load it back; can also be done in TensorFlow Serving.\n",
-    "#     loaded = tf.saved_model.load(path)\n",
-    "\n",
-    "#     # Pass a user id in, get top predicted movie titles back.\n",
-    "#     scores, titles = loaded([\"42\"])\n",
-    "\n",
-    "#     print(f\"Recommendations: {titles[0][:3]}\")"
+    "To learn more about using and tuning fast approximate retrieval models, have a look at our [efficient serving](https://tensorflow.org/recommenders/examples/efficient_serving) notebook."
    ]
   },
   {
@@ -1331,9 +1194,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-8.m92",
+   "name": "tf2-gpu.2-12.m109",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m92"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-12:m109"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -1350,7 +1213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/recommendation_systems/labs/tfrs_basic_retrieval.ipynb
+++ b/notebooks/recommendation_systems/labs/tfrs_basic_retrieval.ipynb
@@ -1147,7 +1147,9 @@
     "id": "15PtZqoO5k_k"
    },
    "source": [
-    "Once installed we can use the TFRS `ScaNN` layer:"
+    "Once installed we can use the TFRS `ScaNN` layer:\n",
+    "\n",
+    "**Disabling this section, since ScaNN library is not compatible with Python 3.10 currently.**"
    ]
   },
   {
@@ -1175,12 +1177,12 @@
     }
    ],
    "source": [
-    "scann_index = tfrs.layers.factorized_top_k.ScaNN(model.user_model)\n",
-    "scann_index.index_from_dataset(\n",
-    "    tf.data.Dataset.zip(\n",
-    "        (movies.batch(100), movies.batch(100).map(model.movie_model))\n",
-    "    )\n",
-    ")"
+    "# scann_index = tfrs.layers.factorized_top_k.ScaNN(model.user_model)\n",
+    "# scann_index.index_from_dataset(\n",
+    "#     tf.data.Dataset.zip(\n",
+    "#         (movies.batch(100), movies.batch(100).map(model.movie_model))\n",
+    "#     )\n",
+    "# )"
    ]
   },
   {
@@ -1215,9 +1217,9 @@
     }
    ],
    "source": [
-    "# Get recommendations.\n",
-    "_, titles = scann_index(tf.constant([\"42\"]))\n",
-    "print(f\"Recommendations for user 42: {titles[0, :3]}\")"
+    "# # Get recommendations.\n",
+    "# _, titles = scann_index(tf.constant([\"42\"]))\n",
+    "# print(f\"Recommendations for user 42: {titles[0, :3]}\")"
    ]
   },
   {
@@ -1273,24 +1275,24 @@
     }
    ],
    "source": [
-    "# Export the query model.\n",
-    "with tempfile.TemporaryDirectory() as tmp:\n",
-    "    path = os.path.join(tmp, \"model\")\n",
+    "# # Export the query model.\n",
+    "# with tempfile.TemporaryDirectory() as tmp:\n",
+    "#     path = os.path.join(tmp, \"model\")\n",
     "\n",
-    "    # Save the index.\n",
-    "    tf.saved_model.save(\n",
-    "        scann_index,\n",
-    "        path,\n",
-    "        options=tf.saved_model.SaveOptions(namespace_whitelist=[\"Scann\"]),\n",
-    "    )\n",
+    "#     # Save the index.\n",
+    "#     tf.saved_model.save(\n",
+    "#         scann_index,\n",
+    "#         path,\n",
+    "#         options=tf.saved_model.SaveOptions(namespace_whitelist=[\"Scann\"]),\n",
+    "#     )\n",
     "\n",
-    "    # Load it back; can also be done in TensorFlow Serving.\n",
-    "    loaded = tf.saved_model.load(path)\n",
+    "#     # Load it back; can also be done in TensorFlow Serving.\n",
+    "#     loaded = tf.saved_model.load(path)\n",
     "\n",
-    "    # Pass a user id in, get top predicted movie titles back.\n",
-    "    scores, titles = loaded([\"42\"])\n",
+    "#     # Pass a user id in, get top predicted movie titles back.\n",
+    "#     scores, titles = loaded([\"42\"])\n",
     "\n",
-    "    print(f\"Recommendations: {titles[0][:3]}\")"
+    "#     print(f\"Recommendations: {titles[0][:3]}\")"
    ]
   },
   {

--- a/notebooks/recommendation_systems/solutions/tfrs_basic_retrieval.ipynb
+++ b/notebooks/recommendation_systems/solutions/tfrs_basic_retrieval.ipynb
@@ -78,17 +78,128 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:54:09.971545Z",
-     "iopub.status.busy": "2020-11-19T23:54:09.968706Z",
-     "iopub.status.idle": "2020-11-19T23:54:15.327905Z",
-     "shell.execute_reply": "2020-11-19T23:54:15.327244Z"
-    },
-    "id": "0vJOdh9WbTpd"
+    "id": "0vJOdh9WbTpd",
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "./kernels/tf_recommenders.sh\n",
+      "creating tf_recommenders_kernel at /home/jupyter/asl-ml-immersion/notebooks/recommendation_systems\n",
+      "Requirement already satisfied: pip in ./tf_recommenders_kernel/lib/python3.10/site-packages (23.1.2)\n",
+      "Collecting pip\n",
+      "  Downloading pip-23.2.1-py3-none-any.whl (2.1 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.1/2.1 MB\u001b[0m \u001b[31m8.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m:00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: pip\n",
+      "  Attempting uninstall: pip\n",
+      "    Found existing installation: pip 23.1.2\n",
+      "    Uninstalling pip-23.1.2:\n",
+      "      Successfully uninstalled pip-23.1.2\n",
+      "Successfully installed pip-23.2.1\n",
+      "Requirement already satisfied: ipykernel in ./tf_recommenders_kernel/lib/python3.10/site-packages (6.23.3)\n",
+      "Requirement already satisfied: comm>=0.1.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (0.1.3)\n",
+      "Requirement already satisfied: debugpy>=1.6.5 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (1.6.7)\n",
+      "Requirement already satisfied: ipython>=7.23.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (8.14.0)\n",
+      "Requirement already satisfied: jupyter-client>=6.1.12 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (8.3.0)\n",
+      "Requirement already satisfied: jupyter-core!=5.0.*,>=4.12 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (5.3.1)\n",
+      "Requirement already satisfied: matplotlib-inline>=0.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (0.1.6)\n",
+      "Requirement already satisfied: nest-asyncio in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (1.5.6)\n",
+      "Requirement already satisfied: packaging in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (23.1)\n",
+      "Requirement already satisfied: psutil in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (5.9.5)\n",
+      "Requirement already satisfied: pyzmq>=20 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (25.1.0)\n",
+      "Requirement already satisfied: tornado>=6.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (6.3.2)\n",
+      "Requirement already satisfied: traitlets>=5.4.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipykernel) (5.9.0)\n",
+      "Requirement already satisfied: backcall in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (0.2.0)\n",
+      "Requirement already satisfied: decorator in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (5.1.1)\n",
+      "Requirement already satisfied: jedi>=0.16 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (0.18.2)\n",
+      "Requirement already satisfied: pickleshare in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (0.7.5)\n",
+      "Requirement already satisfied: prompt-toolkit!=3.0.37,<3.1.0,>=3.0.30 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (3.0.38)\n",
+      "Requirement already satisfied: pygments>=2.4.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (2.15.1)\n",
+      "Requirement already satisfied: stack-data in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (0.6.2)\n",
+      "Requirement already satisfied: pexpect>4.3 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (4.8.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from jupyter-client>=6.1.12->ipykernel) (2.8.2)\n",
+      "Requirement already satisfied: platformdirs>=2.5 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from jupyter-core!=5.0.*,>=4.12->ipykernel) (3.8.0)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from jedi>=0.16->ipython>=7.23.1->ipykernel) (0.8.3)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from pexpect>4.3->ipython>=7.23.1->ipykernel) (0.7.0)\n",
+      "Requirement already satisfied: wcwidth in ./tf_recommenders_kernel/lib/python3.10/site-packages (from prompt-toolkit!=3.0.37,<3.1.0,>=3.0.30->ipython>=7.23.1->ipykernel) (0.2.6)\n",
+      "Requirement already satisfied: six>=1.5 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from python-dateutil>=2.8.2->jupyter-client>=6.1.12->ipykernel) (1.16.0)\n",
+      "Requirement already satisfied: executing>=1.2.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from stack-data->ipython>=7.23.1->ipykernel) (1.2.0)\n",
+      "Requirement already satisfied: asttokens>=2.1.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from stack-data->ipython>=7.23.1->ipykernel) (2.2.1)\n",
+      "Requirement already satisfied: pure-eval in ./tf_recommenders_kernel/lib/python3.10/site-packages (from stack-data->ipython>=7.23.1->ipykernel) (0.2.2)\n",
+      "Installed kernelspec tf_recommenders_kernel in /home/jupyter/.local/share/jupyter/kernels/tf_recommenders_kernel\n",
+      "Requirement already satisfied: tensorflow-recommenders==0.7.2 in ./tf_recommenders_kernel/lib/python3.10/site-packages (0.7.2)\n",
+      "Requirement already satisfied: tensorflow>=2.9.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-recommenders==0.7.2) (2.12.0)\n",
+      "Requirement already satisfied: absl-py>=0.1.6 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-recommenders==0.7.2) (1.4.0)\n",
+      "Requirement already satisfied: astunparse>=1.6.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.6.3)\n",
+      "Requirement already satisfied: flatbuffers>=2.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (23.5.26)\n",
+      "Requirement already satisfied: gast<=0.4.0,>=0.2.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.4.0)\n",
+      "Requirement already satisfied: google-pasta>=0.1.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.2.0)\n",
+      "Requirement already satisfied: grpcio<2.0,>=1.24.3 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.56.0)\n",
+      "Requirement already satisfied: h5py>=2.9.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (3.9.0)\n",
+      "Requirement already satisfied: jax>=0.3.15 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.4.13)\n",
+      "Requirement already satisfied: keras<2.13,>=2.12.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2.12.0)\n",
+      "Requirement already satisfied: libclang>=13.0.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (16.0.0)\n",
+      "Requirement already satisfied: numpy<1.24,>=1.22 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.23.5)\n",
+      "Requirement already satisfied: opt-einsum>=2.3.2 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (3.3.0)\n",
+      "Requirement already satisfied: packaging in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (23.1)\n",
+      "Requirement already satisfied: protobuf!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.20.3 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (3.20.3)\n",
+      "Requirement already satisfied: setuptools in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (65.5.0)\n",
+      "Requirement already satisfied: six>=1.12.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.16.0)\n",
+      "Requirement already satisfied: tensorboard<2.13,>=2.12 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2.12.3)\n",
+      "Requirement already satisfied: tensorflow-estimator<2.13,>=2.12.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2.12.0)\n",
+      "Requirement already satisfied: termcolor>=1.1.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2.3.0)\n",
+      "Requirement already satisfied: typing-extensions>=3.6.6 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (4.7.1)\n",
+      "Requirement already satisfied: wrapt<1.15,>=1.11.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.14.1)\n",
+      "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.23.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.32.0)\n",
+      "Requirement already satisfied: wheel<1.0,>=0.23.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from astunparse>=1.6.0->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.40.0)\n",
+      "Requirement already satisfied: ml-dtypes>=0.1.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from jax>=0.3.15->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.2.0)\n",
+      "Requirement already satisfied: scipy>=1.7 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from jax>=0.3.15->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.11.1)\n",
+      "Requirement already satisfied: google-auth<3,>=1.6.3 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2.21.0)\n",
+      "Requirement already satisfied: google-auth-oauthlib<1.1,>=0.5 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.0.0)\n",
+      "Requirement already satisfied: markdown>=2.6.8 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (3.4.3)\n",
+      "Requirement already satisfied: requests<3,>=2.21.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2.31.0)\n",
+      "Requirement already satisfied: tensorboard-data-server<0.8.0,>=0.7.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.7.1)\n",
+      "Requirement already satisfied: werkzeug>=1.0.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2.3.6)\n",
+      "Requirement already satisfied: cachetools<6.0,>=2.0.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from google-auth<3,>=1.6.3->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (5.3.1)\n",
+      "Requirement already satisfied: pyasn1-modules>=0.2.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from google-auth<3,>=1.6.3->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.3.0)\n",
+      "Requirement already satisfied: rsa<5,>=3.1.4 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from google-auth<3,>=1.6.3->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (4.9)\n",
+      "Requirement already satisfied: urllib3<2.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from google-auth<3,>=1.6.3->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.26.16)\n",
+      "Requirement already satisfied: requests-oauthlib>=0.7.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from google-auth-oauthlib<1.1,>=0.5->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (1.3.1)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from requests<3,>=2.21.0->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (3.1.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from requests<3,>=2.21.0->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (3.4)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from requests<3,>=2.21.0->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2023.5.7)\n",
+      "Requirement already satisfied: MarkupSafe>=2.1.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from werkzeug>=1.0.1->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (2.1.3)\n",
+      "Requirement already satisfied: pyasn1<0.6.0,>=0.4.6 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (0.5.0)\n",
+      "Requirement already satisfied: oauthlib>=3.0.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<1.1,>=0.5->tensorboard<2.13,>=2.12->tensorflow>=2.9.0->tensorflow-recommenders==0.7.2) (3.2.2)\n",
+      "Requirement already satisfied: tensorflow-datasets==4.7.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (4.7.0)\n",
+      "Requirement already satisfied: absl-py in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (1.4.0)\n",
+      "Requirement already satisfied: dill in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (0.3.6)\n",
+      "Requirement already satisfied: etils[epath] in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (1.3.0)\n",
+      "Requirement already satisfied: numpy in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (1.23.5)\n",
+      "Requirement already satisfied: promise in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (2.3)\n",
+      "Requirement already satisfied: protobuf>=3.12.2 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (3.20.3)\n",
+      "Requirement already satisfied: requests>=2.19.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (2.31.0)\n",
+      "Requirement already satisfied: six in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (1.16.0)\n",
+      "Requirement already satisfied: tensorflow-metadata in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (1.13.1)\n",
+      "Requirement already satisfied: termcolor in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (2.3.0)\n",
+      "Requirement already satisfied: toml in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (0.10.2)\n",
+      "Requirement already satisfied: tqdm in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-datasets==4.7.0) (4.65.0)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from requests>=2.19.0->tensorflow-datasets==4.7.0) (3.1.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from requests>=2.19.0->tensorflow-datasets==4.7.0) (3.4)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from requests>=2.19.0->tensorflow-datasets==4.7.0) (1.26.16)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from requests>=2.19.0->tensorflow-datasets==4.7.0) (2023.5.7)\n",
+      "Requirement already satisfied: importlib_resources in ./tf_recommenders_kernel/lib/python3.10/site-packages (from etils[epath]->tensorflow-datasets==4.7.0) (5.12.0)\n",
+      "Requirement already satisfied: typing_extensions in ./tf_recommenders_kernel/lib/python3.10/site-packages (from etils[epath]->tensorflow-datasets==4.7.0) (4.7.1)\n",
+      "Requirement already satisfied: zipp in ./tf_recommenders_kernel/lib/python3.10/site-packages (from etils[epath]->tensorflow-datasets==4.7.0) (3.15.0)\n",
+      "Requirement already satisfied: googleapis-common-protos<2,>=1.52.0 in ./tf_recommenders_kernel/lib/python3.10/site-packages (from tensorflow-metadata->tensorflow-datasets==4.7.0) (1.59.1)\n",
+      "Requirement already satisfied: protobuf==3.20.3 in ./tf_recommenders_kernel/lib/python3.10/site-packages (3.20.3)\n"
+     ]
+    }
+   ],
    "source": [
     "!cd ~/asl-ml-immersion && make tf_recommenders_kernel"
    ]
@@ -120,20 +231,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:54:15.333605Z",
-     "iopub.status.busy": "2020-11-19T23:54:15.332879Z",
-     "iopub.status.idle": "2020-11-19T23:54:23.005957Z",
-     "shell.execute_reply": "2020-11-19T23:54:23.005309Z"
-    },
-    "id": "SZGYDaF-m5wZ"
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Importing necessary modules\n",
     "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "SZGYDaF-m5wZ",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
     "import pprint\n",
     "import tempfile\n",
     "from typing import Dict, Text\n",
@@ -145,15 +263,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:54:23.010486Z",
-     "iopub.status.busy": "2020-11-19T23:54:23.009830Z",
-     "iopub.status.idle": "2020-11-19T23:54:23.373194Z",
-     "shell.execute_reply": "2020-11-19T23:54:23.372587Z"
-    },
-    "id": "BxQ_hy7xPH3N"
+    "id": "BxQ_hy7xPH3N",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -177,30 +290,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:54:23.378511Z",
-     "iopub.status.busy": "2020-11-19T23:54:23.377856Z",
-     "iopub.status.idle": "2020-11-19T23:55:34.157674Z",
-     "shell.execute_reply": "2020-11-19T23:55:34.157128Z"
-    },
-    "id": "aaQhqcLGP0jL"
+    "id": "aaQhqcLGP0jL",
+    "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1mDownloading and preparing dataset movielens/100k-ratings/0.1.0 (download: 4.70 MiB, generated: 32.41 MiB, total: 37.10 MiB) to /home/kbuilder/tensorflow_datasets/movielens/100k-ratings/0.1.0...\u001b[0m\n",
-      "Shuffling and writing examples to /home/kbuilder/tensorflow_datasets/movielens/100k-ratings/0.1.0.incompleteN2R8B5/movielens-train.tfrecord\n",
-      "\u001b[1mDataset movielens downloaded and prepared to /home/kbuilder/tensorflow_datasets/movielens/100k-ratings/0.1.0. Subsequent calls will reuse this data.\u001b[0m\n",
-      "\u001b[1mDownloading and preparing dataset movielens/100k-movies/0.1.0 (download: 4.70 MiB, generated: 150.35 KiB, total: 4.84 MiB) to /home/kbuilder/tensorflow_datasets/movielens/100k-movies/0.1.0...\u001b[0m\n",
-      "Shuffling and writing examples to /home/kbuilder/tensorflow_datasets/movielens/100k-movies/0.1.0.incompleteH88HCK/movielens-train.tfrecord\n",
-      "\u001b[1mDataset movielens downloaded and prepared to /home/kbuilder/tensorflow_datasets/movielens/100k-movies/0.1.0. Subsequent calls will reuse this data.\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# TODO 1 - Your code is here.\n",
     "# Ratings data.\n",
@@ -228,15 +323,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:34.162932Z",
-     "iopub.status.busy": "2020-11-19T23:55:34.162262Z",
-     "iopub.status.idle": "2020-11-19T23:55:34.213467Z",
-     "shell.execute_reply": "2020-11-19T23:55:34.213898Z"
-    },
-    "id": "_1-KQV2ynMdh"
+    "id": "_1-KQV2ynMdh",
+    "tags": []
    },
    "outputs": [
     {
@@ -275,15 +365,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:34.218885Z",
-     "iopub.status.busy": "2020-11-19T23:55:34.218204Z",
-     "iopub.status.idle": "2020-11-19T23:55:34.248818Z",
-     "shell.execute_reply": "2020-11-19T23:55:34.249261Z"
-    },
-    "id": "kHLsIHhw_x1d"
+    "id": "kHLsIHhw_x1d",
+    "tags": []
    },
    "outputs": [
     {
@@ -315,15 +400,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:34.255269Z",
-     "iopub.status.busy": "2020-11-19T23:55:34.254434Z",
-     "iopub.status.idle": "2020-11-19T23:55:34.303953Z",
-     "shell.execute_reply": "2020-11-19T23:55:34.303149Z"
-    },
-    "id": "uhbEvPJqxLec"
+    "id": "uhbEvPJqxLec",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -351,15 +431,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:34.309737Z",
-     "iopub.status.busy": "2020-11-19T23:55:34.308925Z",
-     "iopub.status.idle": "2020-11-19T23:55:34.313579Z",
-     "shell.execute_reply": "2020-11-19T23:55:34.313049Z"
-    },
-    "id": "rS0eDfkjnjJL"
+    "id": "rS0eDfkjnjJL",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -386,15 +461,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:34.319472Z",
-     "iopub.status.busy": "2020-11-19T23:55:34.318762Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.398905Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.399392Z"
-    },
-    "id": "MKROCiPo_5LJ"
+    "id": "MKROCiPo_5LJ",
+    "tags": []
    },
    "outputs": [
     {
@@ -409,7 +479,7 @@
        "       b'39 Steps, The (1935)'], dtype=object)"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,15 +523,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.404100Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.403412Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.405427Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.405826Z"
-    },
-    "id": "QbIy1FP8aCTq"
+    "id": "QbIy1FP8aCTq",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -481,15 +546,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.411279Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.410595Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.434393Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.434901Z"
-    },
-    "id": "kHQZJEhXP93N"
+    "id": "kHQZJEhXP93N",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -528,15 +588,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.442915Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.442232Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.450293Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.450728Z"
-    },
-    "id": "qNUwfIJTQ332"
+    "id": "qNUwfIJTQ332",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -571,15 +626,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.455869Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.455118Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.526325Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.525724Z"
-    },
-    "id": "1dLDL6pZVPO8"
+    "id": "1dLDL6pZVPO8",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -607,15 +657,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.534258Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.533537Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.535402Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.535806Z"
-    },
-    "id": "tJ61Iz2QTBw3"
+    "id": "tJ61Iz2QTBw3",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -648,15 +693,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.542749Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.542072Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.543933Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.544345Z"
-    },
-    "id": "8n7c5CHFp0ow"
+    "id": "8n7c5CHFp0ow",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -770,15 +810,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.563618Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.562890Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.580740Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.581184Z"
-    },
-    "id": "aW63YaqP2wCf"
+    "id": "aW63YaqP2wCf",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -798,15 +833,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.585846Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.585173Z",
-     "iopub.status.idle": "2020-11-19T23:55:38.589474Z",
-     "shell.execute_reply": "2020-11-19T23:55:38.588968Z"
-    },
-    "id": "53QJwY1gUnfv"
+    "id": "53QJwY1gUnfv",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -825,15 +855,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:38.595867Z",
-     "iopub.status.busy": "2020-11-19T23:55:38.595164Z",
-     "iopub.status.idle": "2020-11-19T23:55:48.304441Z",
-     "shell.execute_reply": "2020-11-19T23:55:48.303920Z"
-    },
-    "id": "ZxPntlT8EFOZ"
+    "id": "ZxPntlT8EFOZ",
+    "tags": []
    },
    "outputs": [
     {
@@ -841,76 +866,20 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/3\n",
-      "WARNING:tensorflow:The dtype of the source tensor must be floating (e.g. tf.float32) when calling GradientTape.gradient, got tf.int32\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:The dtype of the source tensor must be floating (e.g. tf.float32) when calling GradientTape.gradient, got tf.int32\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:Gradients do not exist for variables ['counter:0'] when minimizing the loss.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:Gradients do not exist for variables ['counter:0'] when minimizing the loss.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:The dtype of the source tensor must be floating (e.g. tf.float32) when calling GradientTape.gradient, got tf.int32\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:The dtype of the source tensor must be floating (e.g. tf.float32) when calling GradientTape.gradient, got tf.int32\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:Gradients do not exist for variables ['counter:0'] when minimizing the loss.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:Gradients do not exist for variables ['counter:0'] when minimizing the loss.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "10/10 [==============================] - 2s 238ms/step - factorized_top_k/top_1_categorical_accuracy: 0.0011 - factorized_top_k/top_5_categorical_accuracy: 0.0090 - factorized_top_k/top_10_categorical_accuracy: 0.0190 - factorized_top_k/top_50_categorical_accuracy: 0.0961 - factorized_top_k/top_100_categorical_accuracy: 0.1735 - loss: 69885.1072 - regularization_loss: 0.0000e+00 - total_loss: 69885.1072\n",
+      "10/10 [==============================] - 12s 643ms/step - factorized_top_k/top_1_categorical_accuracy: 1.5000e-04 - factorized_top_k/top_5_categorical_accuracy: 0.0024 - factorized_top_k/top_10_categorical_accuracy: 0.0062 - factorized_top_k/top_50_categorical_accuracy: 0.0590 - factorized_top_k/top_100_categorical_accuracy: 0.1303 - loss: 69818.3991 - regularization_loss: 0.0000e+00 - total_loss: 69818.3991\n",
       "Epoch 2/3\n",
-      "10/10 [==============================] - 2s 224ms/step - factorized_top_k/top_1_categorical_accuracy: 0.0028 - factorized_top_k/top_5_categorical_accuracy: 0.0187 - factorized_top_k/top_10_categorical_accuracy: 0.0374 - factorized_top_k/top_50_categorical_accuracy: 0.1686 - factorized_top_k/top_100_categorical_accuracy: 0.2919 - loss: 67523.3707 - regularization_loss: 0.0000e+00 - total_loss: 67523.3707\n",
+      "10/10 [==============================] - 6s 567ms/step - factorized_top_k/top_1_categorical_accuracy: 0.0010 - factorized_top_k/top_5_categorical_accuracy: 0.0121 - factorized_top_k/top_10_categorical_accuracy: 0.0275 - factorized_top_k/top_50_categorical_accuracy: 0.1435 - factorized_top_k/top_100_categorical_accuracy: 0.2662 - loss: 67458.0007 - regularization_loss: 0.0000e+00 - total_loss: 67458.0007\n",
       "Epoch 3/3\n",
-      "10/10 [==============================] - 2s 219ms/step - factorized_top_k/top_1_categorical_accuracy: 0.0035 - factorized_top_k/top_5_categorical_accuracy: 0.0222 - factorized_top_k/top_10_categorical_accuracy: 0.0457 - factorized_top_k/top_50_categorical_accuracy: 0.1877 - factorized_top_k/top_100_categorical_accuracy: 0.3158 - loss: 66302.9609 - regularization_loss: 0.0000e+00 - total_loss: 66302.9609\n"
+      "10/10 [==============================] - 6s 577ms/step - factorized_top_k/top_1_categorical_accuracy: 0.0015 - factorized_top_k/top_5_categorical_accuracy: 0.0186 - factorized_top_k/top_10_categorical_accuracy: 0.0394 - factorized_top_k/top_50_categorical_accuracy: 0.1777 - factorized_top_k/top_100_categorical_accuracy: 0.3053 - loss: 66312.9183 - regularization_loss: 0.0000e+00 - total_loss: 66312.9183\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x7f04c679ca20>"
+       "<keras.callbacks.History at 0x7f5c44cdf100>"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -943,38 +912,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:48.310172Z",
-     "iopub.status.busy": "2020-11-19T23:55:48.309127Z",
-     "iopub.status.idle": "2020-11-19T23:55:49.757116Z",
-     "shell.execute_reply": "2020-11-19T23:55:49.757537Z"
-    },
-    "id": "W-zu6HLODNeI"
+    "id": "W-zu6HLODNeI",
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5/5 [==============================] - 1s 118ms/step - factorized_top_k/top_1_categorical_accuracy: 0.0010 - factorized_top_k/top_5_categorical_accuracy: 0.0097 - factorized_top_k/top_10_categorical_accuracy: 0.0226 - factorized_top_k/top_50_categorical_accuracy: 0.1244 - factorized_top_k/top_100_categorical_accuracy: 0.2327 - loss: 31079.0628 - regularization_loss: 0.0000e+00 - total_loss: 31079.0628\n"
+      "5/5 [==============================] - 5s 338ms/step - factorized_top_k/top_1_categorical_accuracy: 0.0013 - factorized_top_k/top_5_categorical_accuracy: 0.0086 - factorized_top_k/top_10_categorical_accuracy: 0.0214 - factorized_top_k/top_50_categorical_accuracy: 0.1239 - factorized_top_k/top_100_categorical_accuracy: 0.2339 - loss: 31094.2777 - regularization_loss: 0.0000e+00 - total_loss: 31094.2777\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'factorized_top_k/top_1_categorical_accuracy': 0.0010000000474974513,\n",
-       " 'factorized_top_k/top_5_categorical_accuracy': 0.009650000371038914,\n",
-       " 'factorized_top_k/top_10_categorical_accuracy': 0.022600000724196434,\n",
-       " 'factorized_top_k/top_50_categorical_accuracy': 0.12439999729394913,\n",
-       " 'factorized_top_k/top_100_categorical_accuracy': 0.23270000517368317,\n",
-       " 'loss': 28244.76953125,\n",
+       "{'factorized_top_k/top_1_categorical_accuracy': 0.0013000000035390258,\n",
+       " 'factorized_top_k/top_5_categorical_accuracy': 0.008550000376999378,\n",
+       " 'factorized_top_k/top_10_categorical_accuracy': 0.02135000005364418,\n",
+       " 'factorized_top_k/top_50_categorical_accuracy': 0.12394999712705612,\n",
+       " 'factorized_top_k/top_100_categorical_accuracy': 0.23389999568462372,\n",
+       " 'loss': 28273.32421875,\n",
        " 'regularization_loss': 0,\n",
-       " 'total_loss': 28244.76953125}"
+       " 'total_loss': 28273.32421875}"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1012,23 +976,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 19,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:49.783831Z",
-     "iopub.status.busy": "2020-11-19T23:55:49.782958Z",
-     "iopub.status.idle": "2020-11-19T23:55:49.986051Z",
-     "shell.execute_reply": "2020-11-19T23:55:49.986495Z"
-    },
-    "id": "IRD6bEtZW_8j"
+    "id": "IRD6bEtZW_8j",
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Recommendations for user 42: [b'Bridges of Madison County, The (1995)'\n",
-      " b'Father of the Bride Part II (1995)' b'Rudy (1993)']\n"
+      "Recommendations for user 42: [b\"Kid in King Arthur's Court, A (1995)\"\n",
+      " b'Bedknobs and Broomsticks (1971)' b'Aristocats, The (1970)']\n"
      ]
     }
    ],
@@ -1085,22 +1044,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 20,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:49.993195Z",
-     "iopub.status.busy": "2020-11-19T23:55:49.991304Z",
-     "iopub.status.idle": "2020-11-19T23:55:50.846812Z",
-     "shell.execute_reply": "2020-11-19T23:55:50.847256Z"
-    },
-    "id": "oJkRNBfCW5_E"
+    "id": "oJkRNBfCW5_E",
+    "tags": []
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:Model's `__init__()` arguments contain non-serializable objects. Please implement a `get_config()` method in the subclassed Model for proper saving and loading. Defaulting to empty config.\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-09-29 13:25:05.366590: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n",
+      "WARNING:tensorflow:Model's `__init__()` arguments contain non-serializable objects. Please implement a `get_config()` method in the subclassed Model for proper saving and loading. Defaulting to empty config.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:Model's `__init__()` arguments contain non-serializable objects. Please implement a `get_config()` method in the subclassed Model for proper saving and loading. Defaulting to empty config.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:Model's `__init__()` arguments contain non-serializable objects. Please implement a `get_config()` method in the subclassed Model for proper saving and loading. Defaulting to empty config.\n",
       "WARNING:absl:Found untraced functions such as query_with_exclusions while saving (showing 1 of 1). These functions will not be directly callable after loading.\n"
      ]
     },
@@ -1108,22 +1083,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:tensorflow:Assets written to: /tmp/tmpklbnqnat/model/assets\n"
+      "INFO:tensorflow:Assets written to: /var/tmp/tmp15106khc/model/assets\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:tensorflow:Assets written to: /tmp/tmpklbnqnat/model/assets\n"
+      "INFO:tensorflow:Assets written to: /var/tmp/tmp15106khc/model/assets\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Recommendations: [b'Bridges of Madison County, The (1995)'\n",
-      " b'Father of the Bride Part II (1995)' b'Rudy (1993)']\n"
+      "Recommendations: [b\"Kid in King Arthur's Court, A (1995)\"\n",
+      " b'Bedknobs and Broomsticks (1971)' b'Aristocats, The (1970)']\n"
      ]
     }
    ],
@@ -1151,258 +1126,7 @@
     "id": "nBBGodbE5ENC"
    },
    "source": [
-    "We can also export an approximate retrieval index to speed up predictions. This will make it possible to efficiently surface recommendations from sets of tens of millions of candidates.\n",
-    "\n",
-    "To do so, we can use the `scann` package. This is an optional dependency of TFRS, and we installed it separately at the beginning of this notebook by calling `!pip install -q scann`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "15PtZqoO5k_k"
-   },
-   "source": [
-    "Once installed we can use the TFRS `ScaNN` layer:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:50.871341Z",
-     "iopub.status.busy": "2020-11-19T23:55:50.870436Z",
-     "iopub.status.idle": "2020-11-19T23:55:51.206268Z",
-     "shell.execute_reply": "2020-11-19T23:55:51.206720Z"
-    },
-    "id": "rTz8yxyp5uwU"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<tensorflow_recommenders.layers.factorized_top_k.ScaNN at 0x7f04c6617dd8>"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "scann_index = tfrs.layers.factorized_top_k.ScaNN(model.user_model)\n",
-    "scann_index.index_from_dataset(\n",
-    "    tf.data.Dataset.zip(\n",
-    "        (movies.batch(100), movies.batch(100).map(model.movie_model))\n",
-    "    )\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "UpLnoUv256bS"
-   },
-   "source": [
-    "This layer will perform _approximate_ lookups: this makes retrieval slightly less accurate, but orders of magnitude faster on large candidate sets."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:51.216049Z",
-     "iopub.status.busy": "2020-11-19T23:55:51.215339Z",
-     "iopub.status.idle": "2020-11-19T23:55:51.274544Z",
-     "shell.execute_reply": "2020-11-19T23:55:51.275002Z"
-    },
-    "id": "Te_MGu1Q6JrU"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Recommendations for user 42: [b'Bridges of Madison County, The (1995)'\n",
-      " b'Father of the Bride Part II (1995)' b'Rudy (1993)']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Get recommendations.\n",
-    "_, titles = scann_index(tf.constant([\"42\"]))\n",
-    "print(f\"Recommendations for user 42: {titles[0, :3]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Izo0IUMA6TQm"
-   },
-   "source": [
-    "Exporting it for serving is as easy as exporting the `BruteForce` layer:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-19T23:55:51.281935Z",
-     "iopub.status.busy": "2020-11-19T23:55:51.281218Z",
-     "iopub.status.idle": "2020-11-19T23:55:52.228819Z",
-     "shell.execute_reply": "2020-11-19T23:55:52.229297Z"
-    },
-    "id": "K7NUqgxU6W_T"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:Found untraced functions such as query_with_exclusions while saving (showing 1 of 1). These functions will not be directly callable after loading.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: /tmp/tmpnw8jix65/model/assets\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: /tmp/tmpnw8jix65/model/assets\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Recommendations: [b'Bridges of Madison County, The (1995)'\n",
-      " b'Father of the Bride Part II (1995)' b'Rudy (1993)']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# TODO 4 - Your code is here.\n",
-    "# Export the query model.\n",
-    "with tempfile.TemporaryDirectory() as tmp:\n",
-    "    path = os.path.join(tmp, \"model\")\n",
-    "\n",
-    "    # Save the index.\n",
-    "    tf.saved_model.save(index, path)\n",
-    "\n",
-    "    # Load it back; can also be done in TensorFlow Serving.\n",
-    "    loaded = tf.saved_model.load(path)\n",
-    "\n",
-    "    # Pass a user id in, get top predicted movie titles back.\n",
-    "    scores, titles = loaded([\"42\"])\n",
-    "\n",
-    "    print(f\"Recommendations: {titles[0][:3]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "nBBGodbE5ENC"
-   },
-   "source": [
-    "We can also export an approximate retrieval index to speed up predictions. This will make it possible to efficiently surface recommendations from sets of tens of millions of candidates.\n",
-    "\n",
-    "To do so, we can use the `scann` package. This is an optional dependency of TFRS, and we installed it separately at the beginning of this notebook by calling `!pip install -q scann`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "15PtZqoO5k_k"
-   },
-   "source": [
-    "Once installed we can use the TFRS `ScaNN` layer:\n",
-    "\n",
-    "**Disabling this section, since ScaNN library is not compatible with Python 3.10 currently.**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "id": "rTz8yxyp5uwU",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# scann_index = tfrs.layers.factorized_top_k.ScaNN(model.user_model)\n",
-    "# scann_index.index_from_dataset(\n",
-    "#     tf.data.Dataset.zip(\n",
-    "#         (movies.batch(100), movies.batch(100).map(model.movie_model))\n",
-    "#     )\n",
-    "# )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "UpLnoUv256bS"
-   },
-   "source": [
-    "This layer will perform _approximate_ lookups: this makes retrieval slightly less accurate, but orders of magnitude faster on large candidate sets."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "id": "Te_MGu1Q6JrU",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# # Get recommendations.\n",
-    "# _, titles = scann_index(tf.constant([\"42\"]))\n",
-    "# print(f\"Recommendations for user 42: {titles[0, :3]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Izo0IUMA6TQm"
-   },
-   "source": [
-    "Exporting it for serving is as easy as exporting the `BruteForce` layer:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "id": "K7NUqgxU6W_T",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# # Export the query model.\n",
-    "# with tempfile.TemporaryDirectory() as tmp:\n",
-    "#     path = os.path.join(tmp, \"model\")\n",
-    "\n",
-    "#     # Save the index.\n",
-    "#     tf.saved_model.save(\n",
-    "#         scann_index,\n",
-    "#         path,\n",
-    "#         options=tf.saved_model.SaveOptions(namespace_whitelist=[\"Scann\"]),\n",
-    "#     )\n",
-    "\n",
-    "#     # Load it back; can also be done in TensorFlow Serving.\n",
-    "#     loaded = tf.saved_model.load(path)\n",
-    "\n",
-    "#     # Pass a user id in, get top predicted movie titles back.\n",
-    "#     scores, titles = loaded([\"42\"])\n",
-    "\n",
-    "#     print(f\"Recommendations: {titles[0][:3]}\")"
+    "We can also export an approximate retrieval index to speed up predictions. This will make it possible to efficiently surface recommendations from sets of tens of millions of candidates."
    ]
   },
   {
@@ -1449,15 +1173,15 @@
    "toc_visible": true
   },
   "environment": {
-   "kernel": "python3",
-   "name": "tf2-gpu.2-8.m92",
+   "kernel": "tf_recommenders_kernel",
+   "name": "tf2-gpu.2-12.m109",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m92"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-12:m109"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "tf_recommenders_kernel",
    "language": "python",
-   "name": "python3"
+   "name": "tf_recommenders_kernel"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1469,7 +1193,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/recommendation_systems/solutions/tfrs_basic_retrieval.ipynb
+++ b/notebooks/recommendation_systems/solutions/tfrs_basic_retrieval.ipynb
@@ -1288,16 +1288,13 @@
     }
    ],
    "source": [
+    "# TODO 4 - Your code is here.\n",
     "# Export the query model.\n",
     "with tempfile.TemporaryDirectory() as tmp:\n",
     "    path = os.path.join(tmp, \"model\")\n",
     "\n",
     "    # Save the index.\n",
-    "    tf.saved_model.save(\n",
-    "        scann_index,\n",
-    "        path,\n",
-    "        options=tf.saved_model.SaveOptions(namespace_whitelist=[\"Scann\"]),\n",
-    "    )\n",
+    "    tf.saved_model.save(index, path)\n",
     "\n",
     "    # Load it back; can also be done in TensorFlow Serving.\n",
     "    loaded = tf.saved_model.load(path)\n",
@@ -1306,6 +1303,106 @@
     "    scores, titles = loaded([\"42\"])\n",
     "\n",
     "    print(f\"Recommendations: {titles[0][:3]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nBBGodbE5ENC"
+   },
+   "source": [
+    "We can also export an approximate retrieval index to speed up predictions. This will make it possible to efficiently surface recommendations from sets of tens of millions of candidates.\n",
+    "\n",
+    "To do so, we can use the `scann` package. This is an optional dependency of TFRS, and we installed it separately at the beginning of this notebook by calling `!pip install -q scann`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "15PtZqoO5k_k"
+   },
+   "source": [
+    "Once installed we can use the TFRS `ScaNN` layer:\n",
+    "\n",
+    "**Disabling this section, since ScaNN library is not compatible with Python 3.10 currently.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "id": "rTz8yxyp5uwU",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# scann_index = tfrs.layers.factorized_top_k.ScaNN(model.user_model)\n",
+    "# scann_index.index_from_dataset(\n",
+    "#     tf.data.Dataset.zip(\n",
+    "#         (movies.batch(100), movies.batch(100).map(model.movie_model))\n",
+    "#     )\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "UpLnoUv256bS"
+   },
+   "source": [
+    "This layer will perform _approximate_ lookups: this makes retrieval slightly less accurate, but orders of magnitude faster on large candidate sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "id": "Te_MGu1Q6JrU",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # Get recommendations.\n",
+    "# _, titles = scann_index(tf.constant([\"42\"]))\n",
+    "# print(f\"Recommendations for user 42: {titles[0, :3]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Izo0IUMA6TQm"
+   },
+   "source": [
+    "Exporting it for serving is as easy as exporting the `BruteForce` layer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "id": "K7NUqgxU6W_T",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # Export the query model.\n",
+    "# with tempfile.TemporaryDirectory() as tmp:\n",
+    "#     path = os.path.join(tmp, \"model\")\n",
+    "\n",
+    "#     # Save the index.\n",
+    "#     tf.saved_model.save(\n",
+    "#         scann_index,\n",
+    "#         path,\n",
+    "#         options=tf.saved_model.SaveOptions(namespace_whitelist=[\"Scann\"]),\n",
+    "#     )\n",
+    "\n",
+    "#     # Load it back; can also be done in TensorFlow Serving.\n",
+    "#     loaded = tf.saved_model.load(path)\n",
+    "\n",
+    "#     # Pass a user id in, get top predicted movie titles back.\n",
+    "#     scores, titles = loaded([\"42\"])\n",
+    "\n",
+    "#     print(f\"Recommendations: {titles[0][:3]}\")"
    ]
   },
   {


### PR DESCRIPTION
Disabling ScaNN since it's not compatible with Python 3.10.
