### PR TITLE
Comment out data copy commands in KFP notebooks

### DIFF
--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_lightweight.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_lightweight.ipynb
@@ -308,7 +308,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please remove the comment out and run the cell below to create the dataset before running the pipeline."
    ]
   },
   {
@@ -317,9 +317,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+    "# %%bash\n",
+    "# gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "# gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_prebuilt.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_vertex_prebuilt.ipynb
@@ -382,7 +382,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please remove the comment out and run the cell below to create the dataset before running the pipeline."
    ]
   },
   {
@@ -391,9 +391,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+    "# %%bash\n",
+    "# gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "# gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_lightweight.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_lightweight.ipynb
@@ -318,7 +318,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please remove the comment out and run the cell below to create the dataset before running the pipeline."
    ]
   },
   {
@@ -327,9 +327,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+    "# %%bash\n",
+    "# gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "# gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_prebuilt.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_vertex_prebuilt.ipynb
@@ -390,7 +390,7 @@
    "source": [
     "Also, this notebook assumes the dataset is already created and stored in Google Cloud Storage following the instructions covered in the [walkthrough notebook](https://github.com/GoogleCloudPlatform/asl-ml-immersion/blob/master/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_vertex.ipynb).\n",
     "\n",
-    "If you haven't run it, please run the cell below and create the dataset before running the pipeline."
+    "If you haven't run it, please remove the comment out and run the cell below to create the dataset before running the pipeline."
    ]
   },
   {
@@ -401,9 +401,9 @@
    },
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+    "# %%bash\n",
+    "# gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "# gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
    ]
   },
   {


### PR DESCRIPTION
Commented out the file copy commands in KFP notebooks, since I've seen some users run multiple notebooks in parallel and see errors due to file overwrite during cloud training in the pipelines. 
