### PR TITLE
Rebrand Vertex AI to Agent Platform in building production ML systems

### DIFF
--- a/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
@@ -4,20 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Training at scale with the Vertex AI Training Service\n",
+    "# Training at scale with the Agent Platform Training Service\n",
     "**Learning Objectives:**\n",
     "  1. Learn how to organize your training code into a Python package\n",
-    "  1. Train your model using cloud infrastructure via Google Cloud Vertex AI Training Service\n",
+    "  1. Train your model using cloud infrastructure via Google Cloud Agent Platform Training Service\n",
     "  1. Learn how to run your training package using Docker containers and push training Docker images on a Docker registry\n",
     "  1. Monitor Cloud job using TensorBoard\n",
     "\n",
     "## Introduction\n",
     "\n",
-    "In this notebook we'll make the jump from training locally, to training in the cloud. We'll take advantage of Google Cloud's [Vertex AI Training Service](https://cloud.google.com/vertex-ai/). \n",
+    "In this notebook we'll make the jump from training locally, to training in the cloud. We'll take advantage of Google Cloud's [Agent Platform Training Service](https://cloud.google.com/products/gemini-enterprise-agent-platform). \n",
     "\n",
-    "Vertex AI Training Service is a managed service that allows the training and deployment of ML models without having to provision or maintain servers. The infrastructure is handled seamlessly by the managed service for us.\n",
+    "Agent Platform Training Service is a managed service that allows the training and deployment of ML models without having to provision or maintain servers. The infrastructure is handled seamlessly by the managed service for us.\n",
     "\n",
-    "Each learning objective will correspond to a __#TODO__ in the [student lab notebook](../labs/1_training_at_scale_vertex.ipynb) -- try to complete that notebook first before reviewing this solution notebook."
+    "Each learning objective will correspond to a __#TODO__ in the [student lab notebook](../labs/1_training_at_scale.ipynb) -- try to complete that notebook first before reviewing this solution notebook."
    ]
   },
   {
@@ -321,12 +321,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make code compatible with Vertex AI Training Service\n",
-    "In order to make our code compatible with Vertex AI Training Service we need to make the following changes:\n",
+    "## Make code compatible with Agent Platform Training Service\n",
+    "In order to make our code compatible with Agent Platform Training Service we need to make the following changes:\n",
     "\n",
     "1. Upload data to Google Cloud Storage \n",
     "2. Move code into a trainer Python package\n",
-    "4. Submit training job with `gcloud` to train on Vertex AI"
+    "4. Submit training job with `gcloud` to train on Agent Platform"
    ]
   },
   {
@@ -732,14 +732,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run your training package on Vertex AI\n",
+    "## Run your training package on Agent Platform\n",
     "\n",
     "\n",
-    "Once the code works in standalone mode locally, you can run it on the Cloud using Vertex AI.\n",
+    "Once the code works in standalone mode locally, you can run it on the Cloud using Agent Platform.\n",
     "\n",
-    "In Vertex AI, ou can provide training code to Vertex AI in one of the following forms:\n",
+    "In Agent Platform, you can provide training code to Agent Platform in one of the following forms:\n",
     "\n",
-    "- **A Python training application to use with a prebuilt container**. Create a [Python source distribution](https://packaging.python.org/en/latest/overview/#python-source-distributions) with code that trains an ML model and exports it to Cloud Storage. This training application can use any of the dependencies included in the prebuilt container that you plan to use it with. Use this option if one of the Vertex AI prebuilt containers for training includes all the dependencies that you need for training.\n",
+    "- **A Python training application to use with a prebuilt container**. Create a [Python source distribution](https://packaging.python.org/en/latest/overview/#python-source-distributions) with code that trains an ML model and exports it to Cloud Storage. This training application can use any of the dependencies included in the prebuilt container that you plan to use it with. Use this option if one of the Agent Platform prebuilt containers for training includes all the dependencies that you need for training.\n",
     "\n",
     "- **A custom container image**. Create a Docker container image with code that trains an ML model and exports it to Cloud Storage. Include any dependencies required by your code in the container image.\n",
     "\n",
@@ -822,19 +822,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To submit this source distribution to the Cloud we use [CustomJob](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform.CustomJob#google_cloud_aiplatform_CustomJob_get) module under Vertex AI Python SDK, and specify some parameters for Vertex AI Training service under [worker_pool_spec](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.WorkerPoolSpec), which includes:\n",
+    "To submit this source distribution to the Cloud we use [CustomJob](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform.CustomJob#google_cloud_aiplatform_CustomJob_get) module under Agent Platform Python SDK, and specify some parameters for Agent Platform Training service under [worker_pool_spec](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.WorkerPoolSpec), which includes:\n",
     "- [`machine_spec`](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.MachineSpec): Specification of a single machine where we run training. Here we can speficy `machine_type`, as well as the [accelerator specifications](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.AcceleratorType).\n",
     "- `python_package_spec`: Here we provide specification about our Python package runtime, including the prebuilt container URL (`executor_image_uri`), our Python package path (`package_uris`), as well as the custom arguments (`args`) we pass to our training application can be defined and provided here.\n",
     "\n",
-    "Because this is on the entire dataset, it will take a while. You can monitor the job from the GCP console in the Vertex AI Training section."
+    "Because this is on the entire dataset, it will take a while. You can monitor the job from the GCP console in the Agent Platform Training section."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Lab Task #2**: Train your model using cloud infrastructure via Google Cloud Vertex AI Training Service\n",
-    "Fill in the TODOs in the code below to submit your job for training on Vertex AI. "
+    "**Lab Task #2**: Train your model using cloud infrastructure via Google Cloud Agent Platform Training Service\n",
+    "Fill in the TODOs in the code below to submit your job for training on Agent Platform. "
    ]
   },
   {
@@ -962,7 +962,7 @@
     "#### Open TensorBoard\n",
     "Since we specified the `TensorBoard` callback in `model.fit`, the training application saved the intermediate logs for TensorBoard dashboard.\n",
     "\n",
-    "While we can [host TensorBoard in Vertex AI Experiments](https://cloud.google.com/vertex-ai/docs/experiments/tensorboard-introduction), here, let's simply open from this notebook.\n",
+    "While we can [host TensorBoard in Agent Platform Experiments](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/experiments/tensorboard-introduction), here, let's simply open from this notebook.\n",
     "\n",
     "You might not see any data for a bit until the job begins. Check the job status on the console, and then return here to click the refresh button in the top right to update TensorBoard."
    ]
