### PR TITLE
Updated SGD from log (deprecated v1.1) to log_loss (v1.3)

### DIFF
--- a/notebooks/kubeflow_pipelines/cicd/labs/trainer_image_vertex/train.py
+++ b/notebooks/kubeflow_pipelines/cicd/labs/trainer_image_vertex/train.py
@@ -53,7 +53,7 @@ def train_evaluate(
     pipeline = Pipeline(
         [
             ("preprocessor", preprocessor),
-            ("classifier", SGDClassifier(loss="log")),
+            ("classifier", SGDClassifier(loss="log_loss")),
         ]
     )
 

--- a/notebooks/kubeflow_pipelines/cicd/solutions/trainer_image_vertex/train.py
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/trainer_image_vertex/train.py
@@ -53,7 +53,7 @@ def train_evaluate(
     pipeline = Pipeline(
         [
             ("preprocessor", preprocessor),
-            ("classifier", SGDClassifier(loss="log")),
+            ("classifier", SGDClassifier(loss="log_loss")),
         ]
     )
 

--- a/notebooks/kubeflow_pipelines/pipelines/labs/trainer_image_vertex/train.py
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/trainer_image_vertex/train.py
@@ -53,7 +53,7 @@ def train_evaluate(
     pipeline = Pipeline(
         [
             ("preprocessor", preprocessor),
-            ("classifier", SGDClassifier(loss="log")),
+            ("classifier", SGDClassifier(loss="log_loss")),
         ]
     )
 

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/trainer_image_vertex/train.py
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/trainer_image_vertex/train.py
@@ -53,7 +53,7 @@ def train_evaluate(
     pipeline = Pipeline(
         [
             ("preprocessor", preprocessor),
-            ("classifier", SGDClassifier(loss="log")),
+            ("classifier", SGDClassifier(loss="log_loss")),
         ]
     )
 

--- a/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough_vertex.ipynb
@@ -280,7 +280,7 @@
     "pipeline = Pipeline(\n",
     "    [\n",
     "        (\"preprocessor\", preprocessor),\n",
-    "        (\"classifier\", SGDClassifier(loss=\"log\", tol=1e-3)),\n",
+    "        (\"classifier\", SGDClassifier(loss=\"log_loss\", tol=1e-3)),\n",
     "    ]\n",
     ")"
    ]
@@ -415,7 +415,7 @@
     "\n",
     "    pipeline = Pipeline([\n",
     "        ('preprocessor', preprocessor),\n",
-    "        ('classifier', SGDClassifier(loss='log',tol=1e-3))\n",
+    "        ('classifier', SGDClassifier(loss='log_loss',tol=1e-3))\n",
     "    ])\n",
     "\n",
     "    num_features_type_map = {feature: 'float64' for feature in df_train.columns[numeric_feature_indexes]}\n",

--- a/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb
@@ -284,7 +284,7 @@
     "pipeline = Pipeline(\n",
     "    [\n",
     "        (\"preprocessor\", preprocessor),\n",
-    "        (\"classifier\", SGDClassifier(loss=\"log\", tol=1e-3)),\n",
+    "        (\"classifier\", SGDClassifier(loss=\"log_loss\", tol=1e-3)),\n",
     "    ]\n",
     ")"
    ]
@@ -419,7 +419,7 @@
     "\n",
     "    pipeline = Pipeline([\n",
     "        ('preprocessor', preprocessor),\n",
-    "        ('classifier', SGDClassifier(loss='log',tol=1e-3))\n",
+    "        ('classifier', SGDClassifier(loss='log_loss',tol=1e-3))\n",
     "    ])\n",
     "\n",
     "    num_features_type_map = {feature: 'float64' for feature in df_train.columns[numeric_feature_indexes]}\n",


### PR DESCRIPTION
These labs have the potential to fail depending on the runtime. the SGD loss has changed from `log` to `log_loss`. deprecated in v1.1 and removed v1.3.  The workbench run already fails. Amendments have been made to all three labs in this set.
----
Log entry from vertex 
/opt/conda/lib/python3.10/site-packages/sklearn/linear_model/_stochastic_gradient.py:163: FutureWarning: The loss 'log' was deprecated in v1.1 and will be removed in version 1.3. Use `loss='log_loss'` which is equivalent.
