### PR TITLE
Update branding, documentation and console links in operationalize_gen_ai folder

### DIFF
--- a/asl_genai/notebooks/operationalize_gen_ai/labs/gen_ai_evaluation_service.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/labs/gen_ai_evaluation_service.ipynb
@@ -7,9 +7,9 @@
     "tags": []
    },
    "source": [
-    "# Vertex AI GenAI Evaluation Service\n",
+    "# Gen AI Evaluation Service\n",
     "\n",
-    "Vertex AI's Gen AI evaluation service empowers you to assess any generative AI model or application according to your specific requirements.\n",
+    "Agent Platform's Gen AI evaluation service empowers you to assess any generative AI model or application according to your specific requirements.\n",
     "\n",
     "Instead of relying solely on general leaderboards and reports, you can define your own evaluation criteria and directly compare how different models perform against your unique needs, use case and data.\n",
     "\n",
@@ -17,7 +17,7 @@
     "\n",
     "- Gain a deeper understanding of model performance. And, Go beyond general metrics and understand how a model handles your specific data and tasks.\n",
     "- Make informed decisions throughout the development lifecycle. By using evaluations to guide model selection, refine prompt engineering, and optimize model customization.\n",
-    "- Streamline your evaluation workflow by leveraging Vertex AI's integrated tools to easily launch and reuse evaluations as needed.\n",
+    "- Streamline your evaluation workflow by leveraging Agent Platform's integrated tools to easily launch and reuse evaluations as needed.\n",
     "\n",
     "Essentially, it puts you in control of evaluating generative AI, ensuring the models you choose are the best fit for your specific applications.\n",
     "\n",
@@ -25,7 +25,7 @@
     "\n",
     "In this notebook, you will learn:\n",
     "\n",
-    "- How to use Vertex AI Gen AI Evaluation Service \n",
+    "- How to use Gen AI Evaluation Service \n",
     "- Different types of evaluation techniques (Computation Based and Model Based)\n",
     "- How to prepare you dataset and get it ready for evaluation\n",
     "- Analyze and understand the results from evaluation\n",
@@ -131,13 +131,13 @@
    "source": [
     "## Evaluation Process\n",
     "\n",
-    "Vertex AI's Gen AI evaluation service lets you assess any generative model based on your specific needs and criteria.\n",
+    "Agent Platform's Gen AI evaluation service lets you assess any generative model based on your specific needs and criteria.\n",
     "\n",
     "These are the four steps you will follow to help you evaluate:\n",
     "\n",
     "1. Define: Tailor metrics to your business goals and choose your evaluation approach (Computation based vs Model Based).\n",
     "2. Prepare: Create a dataset that reflects your real-world use case.\n",
-    "3. Run: Easily launch evaluations using templates or existing examples. Define your models and create reusable `EvalTasks` within Vertex AI to use in other evaluations.\n",
+    "3. Run: Easily launch evaluations using templates or existing examples. Define your models and create reusable `EvalTasks` within Agent Platform to use in other evaluations.\n",
     "4. Analyze: Interpret your results and understand how each model performs against your specific criteria.\n",
     "\n",
     "Let's take a look at these steps one by one\n"
@@ -152,7 +152,7 @@
    "source": [
     "### Computation Based Metrics\n",
     "\n",
-    "[Computation based metrics](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval#computation-based-metrics) are computed using mathematical formulas to compare the model's output against a **ground truth or reference**. Commonly used computation-based metrics include ROUGE and BLEU. The commonly used metrics can be categorized into the following groups:\n",
+    "[Computation based metrics](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval#computation-based-metrics) are computed using mathematical formulas to compare the model's output against a **ground truth or reference**. Commonly used computation-based metrics include ROUGE and BLEU. The commonly used metrics can be categorized into the following groups:\n",
     "\n",
     "- Lexicon-based metrics: Use math to calculate the string similarities between LLM-generated results and ground truth, such as `Exact Match` and `ROUGE`.\n",
     "- Count-based metrics: Aggregate the number of rows that hit or miss certain ground-truth labels, such as `F1-score`, `Accuracy`, and `Tool Name Match`.\n",
@@ -217,7 +217,7 @@
    "id": "8425b0d3-7cae-43f3-b51b-011f32496840",
    "metadata": {},
    "source": [
-    "Next, we will define the different metrics we want to measure for this task. There are different metrics that are defined by Vertex AI based on the task. You can take a look at the [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval#computation-based-metrics) to see the different metrics. And, take a look at the [API documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.preview.evaluation.EvalTask#vertexai_preview_evaluation_EvalTask) to refer to the right string values for each."
+    "Next, we will define the different metrics we want to measure for this task. There are different metrics that are defined by Agent Platform based on the task. You can take a look at the [documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval#computation-based-metrics) to see the different metrics. And, take a look at the [API documentation](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.evaluation.EvalTask) to refer to the right string values for each."
    ]
   },
   {
@@ -280,11 +280,11 @@
     "tags": []
    },
    "source": [
-    "Now, that we have configured all the parameters, we are ready to start evaluating. We will use [EvalTask](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.preview.evaluation.EvalTask) to kick of a Vertex AI Experiment for our evaluation. \n",
+    "Now, that we have configured all the parameters, we are ready to start evaluating. We will use [EvalTask](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.evaluation.EvalTask) to kick of a Agent Platform Experiment for our evaluation. \n",
     "\n",
     "#### Understand the EvalTask class\n",
     "\n",
-    "The EvalTask class is a core component of the Gen AI Evaluation Service SDK framework. It allows you to define and run evaluation jobs against your Gen AI models/applications, providing a structured way to measure their performance on specific tasks. Think of an EvalTask as a blueprint for your evaluation process. Evaluation tasks must contain an evaluation dataset, and a list of metrics to evaluate. Supported metrics are documented on the Generative AI on Vertex AI [Define your evaluation metrics page](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval). The dataset can be an `pandas.DataFrame`, Python dictionary or a file path URI and can contain default column names such as `prompt`, `reference`, `response`, and `baseline_model_response`.  \n",
+    "The EvalTask class is a core component of the Gen AI Evaluation Service SDK framework. It allows you to define and run evaluation jobs against your Gen AI models/applications, providing a structured way to measure their performance on specific tasks. Think of an EvalTask as a blueprint for your evaluation process. Evaluation tasks must contain an evaluation dataset, and a list of metrics to evaluate. Supported metrics are documented on the Generative AI [Define your evaluation metrics page](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval). The dataset can be an `pandas.DataFrame`, Python dictionary or a file path URI and can contain default column names such as `prompt`, `reference`, `response`, and `baseline_model_response`.  \n",
     "\n",
     "- Bring-your-own-response (BYOR): You already have the data that you want to evaluate stored in the dataset. You can customize the response column names for both your model and the baseline model using parameters like response_column_name and baseline_model_response_column_name or through the metric_column_mapping.\n",
     "\n",
@@ -292,11 +292,11 @@
     "\n",
     "- Perform model inference with a prompt template: You have a dataset containing the input variables to the prompt template and want to assemble the prompts for model inference. Evaluation dataset must contain column names corresponding to the variable names in the prompt template. For example, if prompt template is \"Instruction: {instruction}, context: {context}\", the dataset must contain instruction and context columns.\n",
     "\n",
-    "EvalTask supports extensive evaluation scenarios including BYOR, model inference with Gemini models, 3P models endpoints/SDK clients, or custom model generation functions, using computation-based metrics, model-based pointwise and pairwise metrics. The evaluate() method triggers the evaluation process, optionally taking a model, prompt template, experiment logging configuartions, and other evaluation run configurations. You can view the SDK reference documentation for [Gen AI Evaluation](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.evaluation) package for more details.\n",
+    "EvalTask supports extensive evaluation scenarios including BYOR, model inference with Gemini models, 3P models endpoints/SDK clients, or custom model generation functions, using computation-based metrics, model-based pointwise and pairwise metrics. The evaluate() method triggers the evaluation process, optionally taking a model, prompt template, experiment logging configuartions, and other evaluation run configurations. You can view the SDK reference documentation for [Gen AI Evaluation](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.evaluation) package for more details.\n",
     "\n",
     "To start with, we'll be using model inference with prompt templates.\n",
     "\n",
-    "**Exercise** Define `EvalTask` with the parameters dataset, metrics and experiment. See the documentation for [EvalTask](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.preview.evaluation.EvalTask) "
+    "**Exercise** Define `EvalTask` with the parameters dataset, metrics and experiment. See the documentation for [EvalTask](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.evaluation.EvalTask) "
    ]
   },
   {
@@ -497,7 +497,7 @@
    "id": "5cf4de49-8165-45a7-a743-bc3696c9d0d1",
    "metadata": {},
    "source": [
-    "**Exercise:** For the above `context` list, generate the summary responses from Gemini using the `generate_content()` function. Refer to the [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#non-streaming) "
+    "**Exercise:** For the above `context` list, generate the summary responses from Gemini using the `generate_content()` function. Refer to the [documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/models/inference) "
    ]
   },
   {
@@ -673,7 +673,7 @@
    "id": "91ab6aa6-e791-44df-a92c-30b27be710dd",
    "metadata": {},
    "source": [
-    "Similar to how to defined the evaluation cretiria for pointwise evaluation above, you could customize your evaluation prompt. However, to save time, Vertex AI provides [predefined evaluation prompts](https://cloud.google.com/vertex-ai/generative-ai/docs/models/metrics-templates) in `MetricPromptTemplateExamples` you could use. In this use case, we are going to be evaluating the text quality between the two models. `pointwise_text_quality` will use the following criteria to evalute the model responses.\n",
+    "Similar to how to defined the evaluation cretiria for pointwise evaluation above, you could customize your evaluation prompt. However, to save time, Agent Platform provides [predefined evaluation prompts](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/metrics-templates) in `MetricPromptTemplateExamples` you could use. In this use case, we are going to be evaluating the text quality between the two models. `pointwise_text_quality` will use the following criteria to evalute the model responses.\n",
     "\n",
     "```\n",
     "STEP 1: Analyze Response A based on all the Criteria provided, including Coherence, Fluency, Instruction following, Groundedness, and Verbosity. Provide assessment according to each criterion.\n",
@@ -768,7 +768,7 @@
    "id": "74ef80d4-48a5-446d-ae61-bca2e03c1439",
    "metadata": {},
    "source": [
-    "All of the above evaluation experiments we ran in the notebook are accessible from the [Experiments Tab](https://console.cloud.google.com/vertex-ai/experiments/experiments) in the Vertex AI UI."
+    "All of the above evaluation experiments we ran in the notebook are accessible from the [Experiments Tab](https://console.cloud.google.com/agent-platform/experiments/experiments) in the Agent Platform UI."
    ]
   },
   {

--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/deployment_adk_agent.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/deployment_adk_agent.ipynb
@@ -5,7 +5,7 @@
    "id": "2fdb77ea71896541",
    "metadata": {},
    "source": [
-    "# Deploying ADK Agent on Vertex AI Agent Engine"
+    "# Deploying ADK Agent on Agent Runtime"
    ]
   },
   {
@@ -17,14 +17,14 @@
    "source": [
     "## Overview\n",
     "\n",
-    "This notebook guides you through deploying and managing a conversational AI agent to **Vertex AI Agent Engine**. \n",
+    "This notebook guides you through deploying and managing a conversational AI agent to **Agent Runtime**. \n",
     "\n",
     "## Learning Goals\n",
     "\n",
     "By the end of this notebook, you will understand how to:\n",
-    "* Set up required configuration and deploy ADK **Agents** to **Vertex AI Agent Engine**.\n",
+    "* Set up required configuration and deploy ADK **Agents** to **Agent Runtime**.\n",
     "* Use the ADK **RemoteAgent** ans **RemoteSession** to execute agent interactions.\n",
-    "* Use the Vertex AI SDK to Manage (list/update) and delete agents that you have deployed to Vertex AI Agent Engine."
+    "* Use the Agent Platform SDK to Manage (list/update) and delete agents that you have deployed to Agent Runtime."
    ]
   },
   {
@@ -35,10 +35,10 @@
     "## ADK Agent deployment Options\n",
     "Your ADK agent can be deployed to a range of different environments based on your needs for production readiness or custom flexibility:\n",
     "\n",
-    "#### Agent Engine in Vertex AI\n",
-    "Agent Engine is a fully managed auto-scaling service on Google Cloud specifically designed for deploying, managing, and scaling AI agents built with frameworks such as ADK.\n",
+    "#### Agent Runtime in Agent Platform\n",
+    "Agent Runtime is a fully managed auto-scaling service on Google Cloud specifically designed for deploying, managing, and scaling AI agents built with frameworks such as ADK.\n",
     "\n",
-    "[Learn more about deploying your agent to Vertex AI Agent Engine.](https://google.github.io/adk-docs/deploy/agent-engine/)\n",
+    "[Learn more about deploying your agent to Agent Runtime.](https://google.github.io/adk-docs/deploy/agent-engine/)\n",
     "\n",
     "#### Cloud Run\n",
     "Cloud Run is a managed auto-scaling compute platform on Google Cloud that enables you to run your agent as a container-based application.\n",
@@ -56,10 +56,10 @@
    "id": "7bddc598071d69c5",
    "metadata": {},
    "source": [
-    "### Agent Engine Overview\n",
-    "**Agent Engine** is a set of services that enables developers to deploy, manage, and scale AI Agents in production. It handles the infrastructure to scale agents in production so you can focus on creating applications. Agent Engine integrates closely with the Python SDK for the Gemini model in Vertex AI, and it can manage prompts, agents, and examples in a modular way. Also its compatible with ADK, LangChain, LlamaIndex, or other Python frameworks.\n",
+    "### Agent Runtime Overview\n",
+    "**Agent Runtime** is a set of services that enables developers to deploy, manage, and scale AI Agents in production. It handles the infrastructure to scale agents in production so you can focus on creating applications. Agent Runtime integrates closely with the Python SDK for the Gemini model in Agent Platform, and it can manage prompts, agents, and examples in a modular way. Also its compatible with ADK, LangChain, LlamaIndex, or other Python frameworks.\n",
     "\n",
-    "Here are the services that Agent Engine offers, which you can use individually or in combination:\n",
+    "Here are the services that Agent Runtime offers, which you can use individually or in combination:\n",
     "\n",
     "**Runtime:** Deploy and scale agents with a managed runtime and end-to-end management capabilities.\n",
     "\n",
@@ -67,9 +67,9 @@
     "\n",
     "**Example Store**: Store and dynamically retrieve few-shot examples to improve agent performance.\n",
     "\n",
-    "**Sessions**: Agent Engine Sessions lets you store individual interactions between users and agents, providing definitive sources for conversation context.\n",
+    "**Sessions**: Agent Runtime Sessions lets you store individual interactions between users and agents, providing definitive sources for conversation context.\n",
     "\n",
-    "**Memory Bank**: Agent Engine Memory Bank lets you store and retrieve information from sessions to personalize agent interactions."
+    "**Memory Bank**: Agent Runtime Memory Bank lets you store and retrieve information from sessions to personalize agent interactions."
    ]
   },
   {
@@ -116,7 +116,7 @@
    "source": [
     "LOCATION = \"us-central1\"\n",
     "os.environ[\"GOOGLE_CLOUD_LOCATION\"] = LOCATION\n",
-    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Vertex AI API"
+    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Agent Platform API"
    ]
   },
   {
@@ -233,9 +233,9 @@
     "tags": []
    },
    "source": [
-    "## Deploy to Vertex AI Agent Engine\n",
-    "Agent Engine is a fully managed Google Cloud service enabling developers to deploy, manage, and scale AI agents in production. \n",
-    "Agent Engine handles the infrastructure to scale agents in production so you can focus on creating intelligent and impactful applications."
+    "## Deploy to Agent Runtime\n",
+    "Agent Runtime is a fully managed Google Cloud service enabling developers to deploy, manage, and scale AI agents in production. \n",
+    "Agent Runtime handles the infrastructure to scale agents in production so you can focus on creating intelligent and impactful applications."
    ]
   },
   {
@@ -299,8 +299,8 @@
    "id": "62f3f71a-44db-4919-a668-8f78d0408ef9",
    "metadata": {},
    "source": [
-    "### Prepare your agent for Agent Engine¶\n",
-    "Use `reasoning_engines.AdkApp()` to wrap your agent to make it deployable to Agent Engine"
+    "### Prepare your agent for Agent Runtime¶\n",
+    "Use `reasoning_engines.AdkApp()` to wrap your agent to make it deployable to Agent Runtime"
    ]
   },
   {
@@ -325,9 +325,9 @@
     "tags": []
    },
    "source": [
-    "### Deploy your agent to Agent Engine\n",
+    "### Deploy your agent to Agent Runtime\n",
     "\n",
-    "Now you're ready to deploy your agent to Agent Engine in Vertex AI by calling `client.agent_engines.create()` along with:\n",
+    "Now you're ready to deploy your agent to Agent Runtime in Agent Platform by calling `client.agent_engines.create()` along with:\n",
     "\n",
     "1. The instance of your agent class\n",
     "2. The Python packages and versions that your agent requires at runtime, similar to how you would define packages and versions in a `requirements.txt` file.\n",
@@ -381,13 +381,13 @@
     "\n",
     "The bundle is uploaded to Cloud Storage (under the corresponding folder) for staging the artifacts.\n",
     "The Cloud Storage URIs for the respective artifacts are specified in the PackageSpec.\n",
-    "The Vertex AI Agent Engine service receives the request and builds containers and starts HTTP servers on the backend.\n",
+    "The Agent Runtime service receives the request and builds containers and starts HTTP servers on the backend.\n",
     "\n",
     "Deployment latency depends on the total time it takes to install required packages.\n",
-    "Once deployed, remote_agent corresponds to an instance of agent that is running on Vertex AI and can be queried or deleted.\n",
-    "You can check deployed agents using Cloud Console: Vertex AI -> Agent Engine\n",
+    "Once deployed, remote_agent corresponds to an instance of agent that is running on Agent Platform and can be queried or deleted.\n",
+    "You can check deployed agents using Cloud Console: Agent Platform -> Agent Runtime\n",
     "\n",
-    "[Agent Engine Console](https://console.cloud.google.com/vertex-ai/agents/agent-engines)"
+    "[Agent Runtime Console](https://console.cloud.google.com/agent-platform/runtimes)"
    ]
   },
   {
@@ -397,7 +397,7 @@
     "tags": []
    },
    "source": [
-    "### Try ADK agent on Agent Engine\n",
+    "### Try ADK agent on Agent Runtime\n",
     "#### Create session (remote)\n",
     "Just like you wouldn't start every text message from scratch, agents need context regarding the ongoing interaction.\n",
     "Session is the ADK object designed specifically to track and manage these individual conversation threads.\n",
@@ -523,7 +523,7 @@
    "source": [
     "#### Inspect traces for an agent\n",
     "A trace is a timeline of requests as your agent responds to each query.\n",
-    "Go to [Agent Engine Console](https://console.cloud.google.com/vertex-ai/agents/agent-engines) -> select the deployed agent -> Trace.\n",
+    "Go to [Agent Runtime Console](https://console.cloud.google.com/agent-platform/runtimes) -> select the deployed agent -> Trace.\n",
     "\n",
     "You can witch between the Graph and Timeline view on the top right. In the timeline view, a trace is composed of individual spans, which represent a single unit of work, like a function call or an interaction with an LLM, with the first span representing the overall request. Each span provides details about a specific operation, such as the operation's name, start and end times, and any relevant attributes, within the request."
    ]
@@ -536,7 +536,7 @@
    },
    "source": [
     "#### List sessions (remote)\n",
-    "Vertex AI Agent Engine Sessions maintains the history of interactions between a user and agents.\n",
+    "Agent Platform Sessions maintains the history of interactions between a user and agents.\n",
     "Sessions provide definitive sources for long-term memory and conversation context.\n",
     "In case of resuming existing conversations, you can get all existing sessions for a user:"
    ]
