### PR TITLE
Update KFP AutoML Batch pipeline

### DIFF
--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl_batch_predictions.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl_batch_predictions.ipynb
@@ -195,12 +195,19 @@
     "\n",
     "import os\n",
     "\n",
-    "from google_cloud_pipeline_components.aiplatform import (\n",
-    "    AutoMLTabularTrainingJobRunOp,\n",
-    "    TabularDatasetCreateOp,\n",
+    "from google_cloud_pipeline_components.v1.automl.training_job import (\n",
+    "    AutoMLTabularTrainingJobRunOp\n",
+    ")\n",
+    "\n",
+    "from google_cloud_pipeline_components.v1.dataset import (\n",
+    "    TabularDatasetCreateOp\n",
+    ")\n",
+    "\n",
+    "from google_cloud_pipeline_components.v1.batch_predict_job import (\n",
     "    ModelBatchPredictOp\n",
     ")\n",
-    "from kfp.v2 import dsl\n",
+    "\n",
+    "from kfp import dsl\n",
     "\n",
     "PIPELINE_ROOT = os.getenv(\"PIPELINE_ROOT\")\n",
     "PROJECT = os.getenv(\"PROJECT\")\n",
@@ -403,7 +410,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We compile the pipeline from the Python file we generated into a JSON description using the following command:"
+    "We compile the pipeline from the Python file we generated into a YAML description using the following command:"
    ]
   },
   {
@@ -412,7 +419,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PIPELINE_JSON = \"covertype_automl_vertex_pipeline_batch_preds.json\""
+    "PIPELINE_YAML = \"covertype_automl_vertex_pipeline_batch_preds.yaml\""
    ]
   },
   {
@@ -424,13 +431,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/opt/conda/lib/python3.10/site-packages/kfp/v2/compiler/compiler.py:1290: FutureWarning: APIs imported from the v1 namespace (e.g. kfp.dsl, kfp.components, etc) will not be supported by the v2 compiler since v2.0.0\n",
-      "  warnings.warn(\n"
+      "/home/jupyter/asl-ml-immersion/notebooks/kubeflow_pipelines/pipelines/solutions/covertype_automl_vertex_pipeline_batch_preds.yaml\n"
      ]
     }
    ],
    "source": [
-    "!dsl-compile-v2 --py pipeline_vertex/pipeline_vertex_automl_batch_preds.py --output $PIPELINE_JSON"
+    "!kfp dsl compile --py pipeline_vertex/pipeline_vertex_automl_batch_preds.py --output $PIPELINE_YAML"
    ]
   },
   {
@@ -440,11 +446,11 @@
     "**Note:** You can also use the Python SDK to compile the pipeline:\n",
     "\n",
     "```python\n",
-    "from kfp.v2 import compiler\n",
+    "from kfp import compiler\n",
     "\n",
     "compiler.Compiler().compile(\n",
     "    pipeline_func=create_pipeline, \n",
-    "    package_path=PIPELINE_JSON,\n",
+    "    package_path=PIPELINE_YAML,\n",
     ")\n",
     "\n",
     "```"
@@ -460,27 +466,29 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\n",
-      "  \"pipelineSpec\": {\n",
-      "    \"components\": {\n",
-      "      \"comp-automl-tabular-training-job\": {\n",
-      "        \"executorLabel\": \"exec-automl-tabular-training-job\",\n",
-      "        \"inputDefinitions\": {\n",
-      "          \"artifacts\": {\n",
-      "            \"dataset\": {\n",
-      "              \"artifactType\": {\n",
-      "                \"schemaTitle\": \"google.VertexDataset\",\n"
+      "# PIPELINE DEFINITION\n",
+      "# Name: covertype-vertex-automl-pipeline-batch-preds\n",
+      "# Description: AutoML Vertex Pipeline for covertype\n",
+      "components:\n",
+      "  comp-automl-tabular-training-job:\n",
+      "    executorLabel: exec-automl-tabular-training-job\n",
+      "    inputDefinitions:\n",
+      "      artifacts:\n",
+      "        dataset:\n",
+      "          artifactType:\n"
      ]
     }
    ],
    "source": [
-    "!head {PIPELINE_JSON}"
+    "!head {PIPELINE_YAML}"
    ]
   },
   {
@@ -514,7 +522,7 @@
     "\n",
     "pipeline = aiplatform.PipelineJob(\n",
     "    display_name=\"automl_covertype_kfp_pipeline_batch_predictions\",\n",
-    "    template_path=PIPELINE_JSON,\n",
+    "    template_path=PIPELINE_YAML,\n",
     "    enable_caching=True,\n",
     ")\n",
     "\n",
@@ -558,12 +566,12 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "tf2-gpu.2-12.m109",
+   "name": "tf2-gpu.2-12.m119",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-12:m109"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/tf2-gpu.2-12:m119"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (Local)",
    "language": "python",
    "name": "python3"
   },
@@ -577,7 +585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements for asl-ml-immersion repository
 google-cloud-aiplatform==1.43.0
-google-cloud-pipeline-components==1.0.44
+google-cloud-pipeline-components==2.8.0
 pyyaml==5.3.1
-kfp==1.8.22
+kfp==2.4.0
 # tfx==1.13.0
 cloudml-hypertune
 apache-beam==2.46.0


### PR DESCRIPTION
- Removed `v2` namespace from KFP.
- Changed `google-cloud-pipeline-components` path for v2.
- Changed JSON to YAML since now it is the [preferred format in KFP v2](https://www.kubeflow.org/docs/components/pipelines/v2/migration/#pipeline-package-file-extension).