### PR TITLE
asl_core: gsutil -> gcloud storage update

### DIFF
--- a/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
@@ -303,7 +303,7 @@
    },
    "outputs": [],
    "source": [
-    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-train-000000000000.csv | head -2"
+    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-train-000000000000.csv 2>/dev/null | head -2"
    ]
   },
   {
@@ -316,7 +316,7 @@
    },
    "outputs": [],
    "source": [
-    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-valid-000000000000.csv | head -2"
+    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-valid-000000000000.csv 2>/dev/null | head -2"
    ]
   },
   {

--- a/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
@@ -93,7 +93,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
+    "gcloud storage ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
     "echo $REGION"
    ]
   },
@@ -256,7 +256,7 @@
     "%%bash\n",
     "\n",
     "echo \"Deleting current contents of $OUTDIR\"\n",
-    "gsutil -m -q rm -rf $OUTDIR\n",
+    "gcloud storage rm -r $OUTDIR\n",
     "\n",
     "echo \"Extracting training data to $OUTDIR\"\n",
     "bq --location=US extract \\\n",
@@ -272,7 +272,7 @@
     "   taxifare.feateng_valid_data \\\n",
     "   $OUTDIR/taxi-valid-*.csv\n",
     "\n",
-    "gsutil ls -l $OUTDIR"
+    "gcloud storage ls -l $OUTDIR"
    ]
   },
   {
@@ -288,7 +288,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls gs://$BUCKET/taxifare/data"
+    "!gcloud storage ls gs://$BUCKET/taxifare/data"
    ]
   },
   {
@@ -301,7 +301,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cat gs://$BUCKET/taxifare/data/taxi-train-000000000000.csv | head -2"
+    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-train-000000000000.csv | head -2"
    ]
   },
   {
@@ -314,7 +314,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cat gs://$BUCKET/taxifare/data/taxi-valid-000000000000.csv | head -2"
+    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-valid-000000000000.csv | head -2"
    ]
   },
   {
@@ -808,7 +808,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp taxifare/dist/taxifare_trainer-0.1.tar.gz gs://${BUCKET}/taxifare/"
+    "gcloud storage cp taxifare/dist/taxifare_trainer-0.1.tar.gz gs://${BUCKET}/taxifare/"
    ]
   },
   {

--- a/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
@@ -255,8 +255,10 @@
    "source": [
     "%%bash\n",
     "\n",
-    "echo \"Deleting current contents of $OUTDIR\"\n",
-    "gcloud storage rm -r $OUTDIR\n",
+    "if gcloud storage ls $OUTDIR >/dev/null 2>&1; then\n",
+    "    echo \"Deleting current contents of $OUTDIR\"\n",
+    "    gcloud storage rm -r $OUTDIR\n",
+    "fi\n",
     "\n",
     "echo \"Extracting training data to $OUTDIR\"\n",
     "bq --location=US extract \\\n",

--- a/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/1_training_at_scale.ipynb
@@ -93,7 +93,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gcloud storage ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
+    "gcloud storage ls -L -b gs://$BUCKET | grep \"gs://\\|Location\"\n",
     "echo $REGION"
    ]
   },

--- a/asl_core/notebooks/building_production_ml_systems/labs/2_hyperparameter_tuning.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/labs/2_hyperparameter_tuning.ipynb
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls gs://$BUCKET/taxifare/data"
+    "!gcloud storage ls gs://$BUCKET/taxifare/data"
    ]
   },
   {
@@ -585,7 +585,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp taxifare/dist/taxifare_trainer-0.1.tar.gz gs://${BUCKET}/taxifare/"
+    "gcloud storage cp taxifare/dist/taxifare_trainer-0.1.tar.gz gs://${BUCKET}/taxifare/"
    ]
   },
   {

--- a/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
+    "gcloud storage ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
     "echo $REGION"
    ]
   },
@@ -264,7 +264,7 @@
     "%%bash\n",
     "\n",
     "echo \"Deleting current contents of $OUTDIR\"\n",
-    "gsutil -m -q rm -rf $OUTDIR\n",
+    "gcloud storage rm -r $OUTDIR\n",
     "\n",
     "echo \"Extracting training data to $OUTDIR\"\n",
     "bq --location=US extract \\\n",
@@ -280,7 +280,7 @@
     "   taxifare.feateng_valid_data \\\n",
     "   $OUTDIR/taxi-valid-*.csv\n",
     "\n",
-    "gsutil ls -l $OUTDIR"
+    "gcloud storage ls -l $OUTDIR"
    ]
   },
   {
@@ -298,7 +298,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls gs://$BUCKET/taxifare/data"
+    "!gcloud storage ls gs://$BUCKET/taxifare/data"
    ]
   },
   {
@@ -311,7 +311,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cat gs://$BUCKET/taxifare/data/taxi-train-000000000000.csv | head -2"
+    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-train-000000000000.csv | head -2"
    ]
   },
   {
@@ -324,7 +324,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cat gs://$BUCKET/taxifare/data/taxi-valid-000000000000.csv | head -2"
+    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-valid-000000000000.csv | head -2"
    ]
   },
   {
@@ -811,7 +811,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp taxifare/dist/taxifare_trainer-0.1.tar.gz gs://${BUCKET}/taxifare/"
+    "gcloud storage cp taxifare/dist/taxifare_trainer-0.1.tar.gz gs://${BUCKET}/taxifare/"
    ]
   },
   {

--- a/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gcloud storage ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
+    "gcloud storage ls -L -b gs://$BUCKET | grep \"gs://\\|Location\"\n",
     "echo $REGION"
    ]
   },

