### PR TITLE
modify makefile to fix error caused by installing graphviz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ install:
 	@pip install --user --no-deps -r requirements-without-deps.txt
 	@./scripts/setup_on_jupyterlab.sh
 	@pre-commit install
+	@sudo apt-get update
 	@sudo apt-get -y install graphviz
 
 .PHONY: precommit


### PR DESCRIPTION
The Makefile fails at the `sudo apt-get install graphviz` line with the following error 

```
  404  Not Found [IP: 199.232.98.132 443]
Get:4 https://deb.debian.org/debian bullseye/main amd64 libcgraph6 amd64 2.42.2-5 [85.5 kB]
Get:5 https://deb.debian.org/debian bullseye/main amd64 libgts-0.7-5 amd64 0.7.6+darcs121130-4+b1 [158 kB]
Get:6 https://deb.debian.org/debian bullseye/main amd64 libpathplan4 amd64 2.42.2-5 [64.3 kB]
Get:7 https://deb.debian.org/debian bullseye/main amd64 libgvc6 amd64 2.42.2-5 [695 kB]
Get:8 https://deb.debian.org/debian bullseye/main amd64 libgvpr2 amd64 2.42.2-5 [212 kB]
Get:9 https://deb.debian.org/debian bullseye/main amd64 liblab-gamut1 amd64 2.42.2-5 [221 kB]
Get:10 https://deb.debian.org/debian bullseye/main amd64 graphviz amd64 2.42.2-5 [632 kB]
Get:11 https://deb.debian.org/debian bullseye/main amd64 libgts-bin amd64 0.7.6+darcs121130-4+b1 [50.3 kB]                                                                            
Fetched 2970 kB in 31s (95.3 kB/s)                        
E: Failed to fetch https://deb.debian.org/debian/pool/main/g/graphviz/libcdt5_2.42.2-5_amd64.deb  404  Not Found [IP: 199.232.98.132 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
make: *** [Makefile:38: install] Error 100
```

This error can be fixed by adding a `sudo apt-get update` line before the install line.