### PR TITLE
Update KFP cicd for a cloud build service account change

### DIFF
--- a/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
@@ -47,6 +47,8 @@ steps:
   - |
     python $_PIPELINE_FOLDER/kfp-cli_vertex/run_pipeline.py  # TODO
 
+logsBucket: 'gs://$PROJECT_ID-cloudbuild'
+
 # Push the images to Artifact Registry
 # TODO: List the images to be pushed to the project Docker registry
 images: # TODO

--- a/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml
@@ -47,7 +47,7 @@ steps:
   - |
     python $_PIPELINE_FOLDER/kfp-cli_vertex/run_pipeline.py  # TODO
 
-logsBucket: 'gs://$PROJECT_ID-cloudbuild'
+logsBucket: 'gs://$PROJECT_ID-cicd-log'
 
 # Push the images to Artifact Registry
 # TODO: List the images to be pushed to the project Docker registry

--- a/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
@@ -227,7 +227,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "BUCKET = PROJECT_ID + \"-cloudbuild\"\n",
+    "BUCKET = PROJECT_ID + \"-cicd-log\"\n",
     "os.environ[\"BUCKET\"] = BUCKET"
    ]
   },

--- a/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
@@ -40,7 +40,8 @@
     "PROJECT_ID = !(gcloud config get-value project)\n",
     "PROJECT_ID = PROJECT_ID[0]\n",
     "REGION = \"us-central1\"\n",
-    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\""
+    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\"\n",
+    "os.environ[\"REGION\"] = REGION"
    ]
   },
   {
@@ -202,6 +203,8 @@
     "  - |\n",
     "    python $_PIPELINE_FOLDER/kfp-cli_vertex/run_pipeline.py  # TODO\n",
     "\n",
+    "logsBucket: 'gs://$PROJECT_ID-cloudbuild'\n",
+    "\n",
     "# Push the images to Artifact Registry\n",
     "# TODO: List the images to be pushed to the project Docker registry\n",
     "images: # TODO\n",
@@ -209,6 +212,42 @@
     "\n",
     "# This is required since the pipeline run overflows the default timeout\n",
     "timeout: 10800s\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a GCS bucket to save the build log."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BUCKET = PROJECT_ID + \"-cloudbuild\"\n",
+    "os.environ[\"BUCKET\"] = BUCKET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "if [ -n \"$exists\" ]; then\n",
+    "    echo -e \"Bucket exists, let's not recreate it.\"\n",
+    "else\n",
+    "    echo \"Creating a new GCS bucket.\"\n",
+    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    echo \"Here are your current buckets:\"\n",
+    "    gsutil ls\n",
+    "fi"
    ]
   },
   {
@@ -310,6 +349,7 @@
     "|Tag (regex)|.\\*|\n",
     "|Build Configuration|Cloud Build configuration file (yaml or json)|\n",
     "|Cloud Build configuration file location| ./notebooks/kubeflow_pipelines/cicd/labs/cloudbuild_vertex.yaml|\n",
+    "|Service account| `<PROJECT NUMBER>-compute@developer.gserviceaccount.com` |\n",
     "\n",
     "\n",
     "Use the following values for the substitution variables:\n",

--- a/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
@@ -51,6 +51,8 @@ steps:
   - |
     python $_PIPELINE_FOLDER/kfp-cli_vertex/run_pipeline.py --project_id=$PROJECT_ID --template_path=$_PIPELINE_FOLDER/pipeline_vertex/covertype_kfp_pipeline.yaml --display_name=coverype_kfp_pipeline --region=$_REGION
 
+logsBucket: 'gs://$PROJECT_ID-cloudbuild'
+
 # Push the images to Artifact Registry
 images: ['us-docker.pkg.dev/$PROJECT_ID/asl-artifact-repo/trainer_image_covertype_vertex:latest']
 

--- a/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml
@@ -51,7 +51,7 @@ steps:
   - |
     python $_PIPELINE_FOLDER/kfp-cli_vertex/run_pipeline.py --project_id=$PROJECT_ID --template_path=$_PIPELINE_FOLDER/pipeline_vertex/covertype_kfp_pipeline.yaml --display_name=coverype_kfp_pipeline --region=$_REGION
 
-logsBucket: 'gs://$PROJECT_ID-cloudbuild'
+logsBucket: 'gs://$PROJECT_ID-cicd-log'
 
 # Push the images to Artifact Registry
 images: ['us-docker.pkg.dev/$PROJECT_ID/asl-artifact-repo/trainer_image_covertype_vertex:latest']

--- a/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
@@ -153,7 +153,7 @@
    },
    "outputs": [],
    "source": [
-    "BUCKET = PROJECT_ID + \"-cloudbuild\"\n",
+    "BUCKET = PROJECT_ID + \"-cicd-log\"\n",
     "os.environ[\"BUCKET\"] = BUCKET"
    ]
   },

--- a/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
@@ -25,6 +25,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -34,13 +45,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "PROJECT_ID = !(gcloud config get-value project)\n",
     "PROJECT_ID = PROJECT_ID[0]\n",
     "REGION = \"us-central1\"\n",
-    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\""
+    "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\"\n",
+    "os.environ[\"REGION\"] = REGION"
    ]
   },
   {
@@ -98,7 +112,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!gcloud builds submit --timeout 15m --tag {KFP_CLI_IMAGE_URI} kfp-cli_vertex"
@@ -120,6 +136,46 @@
     " \n",
     "\n",
     "The **Cloud Build** workflow configuration uses both standard and custom [Cloud Build builders](https://cloud.google.com/cloud-build/docs/cloud-builders). The custom builder encapsulates **KFP CLI**. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a GCS bucket to save the build log."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET = PROJECT_ID + \"-cloudbuild\"\n",
+    "os.environ[\"BUCKET\"] = BUCKET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "if [ -n \"$exists\" ]; then\n",
+    "    echo -e \"Bucket exists, let's not recreate it.\"\n",
+    "else\n",
+    "    echo \"Creating a new GCS bucket.\"\n",
+    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    echo \"Here are your current buckets:\"\n",
+    "    gsutil ls\n",
+    "fi"
    ]
   },
   {
@@ -204,6 +260,7 @@
     "|Tag (regex)|.\\*|\n",
     "|Build Configuration|Cloud Build configuration file (yaml or json)|\n",
     "|Cloud Build configuration file location| ./notebooks/kubeflow_pipelines/cicd/solutions/cloudbuild_vertex.yaml|\n",
+    "|Service account| `<PROJECT NUMBER>-compute@developer.gserviceaccount.com` |\n",
     "\n",
     "\n",
     "Use the following values for the substitution variables:\n",

--- a/scripts/setup_on_cloudshell.sh
+++ b/scripts/setup_on_cloudshell.sh
@@ -17,11 +17,6 @@
 PROJECT_ID=$(gcloud config list project --format "value(core.project)")
 PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
 
-# Grant Editor role to Cloud Build service account
-gcloud projects add-iam-policy-binding $PROJECT_ID \
-  --member serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com \
-  --role roles/editor
-
 # Grant Storage Object Admin to Compute Engine service account
 gcloud projects add-iam-policy-binding $PROJECT_ID \
     --member serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com \


### PR DESCRIPTION
Due to a recent Cloud Build Service Account policy change, updated a few logic of the KFP cicd module.
https://cloud.google.com/build/docs/cloud-build-service-account-updates

1. Deleted cloud build default service account config from `scripts/setup_on_cloudshell.sh` (See the link above for the detailed reason)
2. Added an instruction about explicit service account selection.
3. Added the build log destination GCS bucket in the cloud build yaml file.

The same issue is reported in #489.