### PR TITLE
Update cloudbuild_vertex.yaml

### DIFF
--- a/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
@@ -51,6 +51,8 @@ steps:
 # TODO: List the images to be pushed to the project Docker registry
 images: # TODO
 
+options:
+  logging: CLOUD_LOGGING_ONLY
 
 # This is required since the pipeline run overflows the default timeout
 timeout: 10800s


### PR DESCRIPTION
Same update for the Solutions track, cloud build fails due to new requirement to have the service account listed.