### PR TITLE
asl_mlops: gsutil -> gcloud storage update

### DIFF
--- a/asl_mlops/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -77,8 +77,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $ARTIFACT_STORE/data/training/dataset.csv\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $ARTIFACT_STORE/data/validation/dataset.csv"
+    "gcloud storage cp gs://asl-public-data/data/covertype/training/dataset.csv $ARTIFACT_STORE/data/training/dataset.csv\n",
+    "gcloud storage cp gs://asl-public-data/data/covertype/validation/dataset.csv $ARTIFACT_STORE/data/validation/dataset.csv"
    ]
   },
   {
@@ -260,14 +260,14 @@
    "source": [
     "%%bash\n",
     "\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"Here are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },

--- a/asl_mlops/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/cicd/labs/kfp_cicd.ipynb
@@ -260,7 +260,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",

--- a/asl_mlops/notebooks/kubeflow_pipelines/cicd/labs/trainer_image/train.py
+++ b/asl_mlops/notebooks/kubeflow_pipelines/cicd/labs/trainer_image/train.py
@@ -91,7 +91,8 @@ def train_evaluate(
         with open(MODEL_FILENAME, "wb") as model_file:
             pickle.dump(pipeline, model_file)
         subprocess.check_call(
-            ["gsutil", "cp", MODEL_FILENAME, AIP_MODEL_DIR], stderr=sys.stdout
+            ["gcloud", "storage", "cp", MODEL_FILENAME, AIP_MODEL_DIR],
+            stderr=sys.stdout,
         )
         print(f"Saved model in: {AIP_MODEL_DIR}")
 

--- a/asl_mlops/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd.ipynb
@@ -73,7 +73,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -96,8 +96,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $ARTIFACT_STORE/data/training/dataset.csv\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $ARTIFACT_STORE/data/validation/dataset.csv"
+    "gcloud storage cp gs://asl-public-data/data/covertype/training/dataset.csv $ARTIFACT_STORE/data/training/dataset.csv\n",
+    "gcloud storage cp gs://asl-public-data/data/covertype/validation/dataset.csv $ARTIFACT_STORE/data/validation/dataset.csv"
    ]
   },
   {
@@ -194,14 +194,14 @@
    "source": [
     "%%bash\n",
     "\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",
     "    echo \"Creating a new GCS bucket.\"\n",
-    "    gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "    gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "    echo \"Here are your current buckets:\"\n",
-    "    gsutil ls\n",
+    "    gcloud storage ls\n",
     "fi"
    ]
   },

--- a/asl_mlops/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/cicd/solutions/kfp_cicd.ipynb
@@ -194,7 +194,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "if [ -n \"$exists\" ]; then\n",
     "    echo -e \"Bucket exists, let's not recreate it.\"\n",
     "else\n",