@@ -982,7 +982,7 @@
    "source": [
     "### Method 2: Using a custom container\n",
     "\n",
-    "Vertex AI Training also supports training in custom containers, allowing users to bring their own Docker containers with any pre-installed ML framework or algorithm to run on Vertex AI Training. \n",
+    "Agent Platform Training also supports training in custom containers, allowing users to bring their own Docker containers with any pre-installed ML framework or algorithm to run on Agent Platform Training. \n",
     "\n",
     "In this last section, we'll see how to submit a Cloud training job using a customized Docker image. "
    ]
@@ -1074,7 +1074,7 @@
    "source": [
     "#### Submit Custom Job using the Python SDK\n",
     "\n",
-    "As we did above, let's define the worker_pool_spec using Vertex AI Python SDK and run the cloud training.\n",
+    "As we did above, let's define the worker_pool_spec using Agent Platform Python SDK and run the cloud training.\n",
     "\n",
     "The definition is almost the same, but please note that here we specify `container_spec` instead of `python_package_spec`, which simply includes our custom container image path."
    ]
@@ -1165,7 +1165,7 @@
     "LR=0.001\n",
     "NNSIZE=\"32 8\"\n",
     "\n",
-    "# Vertex AI machines to use for training\n",
+    "# Agent Platform machines to use for training\n",
     "MACHINE_TYPE=n1-standard-4\n",
     "REPLICA_COUNT=1\n",
     "\n",

--- a/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "In this notebook we'll make the jump from training locally, to training in the cloud. We'll take advantage of Google Cloud's [Agent Platform Training Service](https://cloud.google.com/products/gemini-enterprise-agent-platform). \n",
+    "In this notebook we'll make the jump from training locally, to training in the cloud. We'll take advantage of Google Cloud's [Agent Platform Training Service](https://console.cloud.google.com/agent-platform/overview). \n",
     "\n",
     "Agent Platform Training Service is a managed service that allows the training and deployment of ML models without having to provision or maintain servers. The infrastructure is handled seamlessly by the managed service for us.\n",
     "\n",

