### PR TITLE
Fix double 'user:' prefix in ADK state instructions

### DIFF
--- a/asl_genai/notebooks/building_agents/labs/adk_agents/agent3_stateful_agent/agent.py
+++ b/asl_genai/notebooks/building_agents/labs/adk_agents/agent3_stateful_agent/agent.py
@@ -31,7 +31,7 @@ root_agent = Agent(
     model=MODEL,
     description="Main agent: Provides weather (state-aware unit), delegates greetings/farewells, saves report to state.",
     instruction="You are the main Weather Agent. Your job is to provide weather using 'get_weather_stateful'. "
-    "If user want to change prefered temperature unit (Celsius/Fahrenheit), use 'set_user_preference' and and change 'user:temperature_unit' state."
+    "If user want to change prefered temperature unit (Celsius/Fahrenheit), use 'set_user_preference' and change 'temperature_unit' state."
     "The tool will format the temperature based on user preference stored in state. "
     "Delegate simple greetings to 'greeting_agent' and farewells to 'farewell_agent'. "
     "Handle only weather requests, greetings, and farewells.",

--- a/asl_genai/notebooks/building_agents/labs/building_agent_with_adk.ipynb
+++ b/asl_genai/notebooks/building_agents/labs/building_agent_with_adk.ipynb
@@ -1225,7 +1225,7 @@
     "    model=MODEL,\n",
     "    description=\"Main agent: Provides weather (state-aware unit), delegates greetings/farewells, saves report to state.\",\n",
     "    instruction=\"You are the main Weather Agent. Your job is to provide weather using 'get_weather_stateful'. \"\n",
-    "                \"If user want to change prefered temperature unit (Celsius/Fahrenheit), use 'set_user_preference' and and change 'user:temperature_unit' state.\"\n",
+    "                \"If user want to change prefered temperature unit (Celsius/Fahrenheit), use 'set_user_preference' and change 'temperature_unit' state.\"\n",
     "                \"The tool will format the temperature based on user preference stored in state. \"\n",
     "                \"Delegate simple greetings to 'greeting_agent' and farewells to 'farewell_agent'. \"\n",
     "                \"Handle only weather requests, greetings, and farewells.\",\n",

--- a/asl_genai/notebooks/building_agents/solutions/adk_agents/agent3_stateful_agent/agent.py
+++ b/asl_genai/notebooks/building_agents/solutions/adk_agents/agent3_stateful_agent/agent.py
@@ -31,7 +31,7 @@ root_agent = Agent(
     model=MODEL,
     description="Main agent: Provides weather (state-aware unit), delegates greetings/farewells, saves report to state.",
     instruction="You are the main Weather Agent. Your job is to provide weather using 'get_weather_stateful'. "
-    "If user want to change prefered temperature unit (Celsius/Fahrenheit), use 'set_user_preference' and and change 'user:temperature_unit' state."
+    "If user want to change prefered temperature unit (Celsius/Fahrenheit), use 'set_user_preference' and change 'temperature_unit' state."
     "The tool will format the temperature based on user preference stored in state. "
     "Delegate simple greetings to 'greeting_agent' and farewells to 'farewell_agent'. "
     "Handle only weather requests, greetings, and farewells.",

--- a/asl_genai/notebooks/building_agents/solutions/building_agent_with_adk.ipynb
+++ b/asl_genai/notebooks/building_agents/solutions/building_agent_with_adk.ipynb
@@ -1203,7 +1203,7 @@
     "    model=MODEL,\n",
     "    description=\"Main agent: Provides weather (state-aware unit), delegates greetings/farewells, saves report to state.\",\n",
     "    instruction=\"You are the main Weather Agent. Your job is to provide weather using 'get_weather_stateful'. \"\n",
-    "                \"If user want to change prefered temperature unit (Celsius/Fahrenheit), use 'set_user_preference' and and change 'user:temperature_unit' state.\"\n",
+    "                \"If user want to change prefered temperature unit (Celsius/Fahrenheit), use 'set_user_preference' and change 'temperature_unit' state.\"\n",
     "                \"The tool will format the temperature based on user preference stored in state. \"\n",
     "                \"Delegate simple greetings to 'greeting_agent' and farewells to 'farewell_agent'. \"\n",
     "                \"Handle only weather requests, greetings, and farewells.\",\n",


### PR DESCRIPTION
### Description
This PR fixes an issue in the `agent3_stateful_agent` where the state key was being prefixed with `user:` twice, causing the stateful weather tool to fail to read user preferences.
**Problem:**
The agent's instruction in `agent.py` guided it to use `'user:temperature_unit'` when calling the `set_user_preference` tool. However, that tool automatically adds the `"user:"` prefix to the preference key:
```python
state_key = f"user:{preference}"
```
This resulted in the state key being saved as `"user:user:temperature_unit"`. Consequently, the `get_weather_stateful` tool, which looks for `"user:temperature_unit"`, could not find the preference and fell back to the default (Celsius).
**Solution:**
Updated the instruction in `agent.py` to tell the agent to use `'temperature_unit'` as the preference name, allowing the tool to add the prefix correctly.
Also fixed a minor typo in the instruction text: changed "and and change" to "and change".
### Files Changed
- `asl_genai/notebooks/building_agents/labs/adk_agents/agent3_stateful_agent/agent.py`
- `asl_genai/notebooks/building_agents/labs/building_agent_with_adk.ipynb`
- `asl_genai/notebooks/building_agents/solutions/adk_agents/agent3_stateful_agent/agent.py`
- `asl_genai/notebooks/building_agents/solutions/building_agent_with_adk.ipynb`