### PR TITLE
Update hptune notebook to Keras 3 and Python SDK

### DIFF
--- a/notebooks/building_production_ml_systems/labs/2_hyperparameter_tuning_vertex.ipynb
+++ b/notebooks/building_production_ml_systems/labs/2_hyperparameter_tuning_vertex.ipynb
@@ -864,7 +864,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%tensorboard --logdir {base_path}/trained_model_20250805_191931 --port 8002"
+    "%tensorboard --logdir {base_path}/trained_model_{timestamp} --port 8002"
    ]
   },
   {

--- a/notebooks/building_production_ml_systems/solutions/2_hyperparameter_tuning_vertex.ipynb
+++ b/notebooks/building_production_ml_systems/solutions/2_hyperparameter_tuning_vertex.ipynb
@@ -853,7 +853,7 @@
    },
    "outputs": [],
    "source": [
-    "%tensorboard --logdir {base_path}/trained_model_20250805_191931 --port 8002"
+    "%tensorboard --logdir {base_path}/trained_model_{timestamp} --port 8002"
    ]
   },
   {


### PR DESCRIPTION
Update Summary:
- Update to Keras 3
- Update from `gcloud ai` to Python SDK
- Added a few markdown descriptions on Hyperparameter Tuning Job setup.
- Added a TensorBoard section.