### PR TITLE
Remove data dependencies in the KFP modules

### DIFF
--- a/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd_vertex.ipynb
@@ -41,7 +41,8 @@
     "PROJECT_ID = PROJECT_ID[0]\n",
     "REGION = \"us-central1\"\n",
     "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\"\n",
-    "os.environ[\"REGION\"] = REGION"
+    "os.environ[\"REGION\"] = REGION\n",
+    "os.environ[\"ARTIFACT_STORE\"] = ARTIFACT_STORE"
    ]
   },
   {
@@ -58,6 +59,26 @@
    "outputs": [],
    "source": [
     "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
+    "\n",
+    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gsutil cp gs://asl-public/data/covertype/training/dataset.csv $ARTIFACT_STORE/data/training/dataset.csv\n",
+    "gsutil cp gs://asl-public/data/covertype/validation/dataset.csv $ARTIFACT_STORE/data/validation/dataset.csv"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
@@ -84,7 +84,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
+++ b/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd_vertex.ipynb
@@ -54,7 +54,8 @@
     "PROJECT_ID = PROJECT_ID[0]\n",
     "REGION = \"us-central1\"\n",
     "ARTIFACT_STORE = f\"gs://{PROJECT_ID}-kfp-artifact-store\"\n",
-    "os.environ[\"REGION\"] = REGION"
+    "os.environ[\"REGION\"] = REGION\n",
+    "os.environ[\"ARTIFACT_STORE\"] = ARTIFACT_STORE"
    ]
   },
   {
@@ -67,10 +68,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
+    "\n",
+    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gsutil cp gs://asl-public/data/covertype/training/dataset.csv $ARTIFACT_STORE/data/training/dataset.csv\n",
+    "gsutil cp gs://asl-public/data/covertype/validation/dataset.csv $ARTIFACT_STORE/data/validation/dataset.csv"
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_lightweight.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_lightweight.ipynb
@@ -308,7 +308,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_lightweight.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_lightweight.ipynb
@@ -306,6 +306,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
+    "\n",
+    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gsutil cp gs://asl-public/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "gsutil cp gs://asl-public/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "**Note:** In case the artifact store was not created and properly set before hand, you may need\n",
     "to run in **CloudShell** the following command to allow Vertex AI to access it:\n",
     "\n",

--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_prebuilt.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_prebuilt.ipynb
@@ -380,6 +380,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
+    "\n",
+    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gsutil cp gs://asl-public/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "gsutil cp gs://asl-public/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "**Note:** In case the artifact store was not created and properly set before hand, you may need\n",
     "to run in **CloudShell** the following command to allow Vertex AI to access it:\n",
     "\n",

--- a/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_prebuilt.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_prebuilt.ipynb
@@ -382,7 +382,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_lightweight.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_lightweight.ipynb
@@ -318,7 +318,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
    ]
   },
   {

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_lightweight.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_lightweight.ipynb
@@ -316,6 +316,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
+    "\n",
+    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gsutil cp gs://asl-public/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "gsutil cp gs://asl-public/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "**Note:** In case the artifact store was not created and properly set before hand, you may need\n",
     "to run in **CloudShell** the following command to allow Vertex AI to access it:\n",
     "\n",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_prebuilt.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_prebuilt.ipynb
@@ -388,6 +388,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
+    "\n",
+    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gsutil cp gs://asl-public/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "gsutil cp gs://asl-public/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "**Note:** In case the artifact store was not created and properly set before hand, you may need\n",
     "to run in **CloudShell** the following command to allow Vertex AI to access it:\n",
     "\n",

--- a/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_prebuilt.ipynb
+++ b/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_prebuilt.ipynb
@@ -390,7 +390,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
    ]
   },
   {


### PR DESCRIPTION
These KFP pipelines/cicd notebooks fail if the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb) wasn't run beforehand. 

Added data copy commands to them to remove this data dependency issue.