@@ -559,7 +559,7 @@
    "metadata": {},
    "source": [
     "You can inspect existing sessions using Google Cloud console.\n",
-    "Go to Vertex AI in the Google Cloud console, and then navigate to the Agent Engine, open \"Sessions\" Tab for specific agent."
+    "Go to Agent Platform in the Google Cloud console, and then navigate to the Agent Runtime, open \"Sessions\" Tab for specific agent."
    ]
   },
   {
@@ -572,7 +572,7 @@
     "#### Get a specific session (remote)\n",
     "Retrieving a specific Session (using its ID) so the agent can continue where it left off.\n",
     "**To get a specific session, you need both the user ID and the session ID:**\n",
-    "While using your agent locally, session ID is stored in session.id, when using your agent remotely on Agent Engine, session ID is stored in remote_session[\"id\"]."
+    "While using your agent locally, session ID is stored in session.id, when using your agent remotely on Agent Runtime, session ID is stored in remote_session[\"id\"]."
    ]
   },
   {
@@ -595,7 +595,7 @@
    "metadata": {},
    "source": [
     "### Manage deployed agents\n",
-    "Deployed agents are resources of type reasoningEngine in Vertex AI."
+    "Deployed agents are resources of type reasoningEngine in Agent Platform."
    ]
   },
   {
@@ -887,7 +887,7 @@
     "## Use Long Term Memory\n",
     "We've seen how Session tracks the history (events) for a single, ongoing conversation. But what if an agent needs to recall information from past conversations in a different session? This is where the concept of Long-Term Knowledge and the MemoryService come into play.\n",
     "\n",
-    "Agent Engine has a build-in long-term memory service, which is already enabled. But in order to attach that capability, we need to add a few tools or callbacks to generate and retrieve memory.\n",
+    "Agent Runtime has a build-in long-term memory service, which is already enabled. But in order to attach that capability, we need to add a few tools or callbacks to generate and retrieve memory.\n",
     "\n",
     "Let's continue to use the weather forecast agent, and attach the memory capability to it."
    ]
