### PR TITLE
Minor fix: fixed local Python 3 kernel duplication

### DIFF
--- a/kernels/lit.sh
+++ b/kernels/lit.sh
@@ -27,6 +27,7 @@ pip install -q ipykernel
 # Adds the conda kernel.
 DL_ANACONDA_ENV_HOME="${DL_ANACONDA_HOME}/envs/$ENVNAME"
 python -m ipykernel install --prefix "${DL_ANACONDA_ENV_HOME}" --name $ENVNAME --display-name "$KERNEL_DISPLAY_NAME"
+rm -rf "${DL_ANACONDA_ENV_HOME}/share/jupyter/kernels/python3"
 
 pip install -q tensorflow==2.14.1 lit-nlp keras_nlp
 


### PR DESCRIPTION
Fixed the LIT kernel script to prevent the duplication of the base Python 3 kernel.

<img width="271" alt="Screenshot 2025-06-18 at 16 11 51" src="https://github.com/user-attachments/assets/132aa644-5230-4078-a9e9-6a4c2c16d9a5" />