--- a/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
@@ -1221,13 +1221,6 @@
    "source": [
     "Copyright 2025 Google Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/asl_core/notebooks/building_production_ml_systems/labs/2_hyperparameter_tuning.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/2_hyperparameter_tuning.ipynb
@@ -598,7 +598,7 @@
     "\n",
     "\n",
     "### Setup CustomJob\n",
-    "To leverage that capability, we first define a CustomJob object, just as you would for a normal custom training job on Agent Platform. For more details, please refer to the [custom training notebook](./1_training_at_scale_vertex.ipynb)."
+    "To leverage that capability, we first define a CustomJob object, just as you would for a normal custom training job on Agent Platform. For more details, please refer to the [custom training notebook](./1_training_at_scale.ipynb)."
    ]
   },
   {

--- a/asl_core/notebooks/building_production_ml_systems/labs/2_hyperparameter_tuning.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/2_hyperparameter_tuning.ipynb
@@ -9,7 +9,7 @@
     "**Learning Objectives**\n",
     "1. Learn how to use `cloudml-hypertune` to report the results for Cloud hyperparameter tuning trial runs\n",
     "2. Learn how to configure the `.yaml` file for submitting a Cloud hyperparameter tuning job\n",
-    "3. Submit a hyperparameter tuning job to Vertex AI\n",
+    "3. Submit a hyperparameter tuning job to Agent Platform\n",
     "\n",
     "## Introduction\n",
     "\n",
@@ -69,9 +69,9 @@
     "Cons\n",
     "- Requires sequential trials for best results, takes longer\n",
     "\n",
-    "**Vertex AI HyperTune**\n",
+    "**Agent Platform HyperTune**\n",
     "\n",
-    "Vertex AI HyperTune, powered by [Google Vizier](https://ai.google/research/pubs/pub46180), uses Bayesian Optimization by default, but [also supports](https://cloud.google.com/vertex-ai/docs/training/hyperparameter-tuning-overview#search_algorithms) Grid Search and Random Search. \n",
+    "Agent Platform HyperTune, powered by [Google Vizier](https://ai.google/research/pubs/pub46180), uses Bayesian Optimization by default, but [also supports](https://cloud.google.com/vertex-ai/docs/training/hyperparameter-tuning-overview#search_algorithms) Grid Search and Random Search. \n",
     "\n",
     "\n",
     "When tuning just a few hyperparameters (say less than 4), Grid Search and Random Search work well, but when tuning several hyperparameters and the search space is large Bayesian Optimization is best."
@@ -134,12 +134,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make code compatible with Vertex AI Training Service\n",
-    "In order to make our code compatible with Vertex AI Training Service we need to make the following changes:\n",
+    "## Make code compatible with Agent Platform Training Service\n",
+    "In order to make our code compatible with Agent Platform Training Service we need to make the following changes:\n",
     "\n",
     "1. Upload data to Google Cloud Storage \n",
     "2. Move code into a trainer Python package\n",
-    "4. Submit training job with `gcloud` to train on Vertex AI"
+    "4. Submit training job with `gcloud` to train on Agent Platform"
    ]
   },
   {
@@ -166,7 +166,7 @@
    "source": [
     "## Move code into python package\n",
     "\n",
-    "In the [previous lab](./1_training_at_scale.ipynb), we moved our code into a python package for training on Vertex AI. Let's just check that the files are there. You should see the following files in the `taxifare/trainer` directory:\n",
+    "In the [previous lab](./1_training_at_scale.ipynb), we moved our code into a python package for training on Agent Platform. Let's just check that the files are there. You should see the following files in the `taxifare/trainer` directory:\n",
     " - `__init__.py`\n",
     " - `model.py`\n",
     " - `task.py`"
@@ -195,7 +195,7 @@
     "\n",
     "  - Report your hyperparameter metrics during training. Note that while you could just report the metrics at the end of training, it is better to set up a callback, to take advantage of Early Stopping.\n",
     "\n",
-    "  - Read in the environment variable `$AIP_MODEL_DIR`, set by Vertex AI and containing the trial number, as our `output-dir`. As the training code will be submitted several times in a parallelized fashion, it is safer to use this variable than trying to assemble a unique id within the trainer code."
+    "  - Read in the environment variable `$AIP_MODEL_DIR`, set by Agent Platform and containing the trial number, as our `output-dir`. As the training code will be submitted several times in a parallelized fashion, it is safer to use this variable than trying to assemble a unique id within the trainer code."
    ]
   },
   {
@@ -592,13 +592,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run Hyperparameter Tuning Job on Vertex AI\n",
+    "## Run Hyperparameter Tuning Job on Agent Platform\n",
     "\n",
     "Hyperparameter tuning takes advantage of the processing infrastructure of Google Cloud to test different hyperparameter configurations when training your model. It can give you optimized values for hyperparameters, which maximizes your model's predictive accuracy.\n",
     "\n",
     "\n",
     "### Setup CustomJob\n",
-    "To leverage that capability, we first define a CustomJob object, just as you would for a normal custom training job on Vertex AI. For more details, please refer to the [custom training notebook](./1_training_at_scale_vertex.ipynb)."
+    "To leverage that capability, we first define a CustomJob object, just as you would for a normal custom training job on Agent Platform. For more details, please refer to the [custom training notebook](./1_training_at_scale_vertex.ipynb)."
    ]
   },
   {
@@ -769,7 +769,7 @@
     "JOB_NAME=taxifare_$TIMESTAMP\n",
     "echo ${BASE_OUTPUT_DIR} ${REGION} ${JOB_NAME}\n",
     "\n",
-    "# Vertex AI machines to use for training\n",
+    "# Agent Platform machines to use for training\n",
     "PYTHON_PACKAGE_URI=\"gs://${BUCKET}/taxifare/taxifare_trainer-0.1.tar.gz\"\n",
     "MACHINE_TYPE=\"n1-standard-4\"\n",
     "REPLICA_COUNT=1\n",

--- a/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
@@ -961,7 +961,7 @@
     "#### Open TensorBoard\n",
     "Since we specified the `TensorBoard` callback in `model.fit`, the training application saved the intermediate logs for TensorBoard dashboard.\n",
     "\n",
-    "While we can [host TensorBoard in Agent Platform Experiments](https://cloud.google.com/vertex-ai/docs/experiments/tensorboard-introduction), here, let's simply open from this notebook.\n",
+    "While we can [host TensorBoard in Agent Platform Experiments](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/experiments/tensorboard-introduction), here, let's simply open from this notebook.\n",
     "\n",
     "You might not see any data for a bit until the job begins. Check the job status on the console, and then return here to click the refresh button in the top right to update TensorBoard."
    ]

