### PR TITLE
Rebrand Vertex AI to Agent Platform in time_series_prediction

### DIFF
--- a/asl_core/notebooks/time_series_prediction/labs/3_modeling_bqml.ipynb
+++ b/asl_core/notebooks/time_series_prediction/labs/3_modeling_bqml.ipynb
@@ -407,7 +407,7 @@
    "source": [
     "### Step 1. Create a Dataset\n",
     "\n",
-    "In the GCP Navigation Menu, navigate to **Vertex AI -> Datasets**.\n",
+    "In the GCP Navigation Menu, navigate to **Agent Platform -> Datasets**.\n",
     "\n",
     "Select **Create** and give it a name like `stock_market`. In the **Select a data type and objective** section, select **Tabular** and under Tabular select, **Regression/Classification**. Click **Create** at the bottom.\n",
     "\n",

--- a/asl_core/notebooks/time_series_prediction/solutions/3_modeling_bqml.ipynb
+++ b/asl_core/notebooks/time_series_prediction/solutions/3_modeling_bqml.ipynb
@@ -430,7 +430,7 @@
    "source": [
     "### Step 1. Create a Dataset\n",
     "\n",
-    "In the GCP Navigation Menu, navigate to **Vertex AI -> Datasets**.\n",
+    "In the GCP Navigation Menu, navigate to **Agent Platform -> Datasets**.\n",
     "\n",
     "Select **Create** and give it a name like `stock_market`. In the **Select a data type and objective** section, select **Tabular** and under Tabular select, **Regression/Classification**. Click **Create** at the bottom.\n",
     "\n",


### PR DESCRIPTION
**Changes:**

File names have been updated by removing Vertex from them.
Updated the links to include the new Agent Platform URLs.