### PR TITLE
Refactor: Remove unnecessary 'self' argument from super().__init__() call

### DIFF
--- a/notebooks/text_models/solutions/text_generation.ipynb
+++ b/notebooks/text_models/solutions/text_generation.ipynb
@@ -695,7 +695,7 @@
    "source": [
     "class MyModel(tf.keras.Model):\n",
     "    def __init__(self, vocab_size, embedding_dim, rnn_units):\n",
-    "        super().__init__(self)\n",
+    "        super().__init__()\n",
     "        # TODO - Create an embedding layer\n",
     "        self.embedding = tf.keras.layers.Embedding(vocab_size, embedding_dim)\n",
     "        # TODO - Create a GRU layer\n",


### PR DESCRIPTION


Problem:  TypeError - Layer.__init__() takes 1 positional argument but 2 were given when calling MyModel class.

Solution: In the MyModel class constructor, the call to super().__init__() should not include the 'self' argument. This change removes the extraneous 'self' argument, aligning with the correct usage in TensorFlow's Keras model classes.