### PR TITLE
Added Keras CV&NLP to the requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ apache-beam==2.46.0
 tensorflow_text==2.12.1
 tf-agents==0.16.0
 tf-models-official==2.12.0
+keras_cv==0.5.1
+keras_nlp==0.5.1
 
 # For development work
 pre-commit


### PR DESCRIPTION
Added `keras_cv==0.5.1` and `keras_nlp==0.5.1` to the `requirements.txt`, since it is/will be used in new modules.

Keras CV and Keras NLP starts multi-backend support from 0.6.x, and dependencies is overhauled on that version. 
So this version `0.5.1` is picked to avoid unintended issues and to minimize the dependencies change.

I confirmed this change won't affect other library dependencies with the commands below.

```
git clone https://github.com/GoogleCloudPlatform/asl-ml-immersion.git
cd asl-ml-immersion
export PATH=$PATH:~/.local/bin
make install

pip list >> pip_old.txt

pip install --user keras_cv==0.5.1
pip install --user keras_nlp==0.5.1

pip list >> pip_new.txt

diff pip_old.txt pip_new.txt
```
Output
```
172a173,174
> keras-cv                                 0.5.1
> keras-nlp                                0.5.1
```