--- a/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
@@ -313,7 +313,7 @@
    },
    "outputs": [],
    "source": [
-    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-train-000000000000.csv | head -2"
+    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-train-000000000000.csv 2>/dev/null | head -2"
    ]
   },
   {
@@ -326,7 +326,7 @@
    },
    "outputs": [],
    "source": [
-    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-valid-000000000000.csv | head -2"
+    "!gcloud storage cat gs://$BUCKET/taxifare/data/taxi-valid-000000000000.csv 2>/dev/null | head -2"
    ]
   },
   {

--- a/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/1_training_at_scale.ipynb
@@ -263,8 +263,10 @@
    "source": [
     "%%bash\n",
     "\n",
-    "echo \"Deleting current contents of $OUTDIR\"\n",
-    "gcloud storage rm -r $OUTDIR\n",
+    "if gcloud storage ls $OUTDIR >/dev/null 2>&1; then\n",
+    "    echo \"Deleting current contents of $OUTDIR\"\n",
+    "    gcloud storage rm -r $OUTDIR\n",
+    "fi\n",
     "\n",
     "echo \"Extracting training data to $OUTDIR\"\n",
     "bq --location=US extract \\\n",

--- a/asl_core/notebooks/building_production_ml_systems/solutions/2_hyperparameter_tuning.ipynb
+++ b/asl_core/notebooks/building_production_ml_systems/solutions/2_hyperparameter_tuning.ipynb
@@ -162,7 +162,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls gs://$BUCKET/taxifare/data"
+    "!gcloud storage ls gs://$BUCKET/taxifare/data"
    ]
   },
   {
@@ -580,7 +580,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp taxifare/dist/taxifare_trainer-0.1.tar.gz gs://${BUCKET}/taxifare/"
+    "gcloud storage cp taxifare/dist/taxifare_trainer-0.1.tar.gz gs://${BUCKET}/taxifare/"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/labs/1b_prepare_data_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/labs/1b_prepare_data_babyweight.ipynb
@@ -125,16 +125,16 @@
     "fi\n",
     "    \n",
     "## Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "    \n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"Here are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },
@@ -403,7 +403,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil ls gs://${BUCKET}/babyweight/data/*.csv"
+    "gcloud storage ls gs://${BUCKET}/babyweight/data/*.csv"
    ]
   },
   {
@@ -413,7 +413,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cat gs://${BUCKET}/babyweight/data/train000000000000.csv | head -5"
+    "gcloud storage cat gs://${BUCKET}/babyweight/data/train000000000000.csv | head -5"
    ]
   },
   {
@@ -423,7 +423,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cat gs://${BUCKET}/babyweight/data/eval000000000000.csv | head -5"
+    "gcloud storage cat gs://${BUCKET}/babyweight/data/eval000000000000.csv | head -5"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/labs/1b_prepare_data_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/labs/1b_prepare_data_babyweight.ipynb
@@ -125,7 +125,7 @@
     "fi\n",
     "    \n",
     "## Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/notebooks/end-to-end-structured/labs/1b_prepare_data_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/labs/1b_prepare_data_babyweight.ipynb
@@ -413,7 +413,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gcloud storage cat gs://${BUCKET}/babyweight/data/train000000000000.csv | head -5"
+    "gcloud storage cat gs://${BUCKET}/babyweight/data/train000000000000.csv 2>/dev/null | head -5"
    ]
   },
   {
@@ -423,7 +423,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gcloud storage cat gs://${BUCKET}/babyweight/data/eval000000000000.csv | head -5"
+    "gcloud storage cat gs://${BUCKET}/babyweight/data/eval000000000000.csv 2>/dev/null | head -5"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/labs/5a_train_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/labs/5a_train_keras_vertex_babyweight.ipynb
@@ -96,7 +96,7 @@
     "if ! gcloud storage ls | grep -q gs://${BUCKET}/; then\n",
     "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "fi\n",
-    "gcloud storage ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
+    "gcloud storage ls -L -b gs://$BUCKET | grep \"gs://\\|Location\"\n",
     "echo $REGION"
    ]
   },

--- a/asl_core/notebooks/end-to-end-structured/labs/5a_train_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/labs/5a_train_keras_vertex_babyweight.ipynb
@@ -93,10 +93,10 @@
    "outputs": [],
    "source": [
     " %%bash\n",
-    "if ! gsutil ls | grep -q gs://${BUCKET}/; then\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "if ! gcloud storage ls | grep -q gs://${BUCKET}/; then\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "fi\n",
-    "gsutil ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
+    "gcloud storage ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
     "echo $REGION"
    ]
   },
@@ -127,7 +127,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil ls gs://${BUCKET}/babyweight/data/*000000000000.csv"
+    "gcloud storage ls gs://${BUCKET}/babyweight/data/*000000000000.csv"
    ]
   },
   {
@@ -467,7 +467,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp babyweight/dist/babyweight_trainer-0.1.tar.gz gs://${BUCKET}/babyweight/"
+    "gcloud storage cp babyweight/dist/babyweight_trainer-0.1.tar.gz gs://${BUCKET}/babyweight/"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/labs/5b_deploy_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/labs/5b_deploy_keras_vertex_babyweight.ipynb
@@ -131,7 +131,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "MODEL_LOCATION=$(gcloud storage ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
+    "MODEL_LOCATION=$(gcloud storage ls -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
     "                 | tail -1)\n",
     "gcloud storage ls ${MODEL_LOCATION}"
    ]

--- a/asl_core/notebooks/end-to-end-structured/labs/5b_deploy_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/labs/5b_deploy_keras_vertex_babyweight.ipynb
@@ -121,7 +121,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil ls gs://${BUCKET}/babyweight/tuned_2*"
+    "gcloud storage ls gs://${BUCKET}/babyweight/tuned_2*"
    ]
   },
   {
@@ -131,9 +131,9 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "MODEL_LOCATION=$(gsutil ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
+    "MODEL_LOCATION=$(gcloud storage ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
     "                 | tail -1)\n",
-    "gsutil ls ${MODEL_LOCATION}"
+    "gcloud storage ls ${MODEL_LOCATION}"
    ]
   },
   {
@@ -347,7 +347,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp inputs.jsonl gs://$BUCKET/babyweight/batchpred/inputs.jsonl"
+    "!gcloud storage cp inputs.jsonl gs://$BUCKET/babyweight/batchpred/inputs.jsonl"
    ]
   },
   {
@@ -386,7 +386,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cat $(gsutil ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.errors_stats-*"
+    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.errors_stats-*"
    ]
   },
   {
@@ -395,7 +395,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cat $(gsutil ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.results-*"
+    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.results-*"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/labs/5b_deploy_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/labs/5b_deploy_keras_vertex_babyweight.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "%%bash\n",
     "MODEL_LOCATION=$(gcloud storage ls -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
-    "                 | tail -1)\n",
+    "                 2>/dev/null | tail -1)\n",
     "gcloud storage ls ${MODEL_LOCATION}"
    ]
   },