--- a/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
@@ -4,20 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Training at scale with the Vertex AI Training Service\n",
+    "# Training at scale with the Agent Platform Training Service\n",
     "**Learning Objectives:**\n",
     "  1. Learn how to organize your training code into a Python package\n",
-    "  1. Train your model using cloud infrastructure via Google Cloud Vertex AI Training Service\n",
+    "  1. Train your model using cloud infrastructure via Google Cloud Agent Platform Training Service\n",
     "  1. Learn how to run your training package using Docker containers and push training Docker images on a Docker registry\n",
     "  1. Monitor Cloud job using TensorBoard\n",
     "\n",
     "## Introduction\n",
     "\n",
-    "In this notebook we'll make the jump from training locally, to training in the cloud. We'll take advantage of Google Cloud's [Vertex AI Training Service](https://cloud.google.com/vertex-ai/). \n",
+    "In this notebook we'll make the jump from training locally, to training in the cloud. We'll take advantage of Google Cloud's [Agent Platform Training Service](https://console.cloud.google.com/agent-platform/overview). \n",
     "\n",
-    "Vertex AI Training Service is a managed service that allows the training and deployment of ML models without having to provision or maintain servers. The infrastructure is handled seamlessly by the managed service for us.\n",
+    "Agent Platform Training Service is a managed service that allows the training and deployment of ML models without having to provision or maintain servers. The infrastructure is handled seamlessly by the managed service for us.\n",
     "\n",