--- a/asl_mlops/notebooks/kubeflow_pipelines/cicd/solutions/trainer_image/train.py
+++ b/asl_mlops/notebooks/kubeflow_pipelines/cicd/solutions/trainer_image/train.py
@@ -91,7 +91,8 @@ def train_evaluate(
         with open(MODEL_FILENAME, "wb") as model_file:
             pickle.dump(pipeline, model_file)
         subprocess.check_call(
-            ["gsutil", "cp", MODEL_FILENAME, AIP_MODEL_DIR], stderr=sys.stdout
+            ["gcloud", "storage", "cp", MODEL_FILENAME, AIP_MODEL_DIR],
+            stderr=sys.stdout,
         )
         print(f"Saved model in: {AIP_MODEL_DIR}")
 

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/challenge_labs/challenge_lab_1.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/challenge_labs/challenge_lab_1.ipynb
@@ -241,7 +241,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/challenge_labs/challenge_lab_2.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/challenge_labs/challenge_lab_2.ipynb
@@ -228,7 +228,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/challenge_labs/challenge_lab_3.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/challenge_labs/challenge_lab_3.ipynb
@@ -239,7 +239,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/challenge_labs/trainer_image/train.py
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/challenge_labs/trainer_image/train.py
@@ -91,7 +91,8 @@ def train_evaluate(
         with open(MODEL_FILENAME, "wb") as model_file:
             pickle.dump(pipeline, model_file)
         subprocess.check_call(
-            ["gsutil", "cp", MODEL_FILENAME, AIP_MODEL_DIR], stderr=sys.stdout
+            ["gcloud", "storage", "cp", MODEL_FILENAME, AIP_MODEL_DIR],
+            stderr=sys.stdout,
         )
         print(f"Saved model in: {AIP_MODEL_DIR}")
 

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_automl_online_predictions.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_automl_online_predictions.ipynb
@@ -263,7 +263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_lightweight.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_lightweight.ipynb
@@ -286,7 +286,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -304,8 +304,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+    "gcloud storage cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "gcloud storage cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_prebuilt.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/kfp_pipeline_prebuilt.ipynb
@@ -360,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -378,8 +378,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+    "gcloud storage cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "gcloud storage cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/trainer_image/train.py
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/labs/trainer_image/train.py
@@ -91,7 +91,8 @@ def train_evaluate(
         with open(MODEL_FILENAME, "wb") as model_file:
             pickle.dump(pipeline, model_file)
         subprocess.check_call(
-            ["gsutil", "cp", MODEL_FILENAME, AIP_MODEL_DIR], stderr=sys.stdout
+            ["gcloud", "storage", "cp", MODEL_FILENAME, AIP_MODEL_DIR],
+            stderr=sys.stdout,
         )
         print(f"Saved model in: {AIP_MODEL_DIR}")
 

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_automl_batch_predictions.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_automl_batch_predictions.ipynb
@@ -365,7 +365,7 @@
     }
    ],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_automl_online_predictions.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_automl_online_predictions.ipynb
@@ -268,7 +268,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_lightweight.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_lightweight.ipynb
@@ -296,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -314,8 +314,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+    "gcloud storage cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "gcloud storage cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_prebuilt.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/kfp_pipeline_prebuilt.ipynb
@@ -368,7 +368,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -388,8 +388,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "gsutil cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
-    "gsutil cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
+    "gcloud storage cp gs://asl-public-data/data/covertype/training/dataset.csv $TRAINING_FILE_PATH\n",
+    "gcloud storage cp gs://asl-public-data/data/covertype/validation/dataset.csv $VALIDATION_FILE_PATH"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/trainer_image/train.py
+++ b/asl_mlops/notebooks/kubeflow_pipelines/pipelines/solutions/trainer_image/train.py
@@ -91,7 +91,8 @@ def train_evaluate(
         with open(MODEL_FILENAME, "wb") as model_file:
             pickle.dump(pipeline, model_file)
         subprocess.check_call(
-            ["gsutil", "cp", MODEL_FILENAME, AIP_MODEL_DIR], stderr=sys.stdout
+            ["gcloud", "storage", "cp", MODEL_FILENAME, AIP_MODEL_DIR],
+            stderr=sys.stdout,
         )
         print(f"Saved model in: {AIP_MODEL_DIR}")
 

--- a/asl_mlops/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/walkthrough/labs/kfp_walkthrough.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -450,7 +450,7 @@
     "        with open(model_filename, 'wb') as model_file:\n",
     "            pickle.dump(pipeline, model_file)\n",
     "        gcs_model_path = \"{}/{}\".format(job_dir, model_filename)\n",
-    "        subprocess.check_call(['gsutil', 'cp', model_filename, gcs_model_path], stderr=sys.stdout)\n",
+    "        subprocess.check_call(['gcloud', 'storage', 'cp', model_filename, gcs_model_path], stderr=sys.stdout)\n",
     "        print(\"Saved model in: {}\".format(gcs_model_path)) \n",
     "    \n",
     "if __name__ == \"__main__\":\n",
@@ -847,7 +847,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls $JOB_DIR"
+    "!gcloud storage ls $JOB_DIR"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -458,7 +458,7 @@
     "        with open(model_filename, 'wb') as model_file:\n",
     "            pickle.dump(pipeline, model_file)\n",
     "        gcs_model_path = \"{}/{}\".format(job_dir, model_filename)\n",
-    "        subprocess.check_call(['gsutil', 'cp', model_filename, gcs_model_path], stderr=sys.stdout)\n",
+    "        subprocess.check_call(['gcloud', 'storage', 'cp', model_filename, gcs_model_path], stderr=sys.stdout)\n",
     "        print(\"Saved model in: {}\".format(gcs_model_path)) \n",
     "    \n",
     "if __name__ == \"__main__\":\n",
@@ -827,7 +827,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls $JOB_DIR"
+    "!gcloud storage ls $JOB_DIR"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_pytorch.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_pytorch.ipynb
@@ -1523,7 +1523,7 @@
    },
    "outputs": [],
    "source": [
-    "!gcloud storage ls -al $DEPLOY_MODEL_GCS_URI"
+    "!gcloud storage ls -a -l $DEPLOY_MODEL_GCS_URI"
    ]
   },
   {

--- a/asl_mlops/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_pytorch.ipynb
+++ b/asl_mlops/notebooks/kubeflow_pipelines/walkthrough/solutions/kfp_walkthrough_pytorch.ipynb
@@ -119,7 +119,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls | grep ^{ARTIFACT_STORE}/$ || gsutil mb -l {REGION} {ARTIFACT_STORE}"
+    "!gcloud storage ls | grep ^{ARTIFACT_STORE}/$ || gcloud storage buckets create --location={REGION} {ARTIFACT_STORE}"
    ]
   },
   {
@@ -910,8 +910,8 @@
     "        gcs_preprocessing_json_path = \"{}/{}\".format(job_dir, preproc_json_filename)\n",
     "\n",
     "        # send files to GCS\n",
-    "        subprocess.check_call(['gsutil', 'cp', model_filename, gcs_model_path], stderr=sys.stdout)\n",
-    "        subprocess.check_call(['gsutil', 'cp', preproc_json_filename, gcs_preprocessing_json_path], \n",
+    "        subprocess.check_call(['gcloud', 'storage', 'cp', model_filename, gcs_model_path], stderr=sys.stdout)\n",
+    "        subprocess.check_call(['gcloud', 'storage', 'cp', preproc_json_filename, gcs_preprocessing_json_path], \n",
     "                              stderr=sys.stdout)\n",
     "\n",
     "\n",
@@ -1288,7 +1288,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls $JOB_DIR"
+    "!gcloud storage ls $JOB_DIR"
    ]
   },
   {
@@ -1462,8 +1462,8 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil cp $JOB_DIR/model.pt ./$PREDICT_APP_FOLDER\n",
-    "!gsutil cp $JOB_DIR/preprocessing.json ./$PREDICT_APP_FOLDER"
+    "!gcloud storage cp $JOB_DIR/model.pt ./$PREDICT_APP_FOLDER\n",
+    "!gcloud storage cp $JOB_DIR/preprocessing.json ./$PREDICT_APP_FOLDER"
    ]
   },
   {
@@ -1512,7 +1512,7 @@
     "TIMESTAMP = time.strftime(\"%Y%m%d_%H%M%S\")\n",
     "DEPLOY_MODEL_GCS_URI = f\"{ARTIFACT_STORE}/pytorch-model-deploy/{TIMESTAMP}\"\n",
     "\n",
-    "!gsutil cp -r $PREDICT_APP_FOLDER $DEPLOY_MODEL_GCS_URI"
+    "!gcloud storage cp -r $PREDICT_APP_FOLDER $DEPLOY_MODEL_GCS_URI"
    ]
   },
   {
@@ -1523,7 +1523,7 @@
    },
    "outputs": [],
    "source": [
-    "!gsutil ls -al $DEPLOY_MODEL_GCS_URI"
+    "!gcloud storage ls -al $DEPLOY_MODEL_GCS_URI"
    ]
   },
   {

--- a/asl_mlops/notebooks/model_monitoring/solutions/model_monitoring.ipynb
+++ b/asl_mlops/notebooks/model_monitoring/solutions/model_monitoring.ipynb
@@ -144,7 +144,7 @@
    ],
    "source": [
     "%%bash\n",
-    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls --buckets | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",

--- a/asl_mlops/notebooks/model_monitoring/solutions/model_monitoring.ipynb
+++ b/asl_mlops/notebooks/model_monitoring/solutions/model_monitoring.ipynb
@@ -144,16 +144,16 @@
    ],
    "source": [
     "%%bash\n",
-    "exists=$(gsutil ls -d | grep -w gs://${BUCKET}/)\n",
+    "exists=$(gcloud storage ls -d | grep -w gs://${BUCKET}/)\n",
     "\n",
     "if [ -n \"$exists\" ]; then\n",
     "   echo -e \"Bucket gs://${BUCKET} already exists.\"\n",
     "    \n",
     "else\n",
     "   echo \"Creating a new GCS bucket.\"\n",
-    "   gsutil mb -l ${REGION} gs://${BUCKET}\n",
+    "   gcloud storage buckets create --location=${REGION} gs://${BUCKET}\n",
     "   echo -e \"\\nHere are your current buckets:\"\n",
-    "   gsutil ls\n",
+    "   gcloud storage ls\n",
     "fi"
    ]
   },