@@ -386,7 +386,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.errors_stats-*"
+    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs 2>/dev/null | tail -n1)prediction.errors_stats-*\n"
    ]
   },
   {
@@ -395,7 +395,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.results-*"
+    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs 2>/dev/null | tail -n1)prediction.results-*\n"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/solutions/1b_prepare_data_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/solutions/1b_prepare_data_babyweight.ipynb
@@ -428,7 +428,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gcloud storage cat gs://${BUCKET}/babyweight/data/train000000000000.csv | head -5"
+    "gcloud storage cat gs://${BUCKET}/babyweight/data/train000000000000.csv 2>/dev/null | head -5"
    ]
   },
   {
@@ -438,7 +438,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gcloud storage cat gs://${BUCKET}/babyweight/data/eval000000000000.csv | head -5"
+    "gcloud storage cat gs://${BUCKET}/babyweight/data/eval000000000000.csv 2>/dev/null | head -5"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/solutions/1b_prepare_data_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/solutions/1b_prepare_data_babyweight.ipynb
@@ -125,7 +125,7 @@
     "fi\n",
     "    \n",
     "## Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/notebooks/end-to-end-structured/solutions/1b_prepare_data_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/solutions/1b_prepare_data_babyweight.ipynb
@@ -125,16 +125,16 @@
     "fi\n",
     "    \n",
     "## Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "    \n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"Here are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },
@@ -418,7 +418,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil ls gs://${BUCKET}/babyweight/data/*.csv"
+    "gcloud storage ls gs://${BUCKET}/babyweight/data/*.csv"
    ]
   },
   {
@@ -428,7 +428,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cat gs://${BUCKET}/babyweight/data/train000000000000.csv | head -5"
+    "gcloud storage cat gs://${BUCKET}/babyweight/data/train000000000000.csv | head -5"
    ]
   },
   {
@@ -438,7 +438,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cat gs://${BUCKET}/babyweight/data/eval000000000000.csv | head -5"
+    "gcloud storage cat gs://${BUCKET}/babyweight/data/eval000000000000.csv | head -5"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/solutions/5a_train_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/solutions/5a_train_keras_vertex_babyweight.ipynb
@@ -98,7 +98,7 @@
     "if ! gcloud storage ls | grep -q gs://${BUCKET}/; then\n",
     "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "fi\n",
-    "gcloud storage ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
+    "gcloud storage ls -L -b gs://$BUCKET | grep \"gs://\\|Location\"\n",
     "echo $REGION"
    ]
   },

--- a/asl_core/notebooks/end-to-end-structured/solutions/5a_train_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/solutions/5a_train_keras_vertex_babyweight.ipynb
@@ -95,10 +95,10 @@
    "outputs": [],
    "source": [
     " %%bash\n",
-    "if ! gsutil ls | grep -q gs://${BUCKET}/; then\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "if ! gcloud storage ls | grep -q gs://${BUCKET}/; then\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "fi\n",
-    "gsutil ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
+    "gcloud storage ls -Lb gs://$BUCKET | grep \"gs://\\|Location\"\n",
     "echo $REGION"
    ]
   },
@@ -129,7 +129,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil ls gs://${BUCKET}/babyweight/data/*000000000000.csv"
+    "gcloud storage ls gs://${BUCKET}/babyweight/data/*000000000000.csv"
    ]
   },
   {
@@ -652,7 +652,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp babyweight/dist/babyweight_trainer-0.1.tar.gz gs://${BUCKET}/babyweight/"
+    "gcloud storage cp babyweight/dist/babyweight_trainer-0.1.tar.gz gs://${BUCKET}/babyweight/"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/solutions/5b_deploy_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/solutions/5b_deploy_keras_vertex_babyweight.ipynb
@@ -121,7 +121,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil ls gs://${BUCKET}/babyweight/tuned_2*"
+    "gcloud storage ls gs://${BUCKET}/babyweight/tuned_2*"
    ]
   },
   {
@@ -131,9 +131,9 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "MODEL_LOCATION=$(gsutil ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
+    "MODEL_LOCATION=$(gcloud storage ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
     "                 | tail -1)\n",
-    "gsutil ls ${MODEL_LOCATION}"
+    "gcloud storage ls ${MODEL_LOCATION}"
    ]
   },
   {
@@ -156,7 +156,7 @@
     "MODEL_DISPLAYNAME=babyweight_model_$TIMESTAMP\n",
     "ENDPOINT_DISPLAYNAME=babyweight_endpoint_$TIMESTAMP\n",
     "IMAGE_URI=\"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-3:latest\"\n",
-    "MODEL_LOCATION=$(gsutil ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
+    "MODEL_LOCATION=$(gcloud storage ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
     "                 | tail -1)\n",
     "echo \"MODEL_LOCATION=${MODEL_LOCATION}\"\n",
     "\n",
@@ -346,7 +346,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp inputs.jsonl gs://$BUCKET/babyweight/batchpred/inputs.jsonl"
+    "!gcloud storage cp inputs.jsonl gs://$BUCKET/babyweight/batchpred/inputs.jsonl"
    ]
   },
   {
@@ -385,7 +385,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cat $(gsutil ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.errors_stats-*"
+    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.errors_stats-*"
    ]
   },
   {
@@ -394,7 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cat $(gsutil ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.results-*"
+    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.results-*"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/solutions/5b_deploy_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/solutions/5b_deploy_keras_vertex_babyweight.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "%%bash\n",
     "MODEL_LOCATION=$(gcloud storage ls -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
-    "                 | tail -1)\n",
+    "                 2>/dev/null | tail -1)\n",
     "gcloud storage ls ${MODEL_LOCATION}"
    ]
   },
@@ -157,7 +157,7 @@
     "ENDPOINT_DISPLAYNAME=babyweight_endpoint_$TIMESTAMP\n",
     "IMAGE_URI=\"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-3:latest\"\n",
     "MODEL_LOCATION=$(gcloud storage ls -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
-    "                 | tail -1)\n",
+    "                 2>/dev/null | tail -1)\n",
     "echo \"MODEL_LOCATION=${MODEL_LOCATION}\"\n",
     "\n",
     "# Model\n",
@@ -385,7 +385,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.errors_stats-*"
+    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs 2>/dev/null | tail -n1)prediction.errors_stats-*\n"
    ]
   },
   {
@@ -394,7 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs | tail -n1)prediction.results-*"
+    "!gcloud storage cat $(gcloud storage ls gs://$BUCKET/babyweight/batchpred/outputs 2>/dev/null | tail -n1)prediction.results-*\n"
    ]
   },
   {

--- a/asl_core/notebooks/end-to-end-structured/solutions/5b_deploy_keras_vertex_babyweight.ipynb
+++ b/asl_core/notebooks/end-to-end-structured/solutions/5b_deploy_keras_vertex_babyweight.ipynb
@@ -131,7 +131,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "MODEL_LOCATION=$(gcloud storage ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
+    "MODEL_LOCATION=$(gcloud storage ls -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
     "                 | tail -1)\n",
     "gcloud storage ls ${MODEL_LOCATION}"
    ]
@@ -156,7 +156,7 @@
     "MODEL_DISPLAYNAME=babyweight_model_$TIMESTAMP\n",
     "ENDPOINT_DISPLAYNAME=babyweight_endpoint_$TIMESTAMP\n",
     "IMAGE_URI=\"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-3:latest\"\n",
