### PR TITLE
[Create Image Captioning Models] Misdefined tuples

### DIFF
--- a/notebooks/multi_modal/labs/image_captioning.ipynb
+++ b/notebooks/multi_modal/labs/image_captioning.ipynb
@@ -562,7 +562,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "word_input = Input(shape=(MAX_CAPTION_LEN), name=\"words\")\n",
+    "word_input = Input(shape=(MAX_CAPTION_LEN,), name=\"words\")\n",
     "\n",
     "# TODO: Define the Embedding layer\n",
     "embed_x = Embedding(...)(word_input)\n",
@@ -722,7 +722,7 @@
    "source": [
     "# TODO: Complete the entire prediction model referring to the traiing model above.\n",
     "\n",
-    "gru_state_input = Input(shape=(ATTENTION_DIM), name=\"gru_state_input\")\n",
+    "gru_state_input = Input(shape=(ATTENTION_DIM,), name=\"gru_state_input\")\n",
     "\n",
     "# Reuse trained GRU, but update it so that it can receive states.\n",
     "gru_output, gru_state = decoder_gru(...)\n",

--- a/notebooks/multi_modal/solutions/image_captioning.ipynb
+++ b/notebooks/multi_modal/solutions/image_captioning.ipynb
@@ -706,7 +706,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "word_input = Input(shape=(MAX_CAPTION_LEN), name=\"words\")\n",
+    "word_input = Input(shape=(MAX_CAPTION_LEN,), name=\"words\")\n",
     "embed_x = Embedding(VOCAB_SIZE, ATTENTION_DIM)(word_input)\n",
     "\n",
     "decoder_gru = GRU(\n",
@@ -921,7 +921,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gru_state_input = Input(shape=(ATTENTION_DIM), name=\"gru_state_input\")\n",
+    "gru_state_input = Input(shape=(ATTENTION_DIM,), name=\"gru_state_input\")\n",
     "\n",
     "# Reuse trained GRU, but update it so that it can receive states.\n",
     "gru_output, gru_state = decoder_gru(embed_x, initial_state=gru_state_input)\n",


### PR DESCRIPTION
While doing the **_Create Image Captioning Models_** course, I was practicing the lab myself but had experienced two runtime errors.  Fortunately, the two errors are equivalent in their classification.

In the **_Decoder Steps_** and **_Caption!_** sections of the notebook:
- In the code cell that calls the `Input` object constructor,
- - The `shape` argument is supposed to accept a tuple, and the author intended to pass a single element tuple,
- - - But a trailing comma after the single element in the tuple definition is missing, which results in the single element being passed to the `shape` variable as a single integer,
- - - - This causes a runtime error in the `Input` constructor.

After adding the trailing comma, the code worked as expected and I was able to complete the lab equivalently to what is shown in the course video.

This PR updates both the blank `labs` and completed `solutions` notebooks.

Thanks again for this great lesson series!  I am enjoying this journey of learning about the internals of these model architectures.  I hope you find these minor fixes helpful to improving the overall quality of the course.
