### PR TITLE
Rebrand Vertex AI to Agent Platform in operationalize_gen_ai

### DIFF
--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/evaluation_adk_agent_with_agent_platform.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/evaluation_adk_agent_with_agent_platform.ipynb
@@ -1570,14 +1570,6 @@
     "https://www.apache.org/licenses/LICENSE-2.0\n",
     "Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "61681970-a984-427c-9043-0a3cb37b6c00",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/gen_ai_evaluation_service.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/gen_ai_evaluation_service.ipynb
@@ -762,7 +762,7 @@
    "id": "74ef80d4-48a5-446d-ae61-bca2e03c1439",
    "metadata": {},
    "source": [
-    "All of the above evaluation experiments we ran in the notebook are accessible from the [Experiments Tab](https://console.cloud.google.com/agent-platform/experiments/experiments) in the Agent Platform UI."
+    "All of the above evaluation experiments we ran in the notebook are accessible from the [Experiments Tab](https://console.cloud.google.com/agent-platform/experiments/experiments) in the Agent Platform UI. "
    ]
   },
   {

--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/gen_ai_evaluation_service.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/gen_ai_evaluation_service.ipynb
@@ -762,7 +762,7 @@
    "id": "74ef80d4-48a5-446d-ae61-bca2e03c1439",
    "metadata": {},
    "source": [
-    "All of the above evaluation experiments we ran in the notebook are accessible from the [Experiments Tab](https://console.cloud.google.com/agent-platform/experiments/experiments) in the Agent Platform UI. "
+    "All of the above evaluation experiments we ran in the notebook are accessible from the [Experiments Tab](https://console.cloud.google.com/agent-platform/experiments/experiments) in the Agent Platform UI."
    ]
   },
   {

--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/prompt_management_and_context_caching.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/prompt_management_and_context_caching.ipynb
@@ -102,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "# Initialize Agent Platform\n",
+    "# Initialize Agent Platform client\n",
     "vertexai.init(project=PROJECT, location=\"us-central1\")\n",
     "\n",
     "# Create local Prompt\n",

--- a/asl_genai/notebooks/operationalize_gen_ai/solutions/prompt_management_and_context_caching.ipynb
+++ b/asl_genai/notebooks/operationalize_gen_ai/solutions/prompt_management_and_context_caching.ipynb
@@ -102,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "# Initialize vertexai\n",
+    "# Initialize Agent Platform\n",
     "vertexai.init(project=PROJECT, location=\"us-central1\")\n",
     "\n",
     "# Create local Prompt\n",


### PR DESCRIPTION
**Changes:**

- Vertex AI to Agent Platform renaming
- File rename from `vertex_ai` to `agent_platform`