### PR TITLE
Update KFP AutoML Online pipeline 

### DIFF
--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_automl_online_predictions.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_automl_online_predictions.ipynb
@@ -126,13 +126,16 @@
     "\n",
     "import os\n",
     "\n",
-    "from google_cloud_pipeline_components.aiplatform import (\n",
+    "from google_cloud_pipeline_components.v1.automl.training_job import (\n",
     "    AutoMLTabularTrainingJobRunOp,\n",
+    ")\n",
+    "from google_cloud_pipeline_components.v1.dataset import TabularDatasetCreateOp\n",
+    "from google_cloud_pipeline_components.v1.endpoint import (\n",
     "    EndpointCreateOp,\n",
     "    ModelDeployOp,\n",
-    "    TabularDatasetCreateOp,\n",
     ")\n",
-    "from kfp.v2 import dsl\n",
+    "\n",
+    "from kfp import dsl\n",
     "\n",
     "PIPELINE_ROOT = os.getenv(\"PIPELINE_ROOT\")\n",
     "PROJECT = os.getenv(\"PROJECT\")\n",
@@ -224,7 +227,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We compile the pipeline from the Python file we generated into a JSON description using the following command:"
+    "We compile the pipeline from the Python file we generated into a YAML description using the following command:"
    ]
   },
   {
@@ -233,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PIPELINE_JSON = \"covertype_automl_vertex_pipeline.json\""
+    "PIPELINE_YAML = \"covertype_automl_vertex_pipeline.yaml\""
    ]
   },
   {
@@ -242,7 +245,7 @@
    "source": [
     "### Exercise\n",
     "\n",
-    "Compile the pipeline with the `dsl-compile-v2` command line:"
+    "Compile the pipeline with the `kfp dsl compile` command line:"
    ]
   },
   {
@@ -261,11 +264,11 @@
     "**Note:** You can also use the Python SDK to compile the pipeline:\n",
     "\n",
     "```python\n",
-    "from kfp.v2 import compiler\n",
+    "from kfp import compiler\n",
     "\n",
     "compiler.Compiler().compile(\n",
     "    pipeline_func=create_pipeline, \n",
-    "    package_path=PIPELINE_JSON,\n",
+    "    package_path=PIPELINE_YAML,\n",
     ")\n",
     "\n",
     "```"
@@ -284,7 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!head {PIPELINE_JSON}"
+    "!head {PIPELINE_YAML}"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl_online_predictions.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_automl_online_predictions.ipynb
@@ -119,13 +119,16 @@
     "\n",
     "import os\n",
     "\n",
-    "from google_cloud_pipeline_components.aiplatform import (\n",
+    "from google_cloud_pipeline_components.v1.automl.training_job import (\n",
     "    AutoMLTabularTrainingJobRunOp,\n",
+    ")\n",
+    "from google_cloud_pipeline_components.v1.dataset import TabularDatasetCreateOp\n",
+    "from google_cloud_pipeline_components.v1.endpoint import (\n",
     "    EndpointCreateOp,\n",
     "    ModelDeployOp,\n",
-    "    TabularDatasetCreateOp,\n",
     ")\n",
-    "from kfp.v2 import dsl\n",
+    "\n",
+    "from kfp import dsl\n",
     "\n",
     "PIPELINE_ROOT = os.getenv(\"PIPELINE_ROOT\")\n",
     "PROJECT = os.getenv(\"PROJECT\")\n",
@@ -229,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We compile the pipeline from the Python file we generated into a JSON description using the following command:"
+    "We compile the pipeline from the Python file we generated into a YAML description using the following command:"
    ]
   },
   {
@@ -238,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PIPELINE_JSON = \"covertype_automl_vertex_pipeline.json\""
+    "PIPELINE_YAML = \"covertype_automl_vertex_pipeline.yaml\""
    ]
   },
   {
@@ -247,7 +250,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!dsl-compile-v2 --py pipeline_vertex/pipeline_vertex_automl.py --output $PIPELINE_JSON"
+    "!kfp dsl compile --py pipeline_vertex/pipeline_vertex_automl.py --output $PIPELINE_YAML"
    ]
   },
   {
@@ -257,11 +260,11 @@
     "**Note:** You can also use the Python SDK to compile the pipeline:\n",
     "\n",
     "```python\n",
-    "from kfp.v2 import compiler\n",
+    "from kfp import compiler\n",
     "\n",
     "compiler.Compiler().compile(\n",
     "    pipeline_func=create_pipeline, \n",
-    "    package_path=PIPELINE_JSON,\n",
+    "    package_path=PIPELINE_YAML,\n",
     ")\n",
     "\n",
     "```"
@@ -280,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!head {PIPELINE_JSON}"
+    "!head {PIPELINE_YAML}"
    ]
   },
   {
@@ -293,14 +296,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "aiplatform.init(project=PROJECT, location=REGION)\n",
     "\n",
     "pipeline = aiplatform.PipelineJob(\n",
     "    display_name=\"automl_covertype_kfp_pipeline\",\n",
-    "    template_path=PIPELINE_JSON,\n",
+    "    template_path=PIPELINE_YAML,\n",
     "    enable_caching=True,\n",
     ")\n",
     "\n",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/pipeline_vertex_automl.py
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/pipeline_vertex_automl.py
@@ -16,13 +16,15 @@
 
 import os
 
-from google_cloud_pipeline_components.aiplatform import (
+from google_cloud_pipeline_components.v1.automl.training_job import (
     AutoMLTabularTrainingJobRunOp,
+)
+from google_cloud_pipeline_components.v1.dataset import TabularDatasetCreateOp
+from google_cloud_pipeline_components.v1.endpoint import (
     EndpointCreateOp,
     ModelDeployOp,
-    TabularDatasetCreateOp,
 )
-from kfp.v2 import dsl
+from kfp import dsl
 
 PIPELINE_ROOT = os.getenv("PIPELINE_ROOT")
 PROJECT = os.getenv("PROJECT")
@@ -39,6 +41,7 @@ SERVING_MACHINE_TYPE = os.getenv("SERVING_MACHINE_TYPE", "n1-standard-16")
     pipeline_root=PIPELINE_ROOT,
 )
 def create_pipeline():
+
     dataset_create_task = TabularDatasetCreateOp(
         display_name=DISPLAY_NAME,
         bq_source=DATASET_SOURCE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements for asl-ml-immersion repository
 google-cloud-aiplatform==1.43.0
-google-cloud-pipeline-components==1.0.44
+google-cloud-pipeline-components==2.8.0
 pyyaml==5.3.1
-kfp==1.8.22
+kfp==2.4.0
 # tfx==1.13.0
 cloudml-hypertune
 apache-beam==2.46.0


### PR DESCRIPTION
- Removed `v2` namespace from KFP.
- Changed `google-cloud-pipeline-components` path for v2.
- Changed JSON to YAML since now it is the [preferred format in KFP v2](https://www.kubeflow.org/docs/components/pipelines/v2/migration/#pipeline-package-file-extension).