-    "Each learning objective will correspond to a __#TODO__ in the [student lab notebook](../labs/1_training_at_scale_vertex.ipynb) -- try to complete that notebook first before reviewing this solution notebook."
+    "Each learning objective will correspond to a __#TODO__ in the [student lab notebook](../labs/1_training_at_scale.ipynb) -- try to complete that notebook first before reviewing this solution notebook."
    ]
   },
   {
@@ -331,12 +331,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make code compatible with Vertex AI Training Service\n",
-    "In order to make our code compatible with Vertex AI Training Service we need to make the following changes:\n",
+    "## Make code compatible with Agent Platform Training Service\n",
+    "In order to make our code compatible with Agent Platform Training Service we need to make the following changes:\n",
     "\n",
     "1. Upload data to Google Cloud Storage \n",
     "2. Move code into a trainer Python package\n",
-    "4. Submit training job with `gcloud` to train on Vertex AI"
+    "4. Submit training job with `gcloud` to train on Agent Platform"
    ]
   },
   {
@@ -735,14 +735,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run your training package on Vertex AI\n",
+    "## Run your training package on Agent Platform\n",
     "\n",
     "\n",
-    "Once the code works in standalone mode locally, you can run it on the Cloud using Vertex AI.\n",
+    "Once the code works in standalone mode locally, you can run it on the Cloud using Agent Platform.\n",
     "\n",
-    "In Vertex AI, ou can provide training code to Vertex AI in one of the following forms:\n",
+    "In Agent Platform, you can provide training code to Agent Platform in one of the following forms:\n",
     "\n",
-    "- **A Python training application to use with a prebuilt container**. Create a [Python source distribution](https://packaging.python.org/en/latest/overview/#python-source-distributions) with code that trains an ML model and exports it to Cloud Storage. This training application can use any of the dependencies included in the prebuilt container that you plan to use it with. Use this option if one of the Vertex AI prebuilt containers for training includes all the dependencies that you need for training.\n",
+    "- **A Python training application to use with a prebuilt container**. Create a [Python source distribution](https://packaging.python.org/en/latest/overview/#python-source-distributions) with code that trains an ML model and exports it to Cloud Storage. This training application can use any of the dependencies included in the prebuilt container that you plan to use it with. Use this option if one of the Agent Platform prebuilt containers for training includes all the dependencies that you need for training.\n",
     "\n",
     "- **A custom container image**. Create a Docker container image with code that trains an ML model and exports it to Cloud Storage. Include any dependencies required by your code in the container image.\n",
     "\n",
@@ -825,11 +825,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To submit this source distribution to the Cloud we use [CustomJob](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform.CustomJob#google_cloud_aiplatform_CustomJob_get) module under Vertex AI Python SDK, and specify some parameters for Vertex AI Training service under [worker_pool_spec](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.WorkerPoolSpec), which includes:\n",
+    "To submit this source distribution to the Cloud we use [CustomJob](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform.CustomJob#google_cloud_aiplatform_CustomJob_get) module under Agent Platform Python SDK, and specify some parameters for Agent Platform Training service under [worker_pool_spec](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.WorkerPoolSpec), which includes:\n",
     "- [`machine_spec`](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.MachineSpec): Specification of a single machine where we run training. Here we can speficy `machine_type`, as well as the [accelerator specifications](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.AcceleratorType).\n",
     "- `python_package_spec`: Here we provide specification about our Python package runtime, including the prebuilt container URL (`executor_image_uri`), our Python package path (`package_uris`), as well as the custom arguments (`args`) we pass to our training application can be defined and provided here.\n",
     "\n",
-    "Because this is on the entire dataset, it will take a while. You can monitor the job from the GCP console in the Vertex AI Training section."
+    "Because this is on the entire dataset, it will take a while. You can monitor the job from the GCP console in the Agent Platform Training section."
    ]
   },
   {
@@ -961,7 +961,7 @@
     "#### Open TensorBoard\n",
     "Since we specified the `TensorBoard` callback in `model.fit`, the training application saved the intermediate logs for TensorBoard dashboard.\n",
     "\n",
-    "While we can [host TensorBoard in Vertex AI Experiments](https://cloud.google.com/vertex-ai/docs/experiments/tensorboard-introduction), here, let's simply open from this notebook.\n",
+    "While we can [host TensorBoard in Agent Platform Experiments](https://cloud.google.com/vertex-ai/docs/experiments/tensorboard-introduction), here, let's simply open from this notebook.\n",
     "\n",
     "You might not see any data for a bit until the job begins. Check the job status on the console, and then return here to click the refresh button in the top right to update TensorBoard."
    ]