-    "MODEL_LOCATION=$(gcloud storage ls -d -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
+    "MODEL_LOCATION=$(gcloud storage ls -- gs://${BUCKET}/babyweight/tuned_2*/2* \\\n",
     "                 | tail -1)\n",
     "echo \"MODEL_LOCATION=${MODEL_LOCATION}\"\n",
     "\n",

--- a/asl_core/notebooks/image_models/labs/classification_automl_vision.ipynb
+++ b/asl_core/notebooks/image_models/labs/classification_automl_vision.ipynb
@@ -94,9 +94,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud storage buckets create -p {PROJECT_ID} \\\n",
-    "    -c standard \\\n",
-    "    -l us-central1 \\\n",
+    "!gcloud storage ls --buckets | grep -w gs://{BUCKET}/ || gcloud storage buckets create --project={PROJECT_ID} \\\n",
+    "    --default-storage-class=standard \\\n",
+    "    --location=us-central1 \\\n",
     "    gs://{BUCKET}"
    ]
   },

--- a/asl_core/notebooks/image_models/labs/classification_automl_vision.ipynb
+++ b/asl_core/notebooks/image_models/labs/classification_automl_vision.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil mb -p {PROJECT_ID} \\\n",
+    "!gcloud storage buckets create -p {PROJECT_ID} \\\n",
     "    -c standard \\\n",
     "    -l us-central1 \\\n",
     "    gs://{BUCKET}"
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil -mq cp -r gs://asl-public-data/data/car_damage_lab_images* gs://{BUCKET}/car_damage_lab_images"
+    "!gcloud storage cp -r gs://asl-public-data/data/car_damage_lab_images* gs://{BUCKET}/car_damage_lab_images"
    ]
   },
   {
@@ -141,7 +141,7 @@
     "\n",
     "LABELS = [\"bumper\", \"engine_compartment\", \"hood\", \"lateral\", \"windshield\"]\n",
     "for label in LABELS:\n",
-    "    !gsutil -q cp gs://{BUCKET}/car_damage_lab_images/{label}/{label}1.jpg ./car_damage_lab_images\n",
+    "    !gcloud storage cp gs://{BUCKET}/car_damage_lab_images/{label}/{label}1.jpg ./car_damage_lab_images\n",
     "    img = mpimg.imread(f\"car_damage_lab_images/{label}1.jpg\")\n",
     "    plt.imshow(img)\n",
     "    plt.title(label)\n",
@@ -183,7 +183,7 @@
     "data_list = []\n",
     "\n",
     "for label in LABELS:\n",
-    "    data = !gsutil ls gs://{BUCKET}/car_damage_lab_images/{label}\n",
+    "    data = !gcloud storage ls gs://{BUCKET}/car_damage_lab_images/{label}\n",
     "    for i, img_path in enumerate(data):\n",
     "        assign = \"TRAIN\" if i % 5 > 0 else \"VALIDATION\"  # 80:20\n",
     "        data_list.append([assign, img_path, label])\n",
@@ -218,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp ./{CSV_FILE} gs://{BUCKET}/car_damage_lab_images"
+    "!gcloud storage cp ./{CSV_FILE} gs://{BUCKET}/car_damage_lab_images"
    ]
   },
   {

--- a/asl_core/notebooks/image_models/labs/object_detection_automl.ipynb
+++ b/asl_core/notebooks/image_models/labs/object_detection_automl.ipynb
@@ -138,16 +138,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "    \n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },
@@ -173,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp ../dataset_import_files/salads.csv gs://{BUCKET}/"
+    "!gcloud storage cp ../dataset_import_files/salads.csv gs://{BUCKET}/"
    ]
   },
   {

--- a/asl_core/notebooks/image_models/labs/object_detection_automl.ipynb
+++ b/asl_core/notebooks/image_models/labs/object_detection_automl.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/image_models/labs/serving.ipynb
+++ b/asl_core/notebooks/image_models/labs/serving.ipynb
@@ -111,8 +111,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !gsutil mb gs://{BUCKET}\n",
-    "# !gsutil cp gs://asl-public-data/data/flowers/tfrecords/* {FILE_DIR}"
+    "# !gcloud storage buckets create gs://{BUCKET}\n",
+    "# !gcloud storage cp gs://asl-public-data/data/flowers/tfrecords/* {FILE_DIR}"
    ]
   },
   {
@@ -130,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls {FILE_DIR}"
+    "!gcloud storage ls {FILE_DIR}"
    ]
   },
   {
@@ -679,7 +679,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp -R export/flowers_model_with_signature gs://{BUCKET}/{MODEL_DISPLAYNAME}"
+    "!gcloud storage cp -R export/flowers_model_with_signature gs://{BUCKET}/{MODEL_DISPLAYNAME}"
    ]
   },
   {
@@ -738,7 +738,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "files = !gsutil ls -r gs://asl-public-data/data/flowers/jpegs/*.jpg\n",
+    "files = !gcloud storage ls -r gs://asl-public-data/data/flowers/jpegs/*.jpg\n",
     "print(len(files))"
    ]
   },
