### PR TITLE
Rebrand Vertex AI to Agent Platform in building_agents

### DIFF
--- a/asl_genai/notebooks/building_agents/labs/building_agent_with_adk.ipynb
+++ b/asl_genai/notebooks/building_agents/labs/building_agent_with_adk.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "LOCATION = \"us-central1\"\n",
     "os.environ[\"GOOGLE_CLOUD_LOCATION\"] = LOCATION\n",
-    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Vertex AI API"
+    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Agent Platform API"
    ]
   },
   {
@@ -516,7 +516,7 @@
    "id": "33dc0e35-bb95-472c-957d-666aa22c09a2",
    "metadata": {},
    "source": [
-    "**Note:** if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "**Note:** if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {
@@ -962,7 +962,7 @@
    "id": "6756ebd9-7f99-4e1c-869c-a7a0c6bd0cff",
    "metadata": {},
    "source": [
-    "**Note:** if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "**Note:** if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {
@@ -1536,7 +1536,7 @@
     "* **`reflection_agent`**: act as a professor, providing detailed critique on the essay draft.\n",
     "\n",
     "**Important Note** When you use grounding with Google Search, and you receive Search suggestions in your response, you must display the Search suggestions in production and in your applications.<br>\n",
-    "Please take a look at [the document](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-search-suggestions) for more detail."
+    "Please take a look at [the document](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/grounding/grounding-with-google-search) for more detail."
    ]
   },
   {
@@ -1833,7 +1833,7 @@
    "id": "85c820e1-5938-4be5-96b6-4b7209948f28",
    "metadata": {},
    "source": [
-    "**Note:** if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "**Note:** if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {

--- a/asl_genai/notebooks/building_agents/solutions/agent_safeguard_with_model_armor.ipynb
+++ b/asl_genai/notebooks/building_agents/solutions/agent_safeguard_with_model_armor.ipynb
@@ -93,7 +93,7 @@
     "LOCATION = \"us-central1\"\n",
     "os.environ[\"GOOGLE_CLOUD_PROJECT\"] = PROJECT_ID\n",
     "os.environ[\"GOOGLE_CLOUD_LOCATION\"] = LOCATION\n",
-    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Vertex AI API"
+    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Agent Platform API"
    ]
   },
   {
@@ -491,7 +491,7 @@
    "id": "ab05a36d-8d24-4922-b587-d5db96ab1f47",
    "metadata": {},
    "source": [
-    "Note: if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "Note: if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {
@@ -1250,7 +1250,7 @@
    "id": "4d48837e-de9c-4a21-8bff-57d3cf8e7afc",
    "metadata": {},
    "source": [
-    "Note: if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "Note: if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {

--- a/asl_genai/notebooks/building_agents/solutions/building_agent_with_adk.ipynb
+++ b/asl_genai/notebooks/building_agents/solutions/building_agent_with_adk.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "LOCATION = \"us-central1\"\n",
     "os.environ[\"GOOGLE_CLOUD_LOCATION\"] = LOCATION\n",
-    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Vertex AI API"
+    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Agent Platform API"
    ]
   },
   {
@@ -520,7 +520,7 @@
    "id": "c60c8e43-fae8-48fc-9c9f-c6f588f74c9a",
    "metadata": {},
    "source": [
-    "**Note:** if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "**Note:** if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {
@@ -940,7 +940,7 @@
    "id": "7e02c33f-113d-4ccf-bfaf-7ccbdeae0408",
    "metadata": {},
    "source": [
-    "**Note:** if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "**Note:** if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {
@@ -1434,7 +1434,7 @@
    "id": "0487e6c4-d297-462b-bcfd-0bddde949c05",
    "metadata": {},
    "source": [
-    "**Note:** if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "**Note:** if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {
@@ -1498,7 +1498,7 @@
     "* **`reflection_agent`**: act as a professor, providing detailed critique on the essay draft.\n",
     "\n",
     "**Important Note** When you use grounding with Google Search, and you receive Search suggestions in your response, you must display the Search suggestions in production and in your applications.<br>\n",
-    "Please take a look at [the document](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-search-suggestions) for more detail."
+    "Please take a look at [the document](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/grounding/grounding-with-google-search) for more detail."
    ]
   },
   {
@@ -1811,7 +1811,7 @@
    "id": "0ece1d24-918a-4bdf-bfb9-dca1ad77d1fa",
    "metadata": {},
    "source": [
-    "**Note:** if you are using Vertex AI Workbench, remove the comment out and run the cell below."
+    "**Note:** if you are using Agent Platform Workbench, remove the comment out and run the cell below."
    ]
   },
   {


### PR DESCRIPTION
This PR executes a systematic rebranding of "Vertex AI" to "Agent Platform" across the `asl_genai/notebooks/building_agents` directory.

## Changes Made
I have updated references to "Vertex AI" in Markdown text and Python comments, and updated documentation URLs in the following notebooks:
- `asl_genai/notebooks/building_agents/solutions/agent_safeguard_with_model_armor.ipynb`
- `asl_genai/notebooks/building_agents/labs/building_agent_with_adk.ipynb`
- `asl_genai/notebooks/building_agents/solutions/building_agent_with_adk.ipynb`
### Specific Replacements:
- "Vertex AI Platform" -> "Agent Platform"
- "Vertex AI API" -> "Agent Platform API" (in comments)
- "Vertex AI Workbench" -> "Agent Platform Workbench"
- URL `https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-search-suggestions` -> `https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/grounding/grounding-with-google-search`
I preserved code functionality by not renaming environment variables (like `GOOGLE_GENAI_USE_VERTEXAI`) or Python symbols.