@@ -218,7 +218,7 @@
     "ARTIFACT = f\"gs://{BUCKET}/models/\"\n",
     "MODEL_NAME = \"churn\"\n",
     "\n",
-    "!gsutil -m cp -r ../models/{MODEL_NAME} {ARTIFACT}"
+    "!gcloud storage cp -r ../models/{MODEL_NAME} {ARTIFACT}"
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR updates all `gsutil` CLI commands and `subprocess` invocations to their modern `gcloud storage` equivalents across the `asl_mlops` directory, following [Google Cloud's gsutil transition recommendations](https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud).

### Summary of Changes
- **Updated files**: 21 files (16 Jupyter Notebooks + 5 `train.py` Python scripts)
- **Command mappings applied**:
  - `gsutil cp` ➡️ `gcloud storage cp`
  - `gsutil ls` ➡️ `gcloud storage ls`
  - `gsutil mb` ➡️ `gcloud storage buckets create`
  - `['gsutil', 'cp', ...]` ➡️ `['gcloud', 'storage', 'cp', ...]`

### Verification & Quality Assurance
- ✅ All updated Jupyter Notebooks were verified for valid JSON syntax.
- ✅ All updated Python scripts compiled without syntax errors.
- ✅ Zero remaining `gsutil` references in `asl_mlops`.
- [x] Test changed notebooks
