### PR TITLE
Remove an unusued cell in RNN encoder decoder labs

### DIFF
--- a/asl_core/notebooks/text_models/labs/rnn_encoder_decoder.ipynb
+++ b/asl_core/notebooks/text_models/labs/rnn_encoder_decoder.ipynb
@@ -365,23 +365,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def load_and_integerize(path, num_examples=None):\n",
-    "\n",
-    "    targ_lang, inp_lang = load_and_preprocess(path, num_examples)\n",
-    "\n",
-    "    # TODO 1b\n",
-    "    input_tensor, inp_lang_tokenizer = # TODO\n",
-    "    target_tensor, targ_lang_tokenizer = # TODO\n",
-    "\n",
-    "    return input_tensor, target_tensor, inp_lang_tokenizer, targ_lang_tokenizer"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "tags": []


### PR DESCRIPTION
Remove an unusued cell remaining in the lab version of the RNN encoder decoder notebook.