### PR TITLE
UPDATE: Reinforcement Learning

### DIFF
--- a/notebooks/reinforcement_learning/requirements.txt
+++ b/notebooks/reinforcement_learning/requirements.txt
@@ -1,4 +1,6 @@
+numpy==1.21.6
 pandas==1.3.5
 tensorflow==2.11.0
 tensorflow-io==0.28.0
 tf-agents==0.11.0
+tensorflow-probability==0.19.0


### PR DESCRIPTION
I updated the module kernel only so that the kernel loads the right version of the libraries in the new TF 2.12 environment. 

The lab still requires to load the `reinforcement_learning` kernel to be executed. 

