### PR TITLE
Add fire to the requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ tf-models-official==2.12.0
 tensorflow-model-remediation==0.1.7.1
 keras_cv==0.5.1
 keras_nlp==0.5.1
+fire==0.6.0
 
 # For development work
 pre-commit


### PR DESCRIPTION
Added `fire` module to the requirement.txt due to the dependencies change of other library.
(`fire` was installed implicitly as a dependency of other libraries, but it is not now.)