### PR TITLE
Update KFP CICD

### DIFF
--- a/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
@@ -29,7 +29,7 @@ steps:
   args:
   - '-c'
   - |
-    dsl-compile-v2 # TODO
+    kfp dsl compile # TODO
   env:
   - 'PIPELINE_ROOT=gs://$PROJECT_ID-kfp-artifact-store/pipeline'
   - 'PROJECT_ID=$PROJECT_ID'

--- a/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "In the cell below, write a docker file that\n",
     "* Uses `gcr.io/deeplearning-platform-release/base-cpu` as base image\n",
-    "* Install the python packages `kfp` with version `1.8.22 ` and `google-cloud-aiplatform` with version `1.43.0`\n",
+    "* Install the python packages `kfp` with version `2.4.0 ` and `google-cloud-aiplatform` with version `1.43.0`\n",
     "* Starts `/bin/bash` as entrypoint"
    ]
   },
@@ -184,7 +184,7 @@
     "  args:\n",
     "  - '-c'\n",
     "  - |\n",
-    "    dsl-compile-v2 # TODO\n",
+    "    kfp dsl compile # TODO\n",
     "  env:\n",
     "  - 'PIPELINE_ROOT=gs://$PROJECT_ID-kfp-artifact-store/pipeline'\n",
     "  - 'PROJECT_ID=$PROJECT_ID'\n",

--- a/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "In the cell below, write a docker file that\n",
     "* Uses `gcr.io/deeplearning-platform-release/base-cpu` as base image\n",
-    "* Install the python packages `kfp` with version `2.4.0 ` and `google-cloud-aiplatform` with version `1.43.0`\n",
+    "* Install the python packages `kfp` with version `2.4.0 `, `google-cloud-aiplatform` with version `1.43.0` and `fire`\n",
     "* Starts `/bin/bash` as entrypoint"
    ]
   },

--- a/notebooks/kubeflow_pipelines/cicd/labs/pipeline_vertex/training_lightweight_component.py
+++ b/notebooks/kubeflow_pipelines/cicd/labs/pipeline_vertex/training_lightweight_component.py
@@ -12,12 +12,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 """Lightweight component training function."""
-from kfp.v2.dsl import component
+from kfp.dsl import component
 
 
 @component(
     base_image="python:3.8",
-    output_component_file="covertype_kfp_train_and_deploy.yaml",
     packages_to_install=["google-cloud-aiplatform"],
 )
 def train_and_deploy(

--- a/notebooks/kubeflow_pipelines/cicd/labs/pipeline_vertex/tuning_lightweight_component.py
+++ b/notebooks/kubeflow_pipelines/cicd/labs/pipeline_vertex/tuning_lightweight_component.py
@@ -14,12 +14,11 @@
 """Lightweight component tuning function."""
 from typing import NamedTuple
 
-from kfp.v2.dsl import component
+from kfp.dsl import component
 
 
 @component(
     base_image="python:3.8",
-    output_component_file="covertype_kfp_tune_hyperparameters.yaml",
     packages_to_install=["google-cloud-aiplatform"],
 )
 def tune_hyperparameters(

--- a/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
@@ -32,7 +32,7 @@ steps:
   args:
   - '-c'
   - |
-    dsl-compile-v2 --py pipeline.py --output covertype_kfp_pipeline.json
+    kfp dsl compile --py pipeline.py --output covertype_kfp_pipeline.yaml
   env:
   - 'PIPELINE_ROOT=gs://$PROJECT_ID-kfp-artifact-store/pipeline'
   - 'PROJECT_ID=$PROJECT_ID'
@@ -49,7 +49,7 @@ steps:
   args:
   - '-c'
   - |
-    python $_PIPELINE_FOLDER/kfp-cli_vertex/run_pipeline.py --project_id=$PROJECT_ID --template_path=$_PIPELINE_FOLDER/pipeline_vertex/covertype_kfp_pipeline.json --display_name=coverype_kfp_pipeline --region=$_REGION
+    python $_PIPELINE_FOLDER/kfp-cli_vertex/run_pipeline.py --project_id=$PROJECT_ID --template_path=$_PIPELINE_FOLDER/pipeline_vertex/covertype_kfp_pipeline.yaml --display_name=coverype_kfp_pipeline --region=$_REGION
 
 # Push the images to Artifact Registry
 images: ['us-docker.pkg.dev/$PROJECT_ID/asl-artifact-repo/trainer_image_covertype_vertex:latest']

--- a/notebooks/kubeflow_pipelines/cicd/solutions/kfp-cli_vertex/Dockerfile
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/kfp-cli_vertex/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/deeplearning-platform-release/base-cpu
-RUN pip install kfp==1.8.22
+RUN pip install kfp==2.4.0
 RUN pip install google-cloud-aiplatform==1.43.0
 ENTRYPOINT ["/bin/bash"]

--- a/notebooks/kubeflow_pipelines/cicd/solutions/kfp-cli_vertex/Dockerfile
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/kfp-cli_vertex/Dockerfile
@@ -1,4 +1,3 @@
 FROM gcr.io/deeplearning-platform-release/base-cpu
-RUN pip install kfp==2.4.0
-RUN pip install google-cloud-aiplatform==1.43.0
+RUN pip install kfp==2.4.0 google-cloud-aiplatform==1.43.0 fire
 ENTRYPOINT ["/bin/bash"]

--- a/notebooks/kubeflow_pipelines/cicd/solutions/pipeline_vertex/training_lightweight_component.py
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/pipeline_vertex/training_lightweight_component.py
@@ -12,12 +12,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 """Lightweight component training function."""
-from kfp.v2.dsl import component
+from kfp.dsl import component
 
 
 @component(
     base_image="python:3.8",
-    output_component_file="covertype_kfp_train_and_deploy.yaml",
     packages_to_install=["google-cloud-aiplatform"],
 )
 def train_and_deploy(

--- a/notebooks/kubeflow_pipelines/cicd/solutions/pipeline_vertex/tuning_lightweight_component.py
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/pipeline_vertex/tuning_lightweight_component.py
@@ -14,12 +14,11 @@
 """Lightweight component tuning function."""
 from typing import NamedTuple
 
-from kfp.v2.dsl import component
+from kfp.dsl import component
 
 
 @component(
     base_image="python:3.8",
-    output_component_file="covertype_kfp_tune_hyperparameters.yaml",
     packages_to_install=["google-cloud-aiplatform"],
 )
 def tune_hyperparameters(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements for asl-ml-immersion repository
 google-cloud-aiplatform==1.43.0
-google-cloud-pipeline-components==1.0.44
+google-cloud-pipeline-components==2.8.0
 pyyaml==5.3.1
-kfp==1.8.22
+kfp==2.4.0
 # tfx==1.13.0
 cloudml-hypertune
 apache-beam==2.46.0


### PR DESCRIPTION
- Removed `v2` namespace from KFP.
- Changed JSON to YAML since now it is the [preferred format in KFP v2](https://www.kubeflow.org/docs/components/pipelines/v2/migration/#pipeline-package-file-extension).
- Removed `output_component_file` argument from custom component decorators in python files as [recommended in the migration guide](https://www.kubeflow.org/docs/components/pipelines/v2/migration/#output_component_file-parameter).
- Updated the KFP version, and added fire module (kfp v2 removed `fire` from its dependency) in the Dockerfile.