### PR TITLE
Add notebook for building agents with Google MCP servers

### DIFF
--- a/asl_genai/notebooks/building_agents/solutions/building_agent_with_mcp.ipynb
+++ b/asl_genai/notebooks/building_agents/solutions/building_agent_with_mcp.ipynb
@@ -606,6 +606,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e5c7a12b",
+   "metadata": {},
+   "source": [
+    "**Citation & Disclaimer**\n",
+    "\n",
+    "This notebook is based on and updated from the public example: [Google MCP Launch My Bakery](https://github.com/google/mcp/tree/main/examples/launchmybakery)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "60b2fe8a",
    "metadata": {},
    "source": [

--- a/asl_genai/notebooks/building_agents/solutions/building_agent_with_mcp.ipynb
+++ b/asl_genai/notebooks/building_agents/solutions/building_agent_with_mcp.ipynb
@@ -1,0 +1,640 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a452786d",
+   "metadata": {},
+   "source": [
+    "# Building Agents with Google's MCP Servers\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "In this notebook, you will build an AI Agent using the Agent Development Kit (ADK) and Model Context Protocol (MCP) servers. You'll learn how to leverage MCP servers to connect your agent to external data sources and tools, specifically Google BigQuery and Google Maps, to solve a complex business problem. <br>\n",
+    "Throughout this notebook, you will set up the environment, interact with MCP servers directly to understand their protocol, and finally build and test an agent that uses these servers via the ADK.\n",
+    "\n",
+    "### Scenario: Launching a Bakery\n",
+    "\n",
+    "To apply these concepts, you will build an agent to help a friend launch a new high-end sourdough bakery in Los Angeles. The agent will need to:\n",
+    "1. Query BigQuery to find macro trends (demographics, competitor pricing, sales history).\n",
+    "2. Use Google Maps to validate micro-location details.\n",
+    "\n",
+    "## Learning Goals\n",
+    "\n",
+    "By the end of this notebook, you will understand how to:\n",
+    "* Understand the concept of **Model Context Protocol (MCP)** and how it enables standardized tool integration.\n",
+    "* Interact with MCP servers directly.\n",
+    "* Create an ADK agent that uses MCP servers as tools.\n",
+    "* Use the **ADK Developer UI** to interact with and inspect the agent's execution flow involving MCP tools."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2437e805",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "In this section, we will set up the necessary data in BigQuery. We will create a dataset named `mcp_bakery` and load sample data into four tables:\n",
+    "- `demographics`\n",
+    "- `bakery_prices`\n",
+    "- `sales_history_weekly`\n",
+    "- `foot_traffic`\n",
+    "\n",
+    "Instead of running an external script, we will define the setup steps directly in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1508df4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import google.auth\n",
+    "from google.cloud import bigquery\n",
+    "from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset\n",
+    "from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams\n",
+    "import time\n",
+    "import json\n",
+    "import requests\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc9fb01e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install gcloud alpha component if needed\n",
+    "!gcloud components install alpha --quiet\n",
+    "\n",
+    "# Enable necessary APIs\n",
+    "!gcloud services enable mapstools.googleapis.com\n",
+    "!gcloud services enable bigquery.googleapis.com\n",
+    "\n",
+    "# Enable MCP for services\n",
+    "!gcloud beta services mcp enable mapstools.googleapis.com\n",
+    "!gcloud beta services mcp enable bigquery.googleapis.com"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "837f8878",
+   "metadata": {},
+   "source": [
+    "### Create Google Maps API Key\n",
+    "\n",
+    "We will attempt to automatically create a restricted API key for the Google Maps MCP service. We use Python to parse the JSON response from the `gcloud` command and set it in the `MAPS_API_KEY` environment variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1d128bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run gcloud command and capture output\n",
+    "api_key_name = f\"bakery-demo-key-{int(time.time())}\"\n",
+    "result = !gcloud alpha services api-keys create --display-name=\"{api_key_name}\" --api-target=service=mapstools.googleapis.com --format=json --quiet\n",
+    "\n",
+    "result_str = \"\\n\".join(result)\n",
+    "\n",
+    "# Find the first '{' to skip potential non-JSON text\n",
+    "start = result_str.find(\"{\")\n",
+    "\n",
+    "# Decode the first JSON object found\n",
+    "decoder = json.JSONDecoder()\n",
+    "key_data, idx = decoder.raw_decode(result_str[start:])\n",
+    "\n",
+    "api_key = key_data.get('keyString')\n",
+    "os.environ['MAPS_API_KEY'] = api_key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f54898d",
+   "metadata": {},
+   "source": [
+    "### Use Data from Google Cloud Storage\n",
+    "\n",
+    "We will use the data stored in the public bucket `gs://asl-public-data/data/mcp-bakery`. We will load this data directly into BigQuery in the next step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9412a83c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud storage ls gs://asl-public-data/data/mcp-bakery/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12fb2112",
+   "metadata": {},
+   "source": [
+    "### Create BigQuery Dataset and Tables\n",
+    "\n",
+    "Now we will create the BigQuery dataset and tables, and load the data from the CSV files we just created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17424a00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "credentials, project_id = google.auth.default()\n",
+    "if not project_id:\n",
+    "    project_id = PROJECT_ID\n",
+    "\n",
+    "client = bigquery.Client(project=project_id, credentials=credentials)\n",
+    "\n",
+    "dataset_id = f\"{project_id}.mcp_bakery\"\n",
+    "dataset = bigquery.Dataset(dataset_id)\n",
+    "dataset.location = \"US\"\n",
+    "\n",
+    "try:\n",
+    "    dataset = client.create_dataset(dataset, timeout=30)\n",
+    "    print(f\"Created dataset {dataset_id}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Dataset might already exist or error: {e}\")\n",
+    "\n",
+    "# Helper function to load CSV from GCS to BQ\n",
+    "def load_csv_from_gcs_to_bq(table_name, schema):\n",
+    "    table_id = f\"{dataset_id}.{table_name}\"\n",
+    "    uri = f\"gs://asl-public-data/data/mcp-bakery/{table_name}.csv\"\n",
+    "    \n",
+    "    job_config = bigquery.LoadJobConfig(\n",
+    "        schema=schema,\n",
+    "        skip_leading_rows=1,\n",
+    "        source_format=bigquery.SourceFormat.CSV,\n",
+    "        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,\n",
+    "    )\n",
+    "    \n",
+    "    job = client.load_table_from_uri(uri, table_id, job_config=job_config)\n",
+    "    job.result()  # Wait for the job to complete.\n",
+    "    print(f\"Loaded rows into {table_id} from {uri}.\")\n",
+    "\n",
+    "# Schemas\n",
+    "demo_schema = [\n",
+    "    bigquery.SchemaField(\"zip_code\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"city\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"neighborhood\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"total_population\", \"INT64\"),\n",
+    "    bigquery.SchemaField(\"median_age\", \"FLOAT64\"),\n",
+    "    bigquery.SchemaField(\"bachelors_degree_pct\", \"FLOAT64\"),\n",
+    "    bigquery.SchemaField(\"foot_traffic_index\", \"FLOAT64\"),\n",
+    "]\n",
+    "\n",
+    "prices_schema = [\n",
+    "    bigquery.SchemaField(\"store_name\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"product_type\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"price\", \"FLOAT64\"),\n",
+    "    bigquery.SchemaField(\"region\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"is_organic\", \"BOOLEAN\"),\n",
+    "]\n",
+    "\n",
+    "sales_schema = [\n",
+    "    bigquery.SchemaField(\"week_start_date\", \"DATE\"),\n",
+    "    bigquery.SchemaField(\"store_location\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"product_type\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"quantity_sold\", \"INT64\"),\n",
+    "    bigquery.SchemaField(\"total_revenue\", \"FLOAT64\"),\n",
+    "]\n",
+    "\n",
+    "traffic_schema = [\n",
+    "    bigquery.SchemaField(\"zip_code\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"time_of_day\", \"STRING\"),\n",
+    "    bigquery.SchemaField(\"foot_traffic_score\", \"FLOAT64\"),\n",
+    "]\n",
+    "\n",
+    "# Load tables\n",
+    "load_csv_from_gcs_to_bq(\"demographics\", demo_schema)\n",
+    "load_csv_from_gcs_to_bq(\"bakery_prices\", prices_schema)\n",
+    "load_csv_from_gcs_to_bq(\"sales_history_weekly\", sales_schema)\n",
+    "load_csv_from_gcs_to_bq(\"foot_traffic\", traffic_schema)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "363fa5d0",
+   "metadata": {},
+   "source": [
+    "### Verify Data in BigQuery\n",
+    "\n",
+    "Let's check the first few rows of each table to understand what kind of data we have and verify that it was loaded correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c4fcaaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Function to query and display head of a table\n",
+    "def show_table_head(table_name):\n",
+    "    query = f\"SELECT * FROM `{project_id}.mcp_bakery.{table_name}` LIMIT 5\"\n",
+    "    df = client.query(query).to_dataframe()\n",
+    "    print(f\"\\n--- Table: {table_name} ---\")\n",
+    "    display(df)\n",
+    "\n",
+    "for table in [\"demographics\", \"bakery_prices\", \"sales_history_weekly\", \"foot_traffic\"]:\n",
+    "    show_table_head(table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79a53dbe",
+   "metadata": {},
+   "source": [
+    "## Understand MCP Servers\n",
+    "\n",
+    "### What is MCP?\n",
+    "Model Context Protocol (MCP) is an open standard that enables AI models to securely interact with external data sources and tools. Instead of writing custom integration code for every tool, MCP provides a standardized way for models to discover and use capabilities provided by MCP servers.\n",
+    "\n",
+    "Google provides [a lot of Google-hosted managed MCP servers](https://docs.cloud.google.com/mcp/supported-products).\n",
+    "\n",
+    "In this tutorial, we will use two MCP servers:\n",
+    "1. [**BigQuery MCP**](https://docs.cloud.google.com/bigquery/docs/reference/mcp): Allows the agent to query BigQuery datasets.\n",
+    "2. [**Google Maps MCP**](https://developers.google.com/maps/ai/grounding-lite/reference/mcp): Allows the agent to interact with Google Maps APIs (geocoding, places, etc.)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5409ec95",
+   "metadata": {},
+   "source": [
+    "### Calling MCP Server Directly\n",
+    "\n",
+    "To understand how MCP works under the hood, we can call the MCP server directly using standard HTTP requests. MCP servers typically use JSON-RPC over HTTP or SSE.\n",
+    "\n",
+    "Here we make a direct POST request to list the available tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aec34ac9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAPS_MCP_URL = \"https://mapstools.googleapis.com/mcp\"\n",
+    "BIGQUERY_MCP_URL = \"https://bigquery.googleapis.com/mcp\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa32dd10",
+   "metadata": {},
+   "source": [
+    "Let's setup the header."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f218cbe7",
+   "metadata": {
+    "vscode": {
+     "languageId": "markdown"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Direct call to BigQuery MCP server to list tools\n",
+    "credentials, project_id = google.auth.default(\n",
+    ")\n",
+    "credentials.refresh(google.auth.transport.requests.Request())\n",
+    "oauth_token = credentials.token\n",
+    "\n",
+    "headers = {\n",
+    "    \"Authorization\": f\"Bearer {oauth_token}\",\n",
+    "    \"x-goog-user-project\": project_id,\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6813e625",
+   "metadata": {},
+   "source": [
+    "Let's list available tools under the BigQuery MCP."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b31a028d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# MCP list tools request payload\n",
+    "payload = {\n",
+    "    \"jsonrpc\": \"2.0\",\n",
+    "    \"id\": 1,\n",
+    "    \"method\": \"tools/list\",\n",
+    "    \"params\": {}\n",
+    "}\n",
+    "\n",
+    "response = requests.post(BIGQUERY_MCP_URL, headers=headers, json=payload)\n",
+    "\n",
+    "resp_json = response.json()\n",
+    "tools = resp_json.get('result', {}).get('tools', [])\n",
+    "print(\"Available tools:\")\n",
+    "for t in tools:\n",
+    "    print(f\"- {t.get('name')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1230f96",
+   "metadata": {},
+   "source": [
+    "Now let's try to call a specific tool directly. We will call the `execute_sql` tool to query the `demographics` table we created earlier. We will only print the main content of the response to avoid long output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89da1d37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "payload = {\n",
+    "    \"jsonrpc\": \"2.0\",\n",
+    "    \"id\": 1,\n",
+    "    \"method\": \"tools/call\",\n",
+    "    \"params\": {\n",
+    "        \"name\": \"execute_sql\",\n",
+    "        \"arguments\": {\n",
+    "            \"project_id\": project_id,\n",
+    "            \"query\": f\"SELECT * FROM `{project_id}.mcp_bakery.demographics` LIMIT 2\"\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "response = requests.post(BIGQUERY_MCP_URL, headers=headers, json=payload)\n",
+    "\n",
+    "resp_json = response.json()\n",
+    "result = resp_json.get('result', {})\n",
+    "content = result.get('content', [])\n",
+    "\n",
+    "print(\"Result Content:\")\n",
+    "print(content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "696791e1",
+   "metadata": {},
+   "source": [
+    "Also, let's check what kind of tools are available under the Google Map MCP."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3bdd835",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "payload = {\n",
+    "    \"jsonrpc\": \"2.0\",\n",
+    "    \"id\": 1,\n",
+    "    \"method\": \"tools/list\",\n",
+    "    \"params\": {}\n",
+    "}\n",
+    "\n",
+    "response = requests.post(MAPS_MCP_URL, headers=headers, json=payload)\n",
+    "\n",
+    "resp_json = response.json()\n",
+    "tools = resp_json.get('result', {}).get('tools', [])\n",
+    "print(\"Available tools:\")\n",
+    "for t in tools:\n",
+    "    print(f\"- {t.get('name')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20b609bf",
+   "metadata": {},
+   "source": [
+    "## Define the Agent with MCP\n",
+    "\n",
+    "To use the ADK Developer UI, we need to save our agent definition to a directory. We will create a directory named `mcp_bakery_agents` and write `tools.py` and `agent.py` files containing the agent and toolset definitions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c4f3054",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.makedirs('mcp_bakery_agents/agent', exist_ok=True)\n",
+    "\n",
+    "with open('mcp_bakery_agents/.env', 'w') as f:\n",
+    "    f.write(f\"MAPS_API_KEY={os.environ.get('MAPS_API_KEY', '')}\\n\")\n",
+    "    f.write(f\"GOOGLE_CLOUD_LOCATION=us-central1\\n\")\n",
+    "    f.write(f\"GOOGLE_GENAI_USE_VERTEXAI=TRUE\\n\")\n",
+    "    f.write(f\"PROJECT_ID={project_id}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe861e0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile mcp_bakery_agents/agent/tools.py\n",
+    "import os\n",
+    "import dotenv\n",
+    "import google.auth\n",
+    "from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset\n",
+    "from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams\n",
+    "\n",
+    "MAPS_MCP_URL = \"https://mapstools.googleapis.com/mcp\"\n",
+    "BIGQUERY_MCP_URL = \"https://bigquery.googleapis.com/mcp\"\n",
+    "\n",
+    "def get_maps_mcp_toolset():\n",
+    "    maps_api_key = os.getenv('MAPS_API_KEY', 'YOUR_MAPS_API_KEY')\n",
+    "    return MCPToolset(\n",
+    "        connection_params=StreamableHTTPConnectionParams(\n",
+    "            url=MAPS_MCP_URL,\n",
+    "            headers={\"X-Goog-Api-Key\": maps_api_key},\n",
+    "            timeout=30.0,\n",
+    "            sse_read_timeout=300.0\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "def get_bigquery_mcp_toolset():\n",
+    "    credentials, project_id = google.auth.default(\n",
+    "        scopes=[\"https://www.googleapis.com/auth/bigquery\"]\n",
+    "    )\n",
+    "    credentials.refresh(google.auth.transport.requests.Request())\n",
+    "    oauth_token = credentials.token\n",
+    "    return MCPToolset(\n",
+    "        connection_params=StreamableHTTPConnectionParams(\n",
+    "            url=BIGQUERY_MCP_URL,\n",
+    "            headers={\n",
+    "                \"Authorization\": f\"Bearer {oauth_token}\",\n",
+    "                \"x-goog-user-project\": project_id\n",
+    "            },\n",
+    "            timeout=30.0,\n",
+    "            sse_read_timeout=300.0\n",
+    "        )\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70286ca1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile mcp_bakery_agents/agent/agent.py\n",
+    "import os\n",
+    "from google.adk.agents import LlmAgent\n",
+    "from . import tools\n",
+    "\n",
+    "bq_toolset = tools.get_bigquery_mcp_toolset()\n",
+    "maps_toolset = tools.get_maps_mcp_toolset()\n",
+    "\n",
+    "PROJECT_ID = os.getenv('PROJECT_ID')\n",
+    "\n",
+    "PROMPT = f\"\"\"\n",
+    "You are a helpful business consultant helping a friend launch a new high-end sourdough bakery in Los Angeles.\n",
+    "Your goal is to recommend the best neighborhood and a premium price point.\n",
+    "\n",
+    "To do this, you should:\n",
+    "1. Query BigQuery mcp_bakery dataset under {PROJECT_ID} project to find neighborhoods with high bachelors degree percentage and high foot traffic index (macro trends).\n",
+    "2. Query BigQuery mcp_bakery dataset under {PROJECT_ID} project to analyze competitor pricing for 'Sourdough Loaf' in 'Los Angeles Metro' to suggest a premium price.\n",
+    "3. Use Google Maps tools to validate micro-location details or search for specific locations in the chosen neighborhood.\n",
+    "\n",
+    "Google Cloud project ID:\n",
+    "{PROJECT_ID}\n",
+    "\n",
+    "Be strategic and combine insights from both sources.\n",
+    "\"\"\"\n",
+    "\n",
+    "root_agent = LlmAgent(\n",
+    "    model=\"gemini-2.5-flash\",\n",
+    "    name=\"bakery_consultant_agent\",\n",
+    "    instruction=PROMPT,\n",
+    "    tools=[bq_toolset, maps_toolset],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee718efb",
+   "metadata": {},
+   "source": [
+    "## Call Agent via ADK Web\n",
+    "\n",
+    "You can launch the ADK Developer UI to interact with your agents using the `adk web` command.\n",
+    "\n",
+    "Execute the appropriate cell below depending on your environment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bb9a22e",
+   "metadata": {},
+   "source": [
+    "Once the UI is running, you can interact with the agent. Try asking questions like:\n",
+    "\n",
+    "- \"Which zip code in Los Angeles has the highest morning foot traffic?\"\n",
+    "- \"Is the density of existing bakeries too high in the Silver Lake area?\"\n",
+    "- \"Based on local competitor pricing, what premium price can I charge for a sourdough loaf?\"\n",
+    "- \"Forecast the sales performance based on historical trends.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd366c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# On Cloud Workstations\n",
+    "!adk web mcp_bakery_agents --allow_origins \"regex:https://.*\\.cloudworkstations\\.dev\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b541d4f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: if you are using Vertex AI Workbench, remove the comment out and run the cell below.\n",
+    "# %%bash\n",
+    "# PROXY_BASE=$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/attributes/proxy-url -H \"Metadata-Flavor: Google\")\n",
+    "# echo \"--------------------------------------------------------\"\n",
+    "# echo \"🔗 ACCESS HERE: https://${PROXY_BASE}/proxy/8000\"\n",
+    "# echo \"--------------------------------------------------------\"\n",
+    "# adk web mcp_bakery_agents --url_prefix /proxy/8000  --allow_origins \"regex:https://.*\\.notebooks\\.googleusercontent\\.com\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4b82a2d",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook, we demonstrated how to:\n",
+    "1. Set up sample data in BigQuery for a business scenario.\n",
+    "2. Connect to Google-hosted MCP servers for BigQuery and Google Maps using ADK.\n",
+    "3. Define an AI Agent that leverages these MCP servers to solve complex business problems.\n",
+    "4. Launch the ADK Developer UI to interact with the agent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60b2fe8a",
+   "metadata": {},
+   "source": [
+    "Copyright 2026 Google LLC\n",
+    "\n",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "you may not use this file except in compliance with the License.\n",
+    "You may obtain a copy of the License at\n",
+    "\n",
+    "    https://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    "Unless required by applicable law or agreed to in writing, software\n",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "See the License for the specific language governing permissions and\n",
+    "limitations under the License."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/asl_genai/notebooks/building_agents/solutions/building_agent_with_mcp.ipynb
+++ b/asl_genai/notebooks/building_agents/solutions/building_agent_with_mcp.ipynb
@@ -62,25 +62,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dc9fb01e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install gcloud alpha component if needed\n",
-    "!gcloud components install alpha --quiet\n",
-    "\n",
-    "# Enable necessary APIs\n",
-    "!gcloud services enable mapstools.googleapis.com\n",
-    "!gcloud services enable bigquery.googleapis.com\n",
-    "\n",
-    "# Enable MCP for services\n",
-    "!gcloud beta services mcp enable mapstools.googleapis.com\n",
-    "!gcloud beta services mcp enable bigquery.googleapis.com"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "837f8878",
    "metadata": {},
@@ -637,12 +618,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "ASL Gen AI",
    "language": "python",
-   "name": "python3"
+   "name": "asl_genai"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/asl_genai/notebooks/building_agents/solutions/mcp_bakery_agents/agent/agent.py
+++ b/asl_genai/notebooks/building_agents/solutions/mcp_bakery_agents/agent/agent.py
@@ -1,0 +1,33 @@
+# pylint: skip-file
+import os
+
+from google.adk.agents import LlmAgent
+
+from . import tools
+
+bq_toolset = tools.get_bigquery_mcp_toolset()
+maps_toolset = tools.get_maps_mcp_toolset()
+
+PROJECT_ID = os.getenv("PROJECT_ID")
+
+PROMPT = f"""
+You are a helpful business consultant helping a friend launch a new high-end sourdough bakery in Los Angeles.
+Your goal is to recommend the best neighborhood and a premium price point.
+
+To do this, you should:
+1. Query BigQuery mcp_bakery dataset under {PROJECT_ID} project to find neighborhoods with high bachelors degree percentage and high foot traffic index (macro trends).
+2. Query BigQuery mcp_bakery dataset under {PROJECT_ID} project to analyze competitor pricing for 'Sourdough Loaf' in 'Los Angeles Metro' to suggest a premium price.
+3. Use Google Maps tools to validate micro-location details or search for specific locations in the chosen neighborhood.
+
+Google Cloud project ID:
+{PROJECT_ID}
+
+Be strategic and combine insights from both sources.
+"""
+
+root_agent = LlmAgent(
+    model="gemini-2.5-flash",
+    name="bakery_consultant_agent",
+    instruction=PROMPT,
+    tools=[bq_toolset, maps_toolset],
+)

--- a/asl_genai/notebooks/building_agents/solutions/mcp_bakery_agents/agent/tools.py
+++ b/asl_genai/notebooks/building_agents/solutions/mcp_bakery_agents/agent/tools.py
@@ -1,0 +1,43 @@
+# pylint: skip-file
+import os
+
+import dotenv
+import google.auth
+from google.adk.tools.mcp_tool.mcp_session_manager import (
+    StreamableHTTPConnectionParams,
+)
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
+
+MAPS_MCP_URL = "https://mapstools.googleapis.com/mcp"
+BIGQUERY_MCP_URL = "https://bigquery.googleapis.com/mcp"
+
+
+def get_maps_mcp_toolset():
+    maps_api_key = os.getenv("MAPS_API_KEY", "YOUR_MAPS_API_KEY")
+    return MCPToolset(
+        connection_params=StreamableHTTPConnectionParams(
+            url=MAPS_MCP_URL,
+            headers={"X-Goog-Api-Key": maps_api_key},
+            timeout=30.0,
+            sse_read_timeout=300.0,
+        )
+    )
+
+
+def get_bigquery_mcp_toolset():
+    credentials, project_id = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/bigquery"]
+    )
+    credentials.refresh(google.auth.transport.requests.Request())
+    oauth_token = credentials.token
+    return MCPToolset(
+        connection_params=StreamableHTTPConnectionParams(
+            url=BIGQUERY_MCP_URL,
+            headers={
+                "Authorization": f"Bearer {oauth_token}",
+                "x-goog-user-project": project_id,
+            },
+            timeout=30.0,
+            sse_read_timeout=300.0,
+        )
+    )

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -64,7 +64,9 @@ gcloud services enable \
   dataflow.googleapis.com \
   run.googleapis.com \
   telemetry.googleapis.com \
-  modelarmor.googleapis.com
+  modelarmor.googleapis.com \
+  apikeys.googleapis.com \
+  mapstools.googleapis.com
 
 
 # Setup Artifact Registry


### PR DESCRIPTION
Adds a new notebook and associated agent files to guide users on how to build AI Agents using the Agent Development Kit (ADK) and Model Context Protocol (MCP) servers.

**For testing,  please run `setup_env.sh` on Cloud Shell first, since the command has been updated.**