### PR TITLE
Update KFP Lightweight pipeline

### DIFF
--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_lightweight.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_lightweight.ipynb
@@ -329,7 +329,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We compile the pipeline from the Python file we generated into a JSON description using the following command:"
+    "We compile the pipeline from the Python file we generated into a YAML description using the following command:"
    ]
   },
   {
@@ -338,7 +338,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PIPELINE_JSON = \"covertype_kfp_pipeline.json\""
+    "PIPELINE_YAML = \"covertype_kfp_pipeline.yaml\""
    ]
   },
   {
@@ -347,7 +347,7 @@
    "source": [
     "### Exercise\n",
     "\n",
-    "Compile the `pipeline_vertex/pipeline.py` with the `dsl-compile-v2` command line:"
+    "Compile the `pipeline_vertex/pipeline.py` with the `kfp dsl compile` command line:"
    ]
   },
   {
@@ -368,7 +368,7 @@
     "```python\n",
     "compiler.Compiler().compile(\n",
     "    pipeline_func=covertype_train, \n",
-    "    package_path=PIPELINE_JSON,\n",
+    "    package_path=PIPELINE_YAML,\n",
     ")\n",
     "\n",
     "```"
@@ -387,7 +387,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!head {PIPELINE_JSON}"
+    "!head {PIPELINE_YAML}"
    ]
   },
   {
@@ -413,6 +413,51 @@
    "outputs": [],
    "source": [
     "# TODO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (Optional) Compile the custom components\n",
+    "If you want to easily reuse your custom components in other pipelines, consider compiling them into YAML format. <br>\n",
+    "Be aware that component YAML and pipeline YAML represent distinct objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kfp import compiler, components\n",
+    "from pipeline_vertex.training_lightweight_component import train_and_deploy\n",
+    "from pipeline_vertex.tuning_lightweight_component import tune_hyperparameters\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    train_and_deploy, \"covertype_kfp_train_and_deploy.yaml\"\n",
+    ")\n",
+    "compiler.Compiler().compile(\n",
+    "    tune_hyperparameters, \"covertype_kfp_tune_hyperparameters.yaml\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To reuse a compiled component in another pipeline, easily load it using `kfp.components.load_component_from_file(<YAML PATH>)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_component = components.load_component_from_file(\n",
+    "    \"covertype_kfp_train_and_deploy.yaml\"\n",
+    ")"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/labs/pipeline_vertex/training_lightweight_component.py
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/pipeline_vertex/training_lightweight_component.py
@@ -12,13 +12,12 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 """Lightweight component training function."""
-from kfp.v2.dsl import component
+from kfp.dsl import component
 
 
 # pylint: disable=unused-argument
 @component(
     base_image="python:3.8",
-    output_component_file="covertype_kfp_train_and_deploy.yaml",
     packages_to_install=["google-cloud-aiplatform"],
 )
 def train_and_deploy(

--- a/notebooks/kubeflow_pipelines/pipelines/labs/pipeline_vertex/tuning_lightweight_component.py
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/pipeline_vertex/tuning_lightweight_component.py
@@ -14,13 +14,12 @@
 """Lightweight component tuning function."""
 from typing import NamedTuple
 
-from kfp.v2.dsl import component
+from kfp.dsl import component
 
 
 # pylint: disable=unused-argument
 @component(
     base_image="python:3.8",
-    output_component_file="covertype_kfp_tune_hyperparameters.yaml",
     packages_to_install=["google-cloud-aiplatform"],
 )
 def tune_hyperparameters(

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_lightweight.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_lightweight.ipynb
@@ -339,7 +339,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We compile the pipeline from the Python file we generated into a JSON description using the following command:"
+    "We compile the pipeline from the Python file we generated into a YAML description using the following command:"
    ]
   },
   {
@@ -348,7 +348,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PIPELINE_JSON = \"covertype_kfp_pipeline.json\""
+    "PIPELINE_YAML = \"covertype_kfp_pipeline.yaml\""
    ]
   },
   {
@@ -357,7 +357,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!dsl-compile-v2 --py pipeline_vertex/pipeline.py --output $PIPELINE_JSON"
+    "!kfp dsl compile --py pipeline_vertex/pipeline.py --output $PIPELINE_YAML"
    ]
   },
   {
@@ -369,7 +369,7 @@
     "```python\n",
     "compiler.Compiler().compile(\n",
     "    pipeline_func=covertype_train, \n",
-    "    package_path=PIPELINE_JSON,\n",
+    "    package_path=PIPELINE_YAML,\n",
     ")\n",
     "\n",
     "```"
@@ -388,7 +388,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!head {PIPELINE_JSON}"
+    "!head {PIPELINE_YAML}"
    ]
   },
   {
@@ -401,18 +401,71 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "aiplatform.init(project=PROJECT_ID, location=REGION)\n",
     "\n",
     "pipeline = aiplatform.PipelineJob(\n",
     "    display_name=\"covertype_kfp_pipeline\",\n",
-    "    template_path=PIPELINE_JSON,\n",
+    "    template_path=PIPELINE_YAML,\n",
     "    enable_caching=False,\n",
     ")\n",
     "\n",
     "pipeline.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (Optional) Compile the custom components\n",
+    "If you want to easily reuse your custom components in other pipelines, consider compiling them into YAML format. <br>\n",
+    "Be aware that component YAML and pipeline YAML represent distinct objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from kfp import compiler, components\n",
+    "from pipeline_vertex.training_lightweight_component import train_and_deploy\n",
+    "from pipeline_vertex.tuning_lightweight_component import tune_hyperparameters\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    train_and_deploy, \"covertype_kfp_train_and_deploy.yaml\"\n",
+    ")\n",
+    "compiler.Compiler().compile(\n",
+    "    tune_hyperparameters, \"covertype_kfp_tune_hyperparameters.yaml\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "To reuse a compiled component in another pipeline, easily load it using `kfp.components.load_component_from_file(<YAML PATH>)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "custom_component = components.load_component_from_file(\n",
+    "    \"covertype_kfp_train_and_deploy.yaml\"\n",
+    ")"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/training_lightweight_component.py
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/training_lightweight_component.py
@@ -12,12 +12,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 """Lightweight component training function."""
-from kfp.v2.dsl import component
+from kfp.dsl import component
 
 
 @component(
     base_image="python:3.8",
-    output_component_file="covertype_kfp_train_and_deploy.yaml",
     packages_to_install=["google-cloud-aiplatform"],
 )
 def train_and_deploy(

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/tuning_lightweight_component.py
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/pipeline_vertex/tuning_lightweight_component.py
@@ -14,12 +14,11 @@
 """Lightweight component tuning function."""
 from typing import NamedTuple
 
-from kfp.v2.dsl import component
+from kfp.dsl import component
 
 
 @component(
     base_image="python:3.8",
-    output_component_file="covertype_kfp_tune_hyperparameters.yaml",
     packages_to_install=["google-cloud-aiplatform"],
 )
 def tune_hyperparameters(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements for asl-ml-immersion repository
 google-cloud-aiplatform==1.43.0
-google-cloud-pipeline-components==1.0.44
+google-cloud-pipeline-components==2.8.0
 pyyaml==5.3.1
-kfp==1.8.22
+kfp==2.4.0
 # tfx==1.13.0
 cloudml-hypertune
 apache-beam==2.46.0


### PR DESCRIPTION
- Removed `v2` namespace from KFP.
- Changed JSON to YAML since now it is the [preferred format in KFP v2](https://www.kubeflow.org/docs/components/pipelines/v2/migration/#pipeline-package-file-extension).
- Removed `output_component_file` argument from custom component decorators in python files, and added an optional component compilation section at the end of the notebook, as [recommended in the migration guide](https://www.kubeflow.org/docs/components/pipelines/v2/migration/#output_component_file-parameter).
<img width="1205" alt="image" src="https://github.com/GoogleCloudPlatform/asl-ml-immersion/assets/6895245/4feaad62-ef7a-4454-ae27-9afe07fe2e7f">