@@ -1101,7 +1101,7 @@
    "id": "1fdbe0a9-49c3-407c-a7c1-929a290c5cd7",
    "metadata": {},
    "source": [
-    "Go to the [Agent Engine Console](https://console.cloud.google.com/vertex-ai/agents/agent-engines) -> Select the agent -> Memories to see if the information is stored as a long term memory.\n",
+    "Go to the [Agent Runtime Console](https://console.cloud.google.com/agent-platform/runtimes) -> Select the agent -> Memories to see if the information is stored as a long term memory.\n",
     "\n",
     "If you can find, now let's check if agent can retrieve it **in a different session!**"
    ]
@@ -1146,7 +1146,7 @@
    "source": [
     "### Clean up\n",
     "After you have finished, it is a good practice to clean up your cloud resources. \n",
-    "You can delete the deployed Agent Engine instance by using the next code:"
+    "You can delete the deployed Agent Runtime instance by using the next code:"
    ]
   },
   {

--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/evaluation_adk_agent_with_vertex_ai.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/evaluation_adk_agent_with_vertex_ai.ipynb
@@ -5,15 +5,15 @@
    "id": "5646d634-70b1-4a6b-b53a-8702bcd57894",
    "metadata": {},
    "source": [
-    "# Evaluate your AI Agent using Vertex AI Gen AI Evaluation service\n",
+    "# Evaluate your AI Agent using Gen AI Evaluation service\n",
     "## Overview\n",
     "\n",
-    "This notebook guides you on how to evaluate an ADK (Agent Development Kit) agent using Vertex AI Gen AI Evaluation for agent evaluation.\n",
+    "This notebook guides you on how to evaluate an ADK (Agent Development Kit) agent using Gen AI Evaluation for agent evaluation.\n",
     "\n",
     "## Learning Goals\n",
     "\n",
     "By the end of this notebook, you will understand how to:\n",
-    "* Setup local ADK agent for evaluation with Vertex AI Gen AI Evaluation service\n",
+    "* Setup local ADK agent for evaluation with Gen AI Evaluation service\n",
     "* Prepare Agent Evaluation dataset\n",
     "* Set up and use single-tool usage evaluation\n",
     "* Use the Trajectory evaluation\n",
@@ -22,13 +22,13 @@
     "\n",
     "## Overview\n",
     "\n",
-    "### Vertex Generative AI Evaluation Service\n",
-    "The Vertex Gen AI evaluation service provides enterprise-grade tools for objective, data-driven assessment of generative AI models and AI Agents. \n",
+    "### Gen AI Evaluation Service\n",
+    "The Gen AI evaluation service provides enterprise-grade tools for objective, data-driven assessment of generative AI models and AI Agents. \n",
     "It supports and informs a number of development tasks like model migrations, prompt editing, fine-tuning and AI agent evaluation.\n",
-    "While ADK provides its own built-in evaluation module, this notebook demonstrates how to use the Vertex AI Generative AI Evaluation Service to assess the performance of an ADK-based agent.\n",
+    "While ADK provides its own built-in evaluation module, this notebook demonstrates how to use the Agent Platform Generative AI Evaluation Service to assess the performance of an ADK-based agent.\n",
     "This approach offers a broader, explainable, and quality-controlled toolkit to evaluate generative models or applications using custom metrics and human-aligned benchmarks.\n",
     "\n",
-    "For more information, see the [Vertex AI Gen AI Evaluation service](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview) documentation."
+    "For more information, see the [Gen AI Evaluation service](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/evaluation-overview) documentation."
    ]
   },
   {
@@ -82,7 +82,18 @@
    "source": [
     "LOCATION = \"us-central1\"\n",
     "os.environ[\"GOOGLE_CLOUD_LOCATION\"] = LOCATION\n",
-    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Vertex AI API"
+    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"  # Use Agent Platform API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fca0a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir -p adk_agents\n",
+    "!mkdir -p adk_agents/agent1_weather_lookup"
    ]
   },
   {
@@ -529,7 +540,7 @@
    "id": "28a45e38-154a-44f2-a16c-cf5db21c8d7b",
    "metadata": {},
    "source": [
-    "## Evaluating a ADK agent with Vertex AI Gen AI Evaluation\n",
+    "## Evaluating a ADK agent with Gen AI Evaluation\n",
     "\n",
     "When working with AI agents, it's important to keep track of their performance and how well they're working. You can look at this in two main ways: **monitoring** and **observability**.\n",
     "\n",
@@ -547,7 +558,7 @@
     "\n",
     "* **Failure Rate**: How often does the agent fail to produce a response?\n",
     "\n",
-    "Vertex AI Gen AI Evaluation service helps you to assess all of these aspects both while you are prototyping the agent or after you deploy it in production. It provides [pre-built evaluation criteria and metrics](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval) so you can see exactly how your agents are doing and identify areas for improvement."
+    "Gen AI Evaluation service helps you to assess all of these aspects both while you are prototyping the agent or after you deploy it in production. It provides [pre-built evaluation criteria and metrics](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval) so you can see exactly how your agents are doing and identify areas for improvement."
    ]
   },
   {
@@ -557,7 +568,7 @@
    "source": [
     "### Prepare Agent Evaluation dataset\n",
     "\n",
-    "To evaluate your AI agent using the Vertex AI Gen AI Evaluation service, you need a specific dataset depending on what aspects you want to evaluate of your agent.  \n",
+    "To evaluate your AI agent using the Gen AI Evaluation service, you need a specific dataset depending on what aspects you want to evaluate of your agent.  \n",
     "\n",
     "This dataset should include the prompts given to the agent. It can also contain the ideal or expected response (ground truth) and the intended sequence of tool calls the agent should take (reference trajectory) representing the sequence of tools you expect agent calls for each given prompt.\n",
     "\n",
@@ -690,7 +701,7 @@
    "source": [
     "#### Set single tool usage metrics\n",
     "\n",
-    "The `trajectory_single_tool_use` metric in Vertex AI Gen AI Evaluation gives you a quick way to evaluate whether your agent is using the tool you expect it to use, regardless of any specific tool order. It's a basic but useful way to start evaluating if the right tool was used at some point during the agent's process.\n",
+    "The `trajectory_single_tool_use` metric in Gen AI Evaluation gives you a quick way to evaluate whether your agent is using the tool you expect it to use, regardless of any specific tool order. It's a basic but useful way to start evaluating if the right tool was used at some point during the agent's process.\n",
     "\n",
     "To use the `trajectory_single_tool_use` metric, you need to set what tool should have been used for a particular user's request. For example, if a user asks to \"send an email\", you might expect the agent to use an \"send_email\" tool, and you'd specify that tool's name when using this metric."
    ]
@@ -892,7 +903,7 @@
    "source": [
     "#### Set trajectory metrics\n",
     "\n",
-    "To evaluate agent's trajectory, Vertex AI Gen AI Evaluation provides several ground-truth based metrics:\n",
+    "To evaluate agent's trajectory, Gen AI Evaluation provides several ground-truth based metrics:\n",
     "\n",
     "* `trajectory_exact_match`: identical trajectories (same actions, same order)\n",
     "\n",
@@ -1015,7 +1026,7 @@
    "source": [
     "### Evaluate final response\n",
     "\n",
-    "Similar to model evaluation, you can evaluate the final response of the agent using Vertex AI Gen AI Evaluation."
+    "Similar to model evaluation, you can evaluate the final response of the agent using Gen AI Evaluation."
    ]
   },
   {
@@ -1025,9 +1036,9 @@
    "source": [
     "#### Set response metrics\n",
     "\n",
-    "After agent inference, Vertex AI Gen AI Evaluation provides several metrics to evaluate generated responses. You can use computation-based metrics to compare the response to a reference (if needed) and using existing or custom model-based metrics to determine the quality of the final response.\n",
+    "After agent inference, Gen AI Evaluation provides several metrics to evaluate generated responses. You can use computation-based metrics to compare the response to a reference (if needed) and using existing or custom model-based metrics to determine the quality of the final response.\n",
     "\n",
-    "Check out the [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval) to learn more.\n"
+    "Check out the [documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval) to learn more.\n"
    ]
   },
   {
@@ -1123,7 +1134,7 @@
    "source": [
     "#### Define a custom metric\n",
     "\n",
-    "According to the [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval#model-based-metrics), you can define a prompt template for evaluating whether an AI agent's response follows logically from its actions by setting up criteria and a rating system for this evaluation.\n",
+    "According to the [documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval#model-based-metrics), you can define a prompt template for evaluating whether an AI agent's response follows logically from its actions by setting up criteria and a rating system for this evaluation.\n",
     "\n",
     "Define a `criteria` to set the evaluation guidelines and a `pointwise_rating_rubric` to provide a scoring system (1 or 0). Then use a `PointwiseMetricPromptTemplate` to create the template using these components.\n"
    ]
@@ -1310,9 +1321,9 @@
     "tags": []
    },
    "source": [
-    "## Bonus: Bring-Your-Own-Dataset (BYOD) and evaluate a ADK agent using Vertex AI Gen AI Evaluation\n",
+    "## Bonus: Bring-Your-Own-Dataset (BYOD) and evaluate a ADK agent using Gen AI Evaluation\n",
     "\n",
-    "In Bring Your Own Dataset (BYOD) [scenarios](https://cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-dataset), you provide both the predicted trajectory and the generated response from the agent.\n"
+    "In Bring Your Own Dataset (BYOD) [scenarios](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/evaluation-dataset), you provide both the predicted trajectory and the generated response from the agent.\n"
    ]
   },
   {

--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/gen_ai_evaluation_service.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/gen_ai_evaluation_service.ipynb
@@ -7,9 +7,9 @@
     "tags": []
    },
    "source": [
-    "# Vertex AI GenAI Evaluation Service\n",
+    "# Gen AI Evaluation Service\n",
     "\n",
-    "Vertex AI's Gen AI evaluation service empowers you to assess any generative AI model or application according to your specific requirements.\n",
+    "Agent Platform's Gen AI evaluation service empowers you to assess any generative AI model or application according to your specific requirements.\n",
     "\n",
     "Instead of relying solely on general leaderboards and reports, you can define your own evaluation criteria and directly compare how different models perform against your unique needs, use case and data.\n",
     "\n",
@@ -17,7 +17,7 @@
     "\n",
     "- Gain a deeper understanding of model performance. And, Go beyond general metrics and understand how a model handles your specific data and tasks.\n",
     "- Make informed decisions throughout the development lifecycle. By using evaluations to guide model selection, refine prompt engineering, and optimize model customization.\n",
-    "- Streamline your evaluation workflow by leveraging Vertex AI's integrated tools to easily launch and reuse evaluations as needed.\n",
+    "- Streamline your evaluation workflow by leveraging Agent Platform's integrated tools to easily launch and reuse evaluations as needed.\n",
     "\n",
     "Essentially, it puts you in control of evaluating generative AI, ensuring the models you choose are the best fit for your specific applications.\n",
     "\n",
@@ -25,7 +25,7 @@
     "\n",
     "In this notebook, you will learn:\n",
     "\n",
-    "- How to use Vertex AI Gen AI Evaluation Service \n",
+    "- How to use Gen AI Evaluation Service \n",
     "- Different types of evaluation techniques (Computation Based and Model Based)\n",
     "- How to prepare you dataset and get it ready for evaluation\n",
     "- Analyze and understand the results from evaluation\n",
@@ -131,13 +131,13 @@
    "source": [
     "## Evaluation Process\n",
     "\n",
-    "Vertex AI's Gen AI evaluation service lets you assess any generative model based on your specific needs and criteria.\n",
+    "Agent Platform's Gen AI evaluation service lets you assess any generative model based on your specific needs and criteria.\n",
     "\n",
     "These are the four steps you will follow to help you evaluate:\n",
     "\n",
     "1. Define: Tailor metrics to your business goals and choose your evaluation approach (Computation based vs Model Based).\n",
     "2. Prepare: Create a dataset that reflects your real-world use case.\n",
-    "3. Run: Easily launch evaluations using templates or existing examples. Define your models and create reusable `EvalTasks` within Vertex AI to use in other evaluations.\n",
+    "3. Run: Easily launch evaluations using templates or existing examples. Define your models and create reusable `EvalTasks` within Agent Platform to use in other evaluations.\n",
     "4. Analyze: Interpret your results and understand how each model performs against your specific criteria.\n",
     "\n",
     "Let's take a look at these steps one by one\n"
@@ -152,7 +152,7 @@
    "source": [
     "### Computation Based Metrics\n",
     "\n",
-    "[Computation based metrics](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval#computation-based-metrics) are computed using mathematical formulas to compare the model's output against a **ground truth or reference**. Commonly used computation-based metrics include ROUGE and BLEU. The commonly used metrics can be categorized into the following groups:\n",
+    "[Computation based metrics](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval#computation-based-metrics) are computed using mathematical formulas to compare the model's output against a **ground truth or reference**. Commonly used computation-based metrics include ROUGE and BLEU. The commonly used metrics can be categorized into the following groups:\n",
     "\n",
     "- Lexicon-based metrics: Use math to calculate the string similarities between LLM-generated results and ground truth, such as `Exact Match` and `ROUGE`.\n",
     "- Count-based metrics: Aggregate the number of rows that hit or miss certain ground-truth labels, such as `F1-score`, `Accuracy`, and `Tool Name Match`.\n",
@@ -221,7 +221,7 @@
    "id": "8425b0d3-7cae-43f3-b51b-011f32496840",
    "metadata": {},
    "source": [
-    "Next, we will define the different metrics we want to measure for this task. There are different metrics that are defined by Vertex AI based on the task. You can take a look at the [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval#computation-based-metrics) to see the different metrics. And, take a look at the [API documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.preview.evaluation.EvalTask#vertexai_preview_evaluation_EvalTask) to refer to the right string values for each."
+    "Next, we will define the different metrics we want to measure for this task. There are different metrics that are defined by Agent Platform based on the task. You can take a look at the [documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval#computation-based-metrics) to see the different metrics. And, take a look at the [API documentation](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.evaluation.EvalTask) to refer to the right string values for each."
    ]
   },
   {
@@ -284,11 +284,11 @@
     "tags": []
    },
    "source": [
-    "Now, that we have configured all the parameters, we are ready to start evaluating. We will use [EvalTask](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.preview.evaluation.EvalTask) to kick of a Vertex AI Experiment for our evaluation. \n",
+    "Now, that we have configured all the parameters, we are ready to start evaluating. We will use [EvalTask](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.evaluation.EvalTask) to kick of a Agent Platform Experiment for our evaluation. \n",
     "\n",
     "#### Understand the EvalTask class\n",
     "\n",
-    "The EvalTask class is a core component of the Gen AI Evaluation Service SDK framework. It allows you to define and run evaluation jobs against your Gen AI models/applications, providing a structured way to measure their performance on specific tasks. Think of an EvalTask as a blueprint for your evaluation process. Evaluation tasks must contain an evaluation dataset, and a list of metrics to evaluate. Supported metrics are documented on the Generative AI on Vertex AI [Define your evaluation metrics page](https://cloud.google.com/vertex-ai/generative-ai/docs/models/determine-eval). The dataset can be an `pandas.DataFrame`, Python dictionary or a file path URI and can contain default column names such as `prompt`, `reference`, `response`, and `baseline_model_response`.  \n",
+    "The EvalTask class is a core component of the Gen AI Evaluation Service SDK framework. It allows you to define and run evaluation jobs against your Gen AI models/applications, providing a structured way to measure their performance on specific tasks. Think of an EvalTask as a blueprint for your evaluation process. Evaluation tasks must contain an evaluation dataset, and a list of metrics to evaluate. Supported metrics are documented on the Generative AI [Define your evaluation metrics page](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/determine-eval). The dataset can be an `pandas.DataFrame`, Python dictionary or a file path URI and can contain default column names such as `prompt`, `reference`, `response`, and `baseline_model_response`.  \n",
     "\n",
     "- Bring-your-own-response (BYOR): You already have the data that you want to evaluate stored in the dataset. You can customize the response column names for both your model and the baseline model using parameters like response_column_name and baseline_model_response_column_name or through the metric_column_mapping.\n",
     "\n",
@@ -296,7 +296,7 @@
     "\n",
     "- Perform model inference with a prompt template: You have a dataset containing the input variables to the prompt template and want to assemble the prompts for model inference. Evaluation dataset must contain column names corresponding to the variable names in the prompt template. For example, if prompt template is \"Instruction: {instruction}, context: {context}\", the dataset must contain instruction and context columns.\n",
     "\n",
-    "EvalTask supports extensive evaluation scenarios including BYOR, model inference with Gemini models, 3P models endpoints/SDK clients, or custom model generation functions, using computation-based metrics, model-based pointwise and pairwise metrics. The evaluate() method triggers the evaluation process, optionally taking a model, prompt template, experiment logging configuartions, and other evaluation run configurations. You can view the SDK reference documentation for [Gen AI Evaluation](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.evaluation) package for more details.\n",
+    "EvalTask supports extensive evaluation scenarios including BYOR, model inference with Gemini models, 3P models endpoints/SDK clients, or custom model generation functions, using computation-based metrics, model-based pointwise and pairwise metrics. The evaluate() method triggers the evaluation process, optionally taking a model, prompt template, experiment logging configuartions, and other evaluation run configurations. You can view the SDK reference documentation for [Gen AI Evaluation](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.evaluation) package for more details.\n",
     "\n",
     "To start with, we'll be using model inference with prompt templates."
    ]
@@ -667,7 +667,7 @@
    "id": "91ab6aa6-e791-44df-a92c-30b27be710dd",
    "metadata": {},
    "source": [
-    "Similar to how to defined the evaluation cretiria for pointwise evaluation above, you could customize your evaluation prompt. However, to save time, Vertex AI provides [predefined evaluation prompts](https://cloud.google.com/vertex-ai/generative-ai/docs/models/metrics-templates) in `MetricPromptTemplateExamples` you could use. In this use case, we are going to be evaluating the text quality between the two models. `pointwise_text_quality` will use the following criteria to evalute the model responses.\n",
+    "Similar to how to defined the evaluation cretiria for pointwise evaluation above, you could customize your evaluation prompt. However, to save time, Agent Platform provides [predefined evaluation prompts](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/metrics-templates) in `MetricPromptTemplateExamples` you could use. In this use case, we are going to be evaluating the text quality between the two models. `pointwise_text_quality` will use the following criteria to evalute the model responses.\n",
     "\n",
     "```\n",
     "STEP 1: Analyze Response A based on all the Criteria provided, including Coherence, Fluency, Instruction following, Groundedness, and Verbosity. Provide assessment according to each criterion.\n",
@@ -762,7 +762,7 @@
    "id": "74ef80d4-48a5-446d-ae61-bca2e03c1439",
    "metadata": {},
    "source": [
-    "All of the above evaluation experiments we ran in the notebook are accessible from the [Experiments Tab](https://console.cloud.google.com/vertex-ai/experiments/experiments) in the Vertex AI UI."
+    "All of the above evaluation experiments we ran in the notebook are accessible from the [Experiments Tab](https://console.cloud.google.com/agent-platform/experiments/experiments) in the Agent Platform UI."
    ]
   },
   {

--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/prompt_management_and_context_caching.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/prompt_management_and_context_caching.ipynb
@@ -17,14 +17,14 @@
    "source": [
     "## Learning Objectives\n",
     "\n",
-    "1.  Learn how to use Vertex AI SDK to manage the lifecycle of prompt templates.\n",
+    "1.  Learn how to use Agent Platform SDK to manage the lifecycle of prompt templates.\n",
     "2.  Learn how to define, save, load and manage the prompts directly within Python code.\n",
     "3.  Understand the concept of context caching and its benefits when working with large language models.\n",
-    "4.  Learn how to use the Vertex AI SDK to create and utilize cached content with Gemini models.\n",
+    "4.  Learn how to use the Agent Platform SDK to create and utilize cached content with Gemini models.\n",
     "5.  Compare the performance of using cached content versus generating content from scratch, highlighting the speed and cost advantages.\n",
     "\n",
     "## Overview\n",
-    "This notebook explores two key aspects of working with generative AI on Google Cloud. The first part focuses on Vertex AI's prompt management capabilities, explaining how to programmatically create, version, and organize prompt templates using the Vertex AI SDK. The second part introduces the Gemini API's context caching feature, designed to optimize requests with large, consistent initial contexts. "
+    "This notebook explores two key aspects of working with generative AI on Google Cloud. The first part focuses on Agent Platform's prompt management capabilities, explaining how to programmatically create, version, and organize prompt templates using the Agent Platform SDK. The second part introduces the Gemini API's context caching feature, designed to optimize requests with large, consistent initial contexts. "
    ]
   },
   {
@@ -76,7 +76,7 @@
    "source": [
     "## Prompt Management\n",
     "\n",
-    "Vertex AI offers prompt management through its user interface, Vertex AI Studio, and programmatically via the Vertex AI SDK. This section focuses on the latter method, demonstrating how to leverage the `vertexai.preview.prompts` module to define, save, and manage prompts specifically for Gemini text generation."
+    "Agent Platform offers prompt management through its user interface, Agent Studio, and programmatically via the Agent Platform SDK. This section focuses on the latter method, demonstrating how to leverage the `vertexai.preview.prompts` module to define, save, and manage prompts specifically for Gemini text generation."
    ]
   },
   {
@@ -86,9 +86,9 @@
    "source": [
     "### The Prompt class\n",
     "\n",
-    "To effectively manage prompts, we will use the [Prompt class](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.preview.prompts#prompt). This class represent a prompt object, encapsulates the prompt data, variables, generation configuration, and other relevant information.\n",
+    "To effectively manage prompts, we will use the [Prompt class](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai._genai.prompts). This class represent a prompt object, encapsulates the prompt data, variables, generation configuration, and other relevant information.\n",
     "\n",
-    "Consider managing a social media page that features two-sentence stories with two main characters. The [Prompt class](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest/vertexai.preview.prompts#prompt) can define a reusable prompt template, enabling the generation of multiple stories with varied character pairings from a single structure. \n",
+    "Consider managing a social media page that features two-sentence stories with two main characters. The [Prompt class](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai._genai.prompts) can define a reusable prompt template, enabling the generation of multiple stories with varied character pairings from a single structure. \n",
     "\n",
     "Let's construct the prompt object.\n"
    ]
@@ -188,7 +188,7 @@
     "tags": []
    },
    "source": [
-    "You can go to Google Cloud Console to check your newly created prompt in [Prompt Management](https://console.cloud.google.com/vertex-ai/studio/saved-prompts). You can also retrieve a saved prompt from the online resource using the `vertexai.preview.prompts.get()` method. Simply provide the prompt's unique ID to this function, and it will return the associated Prompt object, as demonstrated in the following code snippet. "
+    "You can go to Google Cloud Console to check your newly created prompt in [Prompt Management](https://console.cloud.google.com/agent-platform/studio/saved-prompts). You can also retrieve a saved prompt from the online resource using the `vertexai.preview.prompts.get()` method. Simply provide the prompt's unique ID to this function, and it will return the associated Prompt object, as demonstrated in the following code snippet. "
    ]
   },
   {
@@ -360,7 +360,7 @@
    "source": [
     "## Context caching\n",
     "\n",
-    "The second section of this notebook demonstrates how to use context caching with Gemini models in Vertex AI. \n",
+    "The second section of this notebook demonstrates how to use context caching with Gemini models in Agent Platform. \n",
     "\n",
     "Context caching allows you to store the processed content, such as research papers, long videos or audios along with system instructions, so you don't have to re-process it every time. <br>\n",
     "When you query the model, it can leverage the stored context, leading to faster response times and reduced resource consumption. This is particularly useful when working with large documents or when using the same context across multiple queries."


### PR DESCRIPTION
This PR updates the notebooks in the `operationalize_gen_ai` folder to reflect the branding change from Vertex AI to Agent Platform, and updates console and documentation URLs to point to the new paths.

Some reference to `vertex` are remaining in SDK URLs, since they are not updated yet.