### PR TITLE
Fix KFP walkthrough lab prediction container gap

### DIFF
--- a/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough_vertex.ipynb
@@ -772,7 +772,7 @@
    "source": [
     "MODEL_NAME = \"forest_cover_classifier_2\"\n",
     "SERVING_CONTAINER_IMAGE_URI = (\n",
-    "    \"us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.0-20:latest\"\n",
+    "    \"us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.1-0:latest\"\n",
     ")\n",
     "SERVING_MACHINE_TYPE = \"n1-standard-2\""
    ]


### PR DESCRIPTION
Fixed scikit-learn version gap between solutions and lab (and training and prediction) which caused an error.