### PR TITLE
Update dpsgd notebook to use a dedicated kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ all: clean install
 kernels: \
  adk_kernel \
  object_detection_kernel \
- pytorch_kfp_kernel
+ pytorch_kfp_kernel \
+ tf_privacy_kernel
 
 .PHONY: clean
 clean:
@@ -52,6 +53,10 @@ object_detection_kernel:
 .PHONY: pytorch_kfp_kernel
 pytorch_kfp_kernel:
 	./kernels/pytorch_kfp.sh
+
+.PHONY: tf_privacy_kernel
+tf_privacy_kernel:
+	./kernels/tf_privacy.sh
 
 .PHONY: tests
 tests:

--- a/kernels/tf_privacy.sh
+++ b/kernels/tf_privacy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# To build the kernel:  ./kernels/tf_privacy.sh
+# To remove the kernel: ./kernels/tf_privacy.sh remove
+#
+# This scripts will create a ipython kernel named $ENVNAME
+
+ENVNAME=tf_privacy_kernel
+KERNEL_DISPLAY_NAME="TF Privacy Kernel"
+
+source ~/.bashrc
+
+# Cleaning up the kernel and exiting if first arg is 'remove'
+if [ "$1" == "remove" ]; then
+  echo Removing kernel $ENVNAME
+  jupyter kernelspec remove $ENVNAME
+  conda env remove -n $ENVNAME -y
+  exit 0
+fi
+
+conda create -q -n $ENVNAME python=3.10.14 -y
+conda activate $ENVNAME
+
+# Install packages using a pip local to the conda environment.
+conda install -q pip
+pip install -q ipykernel
+
+# Adds the conda kernel.
+DL_ANACONDA_ENV_HOME="${DL_ANACONDA_HOME}/envs/$ENVNAME"
+python -m ipykernel install --prefix "${DL_ANACONDA_ENV_HOME}" --name $ENVNAME --display-name "$KERNEL_DISPLAY_NAME"
+rm -rf "${DL_ANACONDA_ENV_HOME}/share/jupyter/kernels/python3"
+
+# Install packages
+pip install tensorflow==2.14.0
+pip install --no-deps tensorflow-privacy==0.8.12 dp_accounting==0.4.3 tensorflow_probability==0.22.0
+pip install numpy==1.23.5 scipy~=1.9 dm-tree==0.1.8 attrs==25.3.0 cloudpickle==3.1.1 scikit-learn==1.*
+
+conda deactivate

--- a/notebooks/responsible_ai/privacy/solutions/privacy_dpsgd.ipynb
+++ b/notebooks/responsible_ai/privacy/solutions/privacy_dpsgd.ipynb
@@ -73,7 +73,8 @@
     "id": "ijJYKVc05DYX"
    },
    "source": [
-    "## Setup"
+    "## Setup\n",
+    "This lab needs a special kernel to run, please run the following cell."
    ]
   },
   {
@@ -85,7 +86,17 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --user --no-deps tensorflow-privacy==0.8.12 dp_accounting==0.4.3"
+    "!echo \"Kernel installation started.\"\n",
+    "!cd ../../../.. && make tf_privacy_kernel > /dev/null 2>&1\n",
+    "!echo \"Kernel installation completed.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When it's completed, select the **`TF Privacy Kernel`** on the top right before going forward in the notebook.<br>\n",
+    "It may take ~1 minutes until the kernel is shown after the installation."
    ]
   },
   {
@@ -94,12 +105,12 @@
     "id": "CKuHPYQCsV-x"
    },
    "source": [
-    "Begin by importing the necessary libraries:"
+    "Let's import the necessary libraries:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -124,9 +135,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-03-11 18:23:24.342772: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-      "2024-03-11 18:23:24.342907: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
-      "2024-03-11 18:23:24.349126: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n"
+      "2025-09-16 22:00:22.222336: E tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc:9342] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+      "2025-09-16 22:00:22.222408: E tensorflow/compiler/xla/stream_executor/cuda/cuda_fft.cc:609] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+      "2025-09-16 22:00:22.222447: E tensorflow/compiler/xla/stream_executor/cuda/cuda_blas.cc:1518] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n"
      ]
     }
    ],
@@ -177,7 +188,16 @@
     "id": "_1ML23FlueTr",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz\n",
+      "11490434/11490434 [==============================] - 0s 0us/step\n"
+     ]
+    }
+   ],
    "source": [
     "train, test = tf.keras.datasets.mnist.load_data()\n",
     "train_data, train_labels = train\n",
@@ -350,13 +370,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1875/1875 [==============================] - 168s 89ms/step - loss: 0.7247 - accuracy: 0.8371 - val_loss: 0.8313 - val_accuracy: 0.8877\n"
+      "1875/1875 [==============================] - 145s 76ms/step - loss: 0.8429 - accuracy: 0.8256 - val_loss: 0.9353 - val_accuracy: 0.8737\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<keras.src.callbacks.History at 0x7f52b431b040>"
+       "<keras.src.callbacks.History at 0x7fdaf0685960>"
       ]
      },
      "execution_count": 9,
@@ -487,7 +507,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Copyright 2024 Google Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License"
+    "Copyright 2025 Google Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License"
    ]
   },
   {
@@ -507,15 +527,15 @@
    "toc_visible": true
   },
   "environment": {
-   "kernel": "conda-base-py",
-   "name": "workbench-notebooks.m121",
+   "kernel": "conda-env-tf_privacy_kernel-tf_privacy_kernel",
+   "name": "workbench-notebooks.m132",
    "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m121"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m132"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel) (Local)",
+   "display_name": "TF Privacy Kernel (Local)",
    "language": "python",
-   "name": "conda-base-py"
+   "name": "conda-env-tf_privacy_kernel-tf_privacy_kernel"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Added a dedicated kernel for the tf_privacy environment to keep the compatibility with pure Tensorflow.

Leaving the output cells for reference for the on-demand course reference.