@@ -765,7 +765,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp {JSON_FILE} {FILE_DIR}"
+    "!gcloud storage cp {JSON_FILE} {FILE_DIR}"
    ]
   },
   {
@@ -827,7 +827,7 @@
    "source": [
     "if batch_pred_job.output_info:\n",
     "    output_dir = batch_pred_job.output_info.gcs_output_directory\n",
-    "    results = !gsutil cat {output_dir}/prediction.results*\n",
+    "    results = !gcloud storage cat {output_dir}/prediction.results*\n",
     "    for r in results[:5]:\n",
     "        r = json.loads(r)\n",
     "        print(f\"filename       : {r['instance']['filenames']}\")\n",
@@ -926,7 +926,7 @@
    "outputs": [],
    "source": [
     "# Download a sample image from GCS.\n",
-    "!gsutil cp gs://asl-public-data/data/flowers/jpegs/10172567486_2748826a8b.jpg sample.jpg\n",
+    "!gcloud storage cp gs://asl-public-data/data/flowers/jpegs/10172567486_2748826a8b.jpg sample.jpg\n",
     "\n",
     "\n",
     "def b64encode(filename):\n",

--- a/asl_core/notebooks/image_models/labs/stable_diffusion_dreambooth.ipynb
+++ b/asl_core/notebooks/image_models/labs/stable_diffusion_dreambooth.ipynb
@@ -271,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls gs://asl-public-data/data/dreambooth_dog/instance/* | head -n 3"
+    "!gcloud storage ls gs://asl-public-data/data/dreambooth_dog/instance/* | head -n 3"
    ]
   },
   {
@@ -280,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls gs://asl-public-data/data/dreambooth_dog/class/* | head -n 3"
+    "!gcloud storage ls gs://asl-public-data/data/dreambooth_dog/class/* | head -n 3"
    ]
   },
   {

--- a/asl_core/notebooks/image_models/labs/unet_segmentation.ipynb
+++ b/asl_core/notebooks/image_models/labs/unet_segmentation.ipynb
@@ -711,7 +711,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w ${STAGING_BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w ${STAGING_BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/image_models/labs/unet_segmentation.ipynb
+++ b/asl_core/notebooks/image_models/labs/unet_segmentation.ipynb
@@ -711,16 +711,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w ${STAGING_BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w ${STAGING_BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "    \n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} ${STAGING_BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} ${STAGING_BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },

--- a/asl_core/notebooks/image_models/solutions/classification_automl_vision.ipynb
+++ b/asl_core/notebooks/image_models/solutions/classification_automl_vision.ipynb
@@ -94,9 +94,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud storage buckets create -p {PROJECT_ID} \\\n",
-    "    -c standard \\\n",
-    "    -l us-central1 \\\n",
+    "!gcloud storage ls --buckets | grep -w gs://{BUCKET}/ || gcloud storage buckets create --project={PROJECT_ID} \\\n",
+    "    --default-storage-class=standard \\\n",
+    "    --location=us-central1 \\\n",
     "    gs://{BUCKET}"
    ]
   },

--- a/asl_core/notebooks/image_models/solutions/classification_automl_vision.ipynb
+++ b/asl_core/notebooks/image_models/solutions/classification_automl_vision.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil mb -p {PROJECT_ID} \\\n",
+    "!gcloud storage buckets create -p {PROJECT_ID} \\\n",
     "    -c standard \\\n",
     "    -l us-central1 \\\n",
     "    gs://{BUCKET}"
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil -mq cp -r gs://asl-public-data/data/car_damage_lab_images* gs://{BUCKET}/car_damage_lab_images"
+    "!gcloud storage cp -r gs://asl-public-data/data/car_damage_lab_images* gs://{BUCKET}/car_damage_lab_images"
    ]
   },
   {
@@ -209,7 +209,7 @@
     "\n",
     "LABELS = [\"bumper\", \"engine_compartment\", \"hood\", \"lateral\", \"windshield\"]\n",
     "for label in LABELS:\n",
-    "    !gsutil -q cp gs://{BUCKET}/car_damage_lab_images/{label}/{label}1.jpg ./car_damage_lab_images\n",
+    "    !gcloud storage cp gs://{BUCKET}/car_damage_lab_images/{label}/{label}1.jpg ./car_damage_lab_images\n",
     "    img = mpimg.imread(f\"car_damage_lab_images/{label}1.jpg\")\n",
     "    plt.imshow(img)\n",
     "    plt.title(label)\n",
@@ -251,7 +251,7 @@
     "data_list = []\n",
     "\n",
     "for label in LABELS:\n",
-    "    data = !gsutil ls gs://{BUCKET}/car_damage_lab_images/{label}\n",
+    "    data = !gcloud storage ls gs://{BUCKET}/car_damage_lab_images/{label}\n",
     "    for i, img_path in enumerate(data):\n",
     "        assign = \"TRAIN\" if i % 5 > 0 else \"VALIDATION\"  # 80:20\n",
     "        data_list.append([assign, img_path, label])\n",
@@ -313,7 +313,7 @@
     }
    ],
    "source": [
-    "!gsutil cp ./{CSV_FILE} gs://{BUCKET}/car_damage_lab_images"
+    "!gcloud storage cp ./{CSV_FILE} gs://{BUCKET}/car_damage_lab_images"
    ]
   },
   {

--- a/asl_core/notebooks/image_models/solutions/create_tfrecords_at_scale.ipynb
+++ b/asl_core/notebooks/image_models/solutions/create_tfrecords_at_scale.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "  echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/image_models/solutions/create_tfrecords_at_scale.ipynb
+++ b/asl_core/notebooks/image_models/solutions/create_tfrecords_at_scale.ipynb
@@ -79,16 +79,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "  echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "    \n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },
@@ -109,7 +109,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cp ../dataset_import_files/flowers.csv {DATASET_FILE}"
+    "!gcloud storage cp ../dataset_import_files/flowers.csv {DATASET_FILE}"
    ]
   },
   {
@@ -541,7 +541,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls -l {OUTPUT_DIR}"
+    "!gcloud storage ls -l {OUTPUT_DIR}"
    ]
   },
   {

--- a/asl_core/notebooks/image_models/solutions/object_detection_automl.ipynb
+++ b/asl_core/notebooks/image_models/solutions/object_detection_automl.ipynb
@@ -138,16 +138,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "    \n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },
@@ -173,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp ../dataset_import_files/salads.csv gs://{BUCKET}/"
+    "!gcloud storage cp ../dataset_import_files/salads.csv gs://{BUCKET}/"
    ]
   },
   {

--- a/asl_core/notebooks/image_models/solutions/object_detection_automl.ipynb
+++ b/asl_core/notebooks/image_models/solutions/object_detection_automl.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/image_models/solutions/serving.ipynb
+++ b/asl_core/notebooks/image_models/solutions/serving.ipynb
@@ -119,8 +119,8 @@
    },
    "outputs": [],
    "source": [
-    "# !gsutil mb gs://{BUCKET}\n",
-    "# !gsutil cp gs://asl-public-data/data/flowers/tfrecords/* {FILE_DIR}"
+    "# !gcloud storage buckets create gs://{BUCKET}\n",
+    "# !gcloud storage cp gs://asl-public-data/data/flowers/tfrecords/* {FILE_DIR}"
    ]
   },
   {
@@ -140,7 +140,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls {FILE_DIR}"
+    "!gcloud storage ls {FILE_DIR}"
    ]
   },
   {
@@ -683,7 +683,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cp -R export/flowers_model_with_signature gs://{BUCKET}/{MODEL_DISPLAYNAME}"
+    "!gcloud storage cp -R export/flowers_model_with_signature gs://{BUCKET}/{MODEL_DISPLAYNAME}"
    ]
   },
   {
@@ -746,7 +746,7 @@
    },
    "outputs": [],
    "source": [
-    "files = !gsutil ls -r gs://asl-public-data/data/flowers/jpegs/*.jpg\n",
+    "files = !gcloud storage ls -r gs://asl-public-data/data/flowers/jpegs/*.jpg\n",
     "print(len(files))"
    ]
   },