@@ -983,7 +983,7 @@
    "source": [
     "### Method 2: Using a custom container\n",
     "\n",
-    "Vertex AI Training also supports training in custom containers, allowing users to bring their own Docker containers with any pre-installed ML framework or algorithm to run on Vertex AI Training. \n",
+    "Agent Platform Training also supports training in custom containers, allowing users to bring their own Docker containers with any pre-installed ML framework or algorithm to run on Agent Platform Training. \n",
     "\n",
     "In this last section, we'll see how to submit a Cloud training job using a customized Docker image. "
    ]
@@ -1074,7 +1074,7 @@
    "source": [
     "#### Submit Custom Job using the Python SDK\n",
     "\n",
-    "As we did above, let's define the worker_pool_spec using Vertex AI Python SDK and run the cloud training.\n",
+    "As we did above, let's define the worker_pool_spec using Agent Platform Python SDK and run the cloud training.\n",
     "\n",
     "The definition is almost the same, but please note that here we specify `container_spec` instead of `python_package_spec`, which simply includes our custom container image path."
    ]
@@ -1167,7 +1167,7 @@
     "LR=0.001\n",
     "NNSIZE=\"32 8\"\n",
     "\n",
-    "# Vertex AI machines to use for training\n",
+    "# Agent Platform machines to use for training\n",
     "MACHINE_TYPE=n1-standard-4\n",
     "REPLICA_COUNT=1\n",
     "\n",

--- a/asl_core/notebooks/building_production_ml_systems/solutions/2_hyperparameter_tuning.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/2_hyperparameter_tuning.ipynb
@@ -9,7 +9,7 @@
     "**Learning Objectives**\n",
     "1. Learn how to use `cloudml-hypertune` to report the results for Cloud hyperparameter tuning trial runs\n",
     "2. Learn how to configure the `.yaml` file for submitting a Cloud hyperparameter tuning job\n",
-    "3. Submit a hyperparameter tuning job to Vertex AI\n",
+    "3. Submit a hyperparameter tuning job to Agent Platform\n",
     "\n",
     "## Introduction\n",
     "\n",
@@ -69,9 +69,9 @@
     "Cons\n",
     "- Requires sequential trials for best results, takes longer\n",
     "\n",
-    "**Vertex AI HyperTune**\n",
+    "**Agent Platform HyperTune**\n",
     "\n",
-    "Vertex AI HyperTune, powered by [Google Vizier](https://ai.google/research/pubs/pub46180), uses Bayesian Optimization by default, but [also supports](https://cloud.google.com/vertex-ai/docs/training/hyperparameter-tuning-overview#search_algorithms) Grid Search and Random Search. \n",
+    "Agent Platform HyperTune, powered by [Google Vizier](https://ai.google/research/pubs/pub46180), uses Bayesian Optimization by default, but [also supports](https://cloud.google.com/vertex-ai/docs/training/hyperparameter-tuning-overview#search_algorithms) Grid Search and Random Search. \n",
     "\n",
     "\n",
     "When tuning just a few hyperparameters (say less than 4), Grid Search and Random Search work well, but when tuning several hyperparameters and the search space is large Bayesian Optimization is best."
@@ -137,12 +137,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make code compatible with Vertex AI Training Service\n",
-    "In order to make our code compatible with Vertex AI Training Service we need to make the following changes:\n",
+    "## Make code compatible with Agent Platform Training Service\n",
+    "In order to make our code compatible with Agent Platform Training Service we need to make the following changes:\n",
     "\n",
     "1. Upload data to Google Cloud Storage \n",
     "2. Move code into a trainer Python package\n",
