### PR TITLE
Move logging before importing TF

### DIFF
--- a/notebooks/introduction_to_tensorflow/labs/1_core_tensorflow.ipynb
+++ b/notebooks/introduction_to_tensorflow/labs/1_core_tensorflow.ipynb
@@ -32,12 +32,14 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
-    "from matplotlib import pyplot as plt\n",
-    "\n",
-    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\""
+    "from matplotlib import pyplot as plt"
    ]
   },
   {

--- a/notebooks/introduction_to_tensorflow/labs/2a_dataset_api.ipynb
+++ b/notebooks/introduction_to_tensorflow/labs/2a_dataset_api.ipynb
@@ -24,15 +24,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
     "import json\n",
     "import math\n",
-    "import os\n",
     "from pprint import pprint\n",
     "\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
-    "\n",
-    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
     "\n",
     "print(tf.version.VERSION)"
    ]

--- a/notebooks/introduction_to_tensorflow/labs/3_keras_sequential_api_vertex.ipynb
+++ b/notebooks/introduction_to_tensorflow/labs/3_keras_sequential_api_vertex.ipynb
@@ -47,8 +47,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datetime\n",
     "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import datetime\n",
     "import shutil\n",
     "\n",
     "import numpy as np\n",
@@ -60,8 +65,6 @@
     "from tensorflow.keras.callbacks import TensorBoard\n",
     "from tensorflow.keras.layers import Dense\n",
     "from tensorflow.keras.models import Sequential\n",
-    "\n",
-    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
     "\n",
     "print(tf.__version__)\n",
     "%matplotlib inline"

--- a/notebooks/introduction_to_tensorflow/labs/4_keras_functional_api.ipynb
+++ b/notebooks/introduction_to_tensorflow/labs/4_keras_functional_api.ipynb
@@ -36,8 +36,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datetime\n",
     "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import datetime\n",
     "import shutil\n",
     "\n",
     "import numpy as np\n",
@@ -359,9 +364,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-8.m91",
+   "name": "tf2-gpu.2-12.m109",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m91"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-12:m109"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -378,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/introduction_to_tensorflow/solutions/1_core_tensorflow.ipynb
+++ b/notebooks/introduction_to_tensorflow/solutions/1_core_tensorflow.ipynb
@@ -27,17 +27,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
-    "from matplotlib import pyplot as plt\n",
-    "\n",
-    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\""
+    "from matplotlib import pyplot as plt"
    ]
   },
   {

--- a/notebooks/introduction_to_tensorflow/solutions/2a_dataset_api.ipynb
+++ b/notebooks/introduction_to_tensorflow/solutions/2a_dataset_api.ipynb
@@ -24,15 +24,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
     "import json\n",
     "import math\n",
-    "import os\n",
     "from pprint import pprint\n",
     "\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
-    "\n",
-    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
     "\n",
     "print(tf.version.VERSION)"
    ]

--- a/notebooks/introduction_to_tensorflow/solutions/3_keras_sequential_api_vertex.ipynb
+++ b/notebooks/introduction_to_tensorflow/solutions/3_keras_sequential_api_vertex.ipynb
@@ -47,8 +47,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datetime\n",
     "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import datetime\n",
     "import shutil\n",
     "\n",
     "import numpy as np\n",
@@ -60,8 +65,6 @@
     "from tensorflow.keras.callbacks import TensorBoard\n",
     "from tensorflow.keras.layers import Dense\n",
     "from tensorflow.keras.models import Sequential\n",
-    "\n",
-    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
     "\n",
     "print(tf.__version__)\n",
     "%matplotlib inline"

--- a/notebooks/introduction_to_tensorflow/solutions/4_keras_functional_api.ipynb
+++ b/notebooks/introduction_to_tensorflow/solutions/4_keras_functional_api.ipynb
@@ -36,8 +36,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datetime\n",
     "import os\n",
+    "import warnings\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import datetime\n",
     "import shutil\n",
     "\n",
     "import numpy as np\n",
@@ -374,9 +379,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-8.m91",
+   "name": "tf2-gpu.2-12.m109",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-8:m91"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-12:m109"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -393,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- The logging level has to be set before importing tensorflow for it to take effect. But, because it was set after import, there was no impact and TF was throwing warning after each epoch which is very distracting. This PR moves the logging to the right place.