@@ -777,7 +777,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cp {JSON_FILE} {FILE_DIR}"
+    "!gcloud storage cp {JSON_FILE} {FILE_DIR}"
    ]
   },
   {
@@ -836,7 +836,7 @@
    "source": [
     "if batch_pred_job.output_info:\n",
     "    output_dir = batch_pred_job.output_info.gcs_output_directory\n",
-    "    results = !gsutil cat {output_dir}/prediction.results*\n",
+    "    results = !gcloud storage cat {output_dir}/prediction.results*\n",
     "    for r in results[:5]:\n",
     "        r = json.loads(r)\n",
     "        print(f\"filename       : {r['instance']['filenames']}\")\n",
@@ -943,7 +943,7 @@
    "outputs": [],
    "source": [
     "# Download a sample image from GCS.\n",
-    "!gsutil cp gs://asl-public-data/data/flowers/jpegs/10172567486_2748826a8b.jpg sample.jpg\n",
+    "!gcloud storage cp gs://asl-public-data/data/flowers/jpegs/10172567486_2748826a8b.jpg sample.jpg\n",
     "\n",
     "\n",
     "def b64encode(filename):\n",

--- a/asl_core/notebooks/image_models/solutions/unet_segmentation.ipynb
+++ b/asl_core/notebooks/image_models/solutions/unet_segmentation.ipynb
@@ -771,16 +771,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w ${STAGING_BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w ${STAGING_BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "    \n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} ${STAGING_BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} ${STAGING_BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },

--- a/asl_core/notebooks/image_models/solutions/unet_segmentation.ipynb
+++ b/asl_core/notebooks/image_models/solutions/unet_segmentation.ipynb
@@ -771,7 +771,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w ${STAGING_BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w ${STAGING_BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
+++ b/asl_core/notebooks/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
@@ -485,7 +485,7 @@
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/notebooks/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
+++ b/asl_core/notebooks/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
@@ -485,15 +485,15 @@
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"\\nHere are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },
@@ -507,7 +507,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cp -R $SAVEDMODEL_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
+    "!gcloud storage cp -R $SAVEDMODEL_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
    ]
   },
   {

--- a/asl_core/notebooks/introduction_to_tensorflow/solutions/3_keras_sequential_api.ipynb
+++ b/asl_core/notebooks/introduction_to_tensorflow/solutions/3_keras_sequential_api.ipynb
@@ -954,15 +954,15 @@
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"\\nHere are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },
@@ -989,7 +989,7 @@
     }
    ],
    "source": [
-    "!gsutil cp -R $SAVEDMODEL_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
+    "!gcloud storage cp -R $SAVEDMODEL_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
    ]
   },
   {

--- a/asl_core/notebooks/introduction_to_tensorflow/solutions/3_keras_sequential_api.ipynb
+++ b/asl_core/notebooks/introduction_to_tensorflow/solutions/3_keras_sequential_api.ipynb
@@ -954,7 +954,7 @@
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/notebooks/launching_into_ml/labs/2_first_model.ipynb
+++ b/asl_core/notebooks/launching_into_ml/labs/2_first_model.ipynb
@@ -87,7 +87,7 @@
     "fi    \n",
     "\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/notebooks/launching_into_ml/labs/2_first_model.ipynb
+++ b/asl_core/notebooks/launching_into_ml/labs/2_first_model.ipynb
@@ -87,15 +87,15 @@
     "fi    \n",
     "\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"\\nHere are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },

--- a/asl_core/notebooks/launching_into_ml/labs/supplemental/improve_data_quality.ipynb
+++ b/asl_core/notebooks/launching_into_ml/labs/supplemental/improve_data_quality.ipynb
@@ -123,7 +123,7 @@
     }
    ],
    "source": [
-    "!gsutil cp gs://cloud-training-demos/feat_eng/transport/untidy_vehicle_data.csv ../data/transport"
+    "!gcloud storage cp gs://cloud-training-demos/feat_eng/transport/untidy_vehicle_data.csv ../data/transport"
    ]
   },
   {

--- a/asl_core/notebooks/launching_into_ml/labs/supplemental/python.BQ_explore_data.ipynb
+++ b/asl_core/notebooks/launching_into_ml/labs/supplemental/python.BQ_explore_data.ipynb
@@ -114,7 +114,7 @@
     }
    ],
    "source": [
-    "!gsutil cp gs://cloud-training-demos/feat_eng/housing/housing_pre-proc.csv ../data/explore"
+    "!gcloud storage cp gs://cloud-training-demos/feat_eng/housing/housing_pre-proc.csv ../data/explore"
    ]
   },
   {

--- a/asl_core/notebooks/launching_into_ml/solutions/2_first_model.ipynb
+++ b/asl_core/notebooks/launching_into_ml/solutions/2_first_model.ipynb
@@ -106,15 +106,15 @@
     "fi    \n",
     "\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"\\nHere are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },

--- a/asl_core/notebooks/launching_into_ml/solutions/2_first_model.ipynb
+++ b/asl_core/notebooks/launching_into_ml/solutions/2_first_model.ipynb
@@ -106,7 +106,7 @@
     "fi    \n",
     "\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/notebooks/launching_into_ml/solutions/supplemental/improve_data_quality.ipynb