-    "4. Submit training job with `gcloud` to train on Vertex AI"
+    "4. Submit training job with `gcloud` to train on Agent Platform"
    ]
   },
   {
@@ -171,7 +171,7 @@
    "source": [
     "## Move code into python package\n",
     "\n",
-    "In the [previous lab](./1_training_at_scale.ipynb), we moved our code into a python package for training on Vertex AI. Let's just check that the files are there. You should see the following files in the `taxifare/trainer` directory:\n",
+    "In the [previous lab](./1_training_at_scale.ipynb), we moved our code into a python package for training on Agent Platform. Let's just check that the files are there. You should see the following files in the `taxifare/trainer` directory:\n",
     " - `__init__.py`\n",
     " - `model.py`\n",
     " - `task.py`"
@@ -202,7 +202,7 @@
     "\n",
     "  - Report your hyperparameter metrics during training. Note that while you could just report the metrics at the end of training, it is better to set up a callback, to take advantage of Early Stopping.\n",
     "\n",
-    "  - Read in the environment variable `$AIP_MODEL_DIR`, set by Vertex AI and containing the trial number, as our `output-dir`. As the training code will be submitted several times in a parallelized fashion, it is safer to use this variable than trying to assemble a unique id within the trainer code."
+    "  - Read in the environment variable `$AIP_MODEL_DIR`, set by Agent Platform and containing the trial number, as our `output-dir`. As the training code will be submitted several times in a parallelized fashion, it is safer to use this variable than trying to assemble a unique id within the trainer code."
    ]
   },
   {
@@ -587,13 +587,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run Hyperparameter Tuning Job on Vertex AI\n",
+    "## Run Hyperparameter Tuning Job on Agent Platform\n",
     "\n",
     "Hyperparameter tuning takes advantage of the processing infrastructure of Google Cloud to test different hyperparameter configurations when training your model. It can give you optimized values for hyperparameters, which maximizes your model's predictive accuracy.\n",
     "\n",
     "\n",
     "### Setup CustomJob\n",
-    "To leverage that capability, we first define a CustomJob object, just as you would for a normal custom training job on Vertex AI. For more details, please refer to the [custom training notebook](./1_training_at_scale_vertex.ipynb)."
+    "To leverage that capability, we first define a CustomJob object, just as you would for a normal custom training job on Agent Platform. For more details, please refer to the [custom training notebook](./1_training_at_scale_vertex.ipynb)."
    ]
   },
   {
@@ -756,7 +756,7 @@
     "JOB_NAME=taxifare_$TIMESTAMP\n",
     "echo ${BASE_OUTPUT_DIR} ${REGION} ${JOB_NAME}\n",
     "\n",
-    "# Vertex AI machines to use for training\n",
+    "# Agent Platform machines to use for training\n",
     "PYTHON_PACKAGE_URI=\"gs://${BUCKET}/taxifare/taxifare_trainer-0.1.tar.gz\"\n",
     "MACHINE_TYPE=\"n1-standard-4\"\n",
     "REPLICA_COUNT=1\n",

--- a/asl_core/notebooks/building_production_ml_systems/solutions/2_hyperparameter_tuning.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/2_hyperparameter_tuning.ipynb
@@ -593,7 +593,7 @@
     "\n",
     "\n",
     "### Setup CustomJob\n",
-    "To leverage that capability, we first define a CustomJob object, just as you would for a normal custom training job on Agent Platform. For more details, please refer to the [custom training notebook](./1_training_at_scale_vertex.ipynb)."
+    "To leverage that capability, we first define a CustomJob object, just as you would for a normal custom training job on Agent Platform. For more details, please refer to the [custom training notebook](./1_training_at_scale.ipynb)."
    ]
   },
   {


### PR DESCRIPTION
Rebranding updates for `asl-ml-immersion/asl_core/notebooks/building_production_ml_systems` from Vertex AI to Agent Platform.

**Changes:**

- File names have been updated by removing vertex from them.
- Updated the links to include the new Agent Platform URLs.
- Lab tested and worked as expected.

<img width="2096" height="1322" alt="1" src="https://github.com/user-attachments/assets/8a93e853-8cb5-4956-84b6-e6664fd3ec8c" />
<img width="1916" height="1268" alt="2" src="https://github.com/user-attachments/assets/def224e1-91b7-45c1-8c62-117caa64ad07" />
