### PR TITLE
Quick `text_generation.ipnyb` legibility fix

### DIFF
--- a/notebooks/text_models/labs/text_generation.ipynb
+++ b/notebooks/text_models/labs/text_generation.ipynb
@@ -1228,7 +1228,9 @@
     "\n",
     "result = tf.strings.join(result)\n",
     "end = time.time()\n",
-    "print(result, \"\\n\\n\" + \"_\" * 80)\n",
+    "for s in result:\n",
+    "    print(s.numpy().decode(\"utf-8\"))\n",
+    "print(\"\\n\\n\" + \"_\" * 80)\n",
     "print(\"\\nRun time:\", end - start)"
    ]
   },

--- a/notebooks/text_models/solutions/text_generation.ipynb
+++ b/notebooks/text_models/solutions/text_generation.ipynb
@@ -1226,7 +1226,9 @@
     "\n",
     "result = tf.strings.join(result)\n",
     "end = time.time()\n",
-    "print(result, \"\\n\\n\" + \"_\" * 80)\n",
+    "for s in result:\n",
+    "    print(s.numpy().decode(\"utf-8\"))\n",
+    "print(\"\\n\\n\" + \"_\" * 80)\n",
     "print(\"\\nRun time:\", end - start)"
    ]
   },


### PR DESCRIPTION
In `notebooks/text_models/solutions/text_generation.ipynb` and the version with **TODO's** in `notebooks/text_models/labs/text_generation.ipynb`:
* In the **Execute the training** section:
    * Update the last code cell to iterate over the `result` iterable and `.numpy().decode('utf-8')` in order to print legible strings.  
        * As a reminder, this is the code cell that demonstrates how to run batches in parallel to speed up inferencing.

Prior to this PR, that code cell outputs a messy list of binary strings which detracts from the satisfaction of learning. 😁

I understand that outsiders are not allowed to merge PR's in this repository.  I'm just an individual enrolled in _Google Cloud Innovators Plus_  learning this stuff for fun.  Thank you for your time and consideration! 