+++ b/asl_core/notebooks/launching_into_ml/solutions/supplemental/improve_data_quality.ipynb
@@ -123,7 +123,7 @@
     }
    ],
    "source": [
-    "!gsutil cp gs://cloud-training-demos/feat_eng/transport/untidy_vehicle_data.csv ../data/transport"
+    "!gcloud storage cp gs://cloud-training-demos/feat_eng/transport/untidy_vehicle_data.csv ../data/transport"
    ]
   },
   {

--- a/asl_core/notebooks/launching_into_ml/solutions/supplemental/python.BQ_explore_data.ipynb
+++ b/asl_core/notebooks/launching_into_ml/solutions/supplemental/python.BQ_explore_data.ipynb
@@ -114,7 +114,7 @@
     }
    ],
    "source": [
-    "!gsutil cp gs://cloud-training-demos/feat_eng/housing/housing_pre-proc.csv ../data/explore"
+    "!gcloud storage cp gs://cloud-training-demos/feat_eng/housing/housing_pre-proc.csv ../data/explore"
    ]
   },
   {

--- a/asl_core/notebooks/responsible_ai/explainable_ai/labs/xai_image.ipynb
+++ b/asl_core/notebooks/responsible_ai/explainable_ai/labs/xai_image.ipynb
@@ -132,7 +132,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/responsible_ai/explainable_ai/labs/xai_image.ipynb
+++ b/asl_core/notebooks/responsible_ai/explainable_ai/labs/xai_image.ipynb
@@ -132,16 +132,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "    \n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },
@@ -179,11 +179,11 @@
     "\n",
     "# Copy training files to GCS\n",
     "for file in training_filenames:\n",
-    "    !gsutil -m cp $file $TRAINING_DATA_PATH/\n",
+    "    !gcloud storage cp $file $TRAINING_DATA_PATH/\n",
     "\n",
     "# Copy eval files to GCS\n",
     "for file in validation_filenames:\n",
-    "    !gsutil -m cp $file $EVAL_DATA_PATH/"
+    "    !gcloud storage cp $file $EVAL_DATA_PATH/"
    ]
   },
   {
@@ -199,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls -l $TRAINING_DATA_PATH"
+    "!gcloud storage ls -l $TRAINING_DATA_PATH"
    ]
   },
   {
@@ -208,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls -l $EVAL_DATA_PATH"
+    "!gcloud storage ls -l $EVAL_DATA_PATH"
    ]
   },
   {
@@ -526,7 +526,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp flowers/dist/flowers_trainer-0.1.tar.gz gs://${BUCKET}/flowers/"
+    "gcloud storage cp flowers/dist/flowers_trainer-0.1.tar.gz gs://${BUCKET}/flowers/"
    ]
   },
   {

--- a/asl_core/notebooks/responsible_ai/explainable_ai/labs/xai_image_saliency.ipynb
+++ b/asl_core/notebooks/responsible_ai/explainable_ai/labs/xai_image_saliency.ipynb
@@ -136,7 +136,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/responsible_ai/explainable_ai/labs/xai_image_saliency.ipynb
+++ b/asl_core/notebooks/responsible_ai/explainable_ai/labs/xai_image_saliency.ipynb
@@ -136,16 +136,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "\n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },
@@ -185,11 +185,11 @@
     "\n",
     "# Copy training files to GCS\n",
     "for file in training_filenames:\n",
-    "    !gsutil -m cp $file $TRAINING_DATA_PATH/\n",
+    "    !gcloud storage cp $file $TRAINING_DATA_PATH/\n",
     "\n",
     "# Copy eval files to GCS\n",
     "for file in validation_filenames:\n",
-    "    !gsutil -m cp $file $EVAL_DATA_PATH/"
+    "    !gcloud storage cp $file $EVAL_DATA_PATH/"
    ]
   },
   {
@@ -207,7 +207,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls -l $TRAINING_DATA_PATH"
+    "!gcloud storage ls -l $TRAINING_DATA_PATH"
    ]
   },
   {
@@ -218,7 +218,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls -l $EVAL_DATA_PATH"
+    "!gcloud storage ls -l $EVAL_DATA_PATH"
    ]
   },
   {

--- a/asl_core/notebooks/responsible_ai/explainable_ai/solutions/xai_image.ipynb
+++ b/asl_core/notebooks/responsible_ai/explainable_ai/solutions/xai_image.ipynb
@@ -136,7 +136,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/responsible_ai/explainable_ai/solutions/xai_image.ipynb
+++ b/asl_core/notebooks/responsible_ai/explainable_ai/solutions/xai_image.ipynb
@@ -136,16 +136,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "    \n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },
@@ -183,11 +183,11 @@
     "\n",
     "# Copy training files to GCS\n",
     "for file in training_filenames:\n",
-    "    !gsutil -m cp $file $TRAINING_DATA_PATH/\n",
+    "    !gcloud storage cp $file $TRAINING_DATA_PATH/\n",
     "\n",
     "# Copy eval files to GCS\n",
     "for file in validation_filenames:\n",
-    "    !gsutil -m cp $file $EVAL_DATA_PATH/"
+    "    !gcloud storage cp $file $EVAL_DATA_PATH/"
    ]
   },
   {
@@ -203,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls -l $TRAINING_DATA_PATH"
+    "!gcloud storage ls -l $TRAINING_DATA_PATH"
    ]
   },
   {
@@ -212,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls -l $EVAL_DATA_PATH"
+    "!gcloud storage ls -l $EVAL_DATA_PATH"
    ]
   },
   {
@@ -530,7 +530,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp flowers/dist/flowers_trainer-0.1.tar.gz gs://${BUCKET}/flowers/"
+    "gcloud storage cp flowers/dist/flowers_trainer-0.1.tar.gz gs://${BUCKET}/flowers/"
    ]
   },
   {

--- a/asl_core/notebooks/responsible_ai/explainable_ai/solutions/xai_image_saliency.ipynb
+++ b/asl_core/notebooks/responsible_ai/explainable_ai/solutions/xai_image_saliency.ipynb
@@ -156,16 +156,16 @@
    ],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "\n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },
@@ -260,11 +260,11 @@
     "\n",
     "# Copy training files to GCS\n",
     "for file in training_filenames:\n",
-    "    !gsutil -m cp $file $TRAINING_DATA_PATH/\n",
+    "    !gcloud storage cp $file $TRAINING_DATA_PATH/\n",
     "\n",
     "# Copy eval files to GCS\n",
     "for file in validation_filenames:\n",
-    "    !gsutil -m cp $file $EVAL_DATA_PATH/"
+    "    !gcloud storage cp $file $EVAL_DATA_PATH/"
    ]
   },
   {
@@ -282,7 +282,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls -l $TRAINING_DATA_PATH"
+    "!gcloud storage ls -l $TRAINING_DATA_PATH"
    ]
   },
   {
@@ -293,7 +293,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls -l $EVAL_DATA_PATH"
+    "!gcloud storage ls -l $EVAL_DATA_PATH"
    ]
   },
   {

--- a/asl_core/notebooks/responsible_ai/explainable_ai/solutions/xai_image_saliency.ipynb
+++ b/asl_core/notebooks/responsible_ai/explainable_ai/solutions/xai_image_saliency.ipynb
@@ -156,7 +156,7 @@
    ],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_core/notebooks/text_models/labs/classify_text_with_bert.ipynb
+++ b/asl_core/notebooks/text_models/labs/classify_text_with_bert.ipynb
@@ -881,7 +881,7 @@
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/notebooks/text_models/labs/classify_text_with_bert.ipynb
+++ b/asl_core/notebooks/text_models/labs/classify_text_with_bert.ipynb
@@ -881,15 +881,15 @@
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"\\nHere are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },
@@ -899,7 +899,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp -r $SAVEDMODEL_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
+    "!gcloud storage cp -r $SAVEDMODEL_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
    ]
   },
   {

--- a/asl_core/notebooks/text_models/solutions/classify_text_with_bert.ipynb
+++ b/asl_core/notebooks/text_models/solutions/classify_text_with_bert.ipynb
@@ -886,7 +886,7 @@
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/notebooks/text_models/solutions/classify_text_with_bert.ipynb
+++ b/asl_core/notebooks/text_models/solutions/classify_text_with_bert.ipynb
@@ -886,15 +886,15 @@
    "source": [
     "%%bash\n",
     "# Create GCS bucket if it doesn't exist already...\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"\\nHere are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },
@@ -904,7 +904,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp -r $SAVEDMODEL_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
+    "!gcloud storage cp -r $SAVEDMODEL_PATH gs://$BUCKET/$MODEL_DISPLAYNAME"
    ]
   },
   {

--- a/asl_core/notebooks/time_series_prediction/labs/1_optional_data_exploration.ipynb
+++ b/asl_core/notebooks/time_series_prediction/labs/1_optional_data_exploration.ipynb
@@ -123,7 +123,7 @@
     "SCHEMA=symbol:STRING,Date:DATE,Open:FLOAT,Close:FLOAT\n",
     "                \n",
     "test -f $TABLE.csv || unzip ../stock_src/$TABLE.csv.zip\n",
-    "gsutil -m cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
+    "gcloud storage cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
     "bq load --source_format=CSV --skip_leading_rows=1 \\\n",
     "    stock_src.$TABLE gs://$BUCKET/stock_src/$TABLE.csv  $SCHEMA"
    ]
@@ -140,7 +140,7 @@
     "SCHEMA=date:DATE,company:STRING,symbol:STRING,surprise:STRING,reported_EPS:FLOAT,consensus_EPS:FLOAT\n",
     "                \n",
     "test -f $TABLE.csv || unzip ../stock_src/$TABLE.csv.zip\n",
-    "gsutil -m cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
+    "gcloud storage cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
     "bq load --source_format=CSV --skip_leading_rows=1 \\\n",
     "    stock_src.$TABLE gs://$BUCKET/stock_src/$TABLE.csv  $SCHEMA"
    ]
@@ -157,7 +157,7 @@
     "SCHEMA=company:STRING,symbol:STRING,industry:STRING\n",
     "                \n",
     "test -f $TABLE.csv || unzip ../stock_src/$TABLE.csv.zip\n",
-    "gsutil -m cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
+    "gcloud storage cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
     "bq load --source_format=CSV --skip_leading_rows=1 \\\n",
     "    stock_src.$TABLE gs://$BUCKET/stock_src/$TABLE.csv  $SCHEMA"
    ]

--- a/asl_core/notebooks/time_series_prediction/solutions/1_optional_data_exploration.ipynb
+++ b/asl_core/notebooks/time_series_prediction/solutions/1_optional_data_exploration.ipynb
@@ -119,7 +119,7 @@
     "SCHEMA=symbol:STRING,Date:DATE,Open:FLOAT,Close:FLOAT\n",
     "                \n",
     "test -f $TABLE.csv || unzip ../stock_src/$TABLE.csv.zip\n",
-    "gsutil -m cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
+    "gcloud storage cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
     "bq load --source_format=CSV --skip_leading_rows=1 \\\n",
     "    stock_src.$TABLE gs://$BUCKET/stock_src/$TABLE.csv  $SCHEMA"
    ]
@@ -136,7 +136,7 @@
     "SCHEMA=date:DATE,company:STRING,symbol:STRING,surprise:STRING,reported_EPS:FLOAT,consensus_EPS:FLOAT\n",
     "                \n",
     "test -f $TABLE.csv || unzip ../stock_src/$TABLE.csv.zip\n",
-    "gsutil -m cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
+    "gcloud storage cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
     "bq load --source_format=CSV --skip_leading_rows=1 \\\n",
     "    stock_src.$TABLE gs://$BUCKET/stock_src/$TABLE.csv  $SCHEMA"
    ]
@@ -153,7 +153,7 @@
     "SCHEMA=company:STRING,symbol:STRING,industry:STRING\n",
     "                \n",
     "test -f $TABLE.csv || unzip ../stock_src/$TABLE.csv.zip\n",
-    "gsutil -m cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
+    "gcloud storage cp $TABLE.csv gs://$BUCKET/stock_src/$TABLE.csv\n",
     "bq load --source_format=CSV --skip_leading_rows=1 \\\n",
     "    stock_src.$TABLE gs://$BUCKET/stock_src/$TABLE.csv  $SCHEMA"
    ]

--- a/asl_core/scaffolds/image_classification_app/deploy.sh
+++ b/asl_core/scaffolds/image_classification_app/deploy.sh
@@ -6,7 +6,7 @@ APP_NAME=flower-classification
 
 echo "Copying the model file..."
 mkdir export
-gsutil cp -r gs://asl-public-data/models/flowers_model export/
+gcloud storage cp -r gs://asl-public-data/models/flowers_model export/
 
 echo "Building the application image..."
 if ! gcloud artifacts repositories describe $STREAMLIT_ARTIFACT_REG_REPO \

--- a/asl_core/scaffolds/image_classification_app/train_and_deploy.ipynb
+++ b/asl_core/scaffolds/image_classification_app/train_and_deploy.ipynb
@@ -123,7 +123,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",

--- a/asl_core/scaffolds/image_classification_app/train_and_deploy.ipynb
+++ b/asl_core/scaffolds/image_classification_app/train_and_deploy.ipynb
@@ -123,16 +123,16 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "    \n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"Here are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },
@@ -153,8 +153,8 @@
    },
    "outputs": [],
    "source": [
-    "# !gsutil mb gs://{BUCKET}\n",
-    "# !gsutil cp gs://asl-public-data/data/flowers/tfrecords/* {FILE_DIR}"
+    "# !gcloud storage buckets create gs://{BUCKET}\n",
+    "# !gcloud storage cp gs://asl-public-data/data/flowers/tfrecords/* {FILE_DIR}"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls {FILE_DIR}"
+    "!gcloud storage ls {FILE_DIR}"
    ]
   },
   {


### PR DESCRIPTION
## Description
This PR updates all `gsutil` CLI commands to their modern `gcloud storage` equivalents across the `asl_core` directory, following [Google Cloud's gsutil transition recommendations](https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud).
### Summary of Changes
- **Updated files**: 39 files (38 Jupyter Notebooks + 1 shell deployment script)
- **Command mappings applied**:
  - `gsutil cp` ➡️ `gcloud storage cp`
  - `gsutil ls` ➡️ `gcloud storage ls`
  - `gsutil cat` ➡️ `gcloud storage cat`
  - `gsutil mb` ➡️ `gcloud storage buckets create`
  - Omitted obsolete `-m` flags (parallel transfers are enabled by default in `gcloud storage`).
### Verification & Quality Assurance
- ✅ All updated Jupyter Notebooks were verified for valid JSON structure.
- ✅ All pre-commit hooks passed (`black`, `isort`, `json check`, trailing whitespace, etc.).
- ✅ Zero remaining `gsutil` references in `asl_core`.
- [x] Testing the changed notebooks