### PR TITLE
replace temperature to thinking_level

### DIFF
--- a/asl_genai/notebooks/generative_ai_fundamentals/labs/gemini_for_multimodal_prompting.ipynb
+++ b/asl_genai/notebooks/generative_ai_fundamentals/labs/gemini_for_multimodal_prompting.ipynb
@@ -178,12 +178,12 @@
     "id": "tDK4XLdz3Oqv"
    },
    "source": [
-    "### Thinking budget\n",
+    "### Thinking level\n",
     "\n",
-    "Thinking budget controls the level of internal reasoning (thinking) the model performs before generating a response. Setting `thinking_level` via `ThinkingConfig` allows you to adjust the depth of the model's reasoning process. Options include `\"MINIMAL\"`, `\"LOW\"`, `\"MEDIUM\"`, and `\"HIGH\"`. You can also specify `max_output_tokens` to cap the total tokens returned.\n",
+    "Thinking level controls the depth of internal reasoning (thinking) the model performs before generating a response. Setting `thinking_level` via `ThinkingConfig` allows you to adjust the level of reasoning. Options include `\"MINIMAL\"`, `\"LOW\"`, `\"MEDIUM\"`, and `\"HIGH\"`. You can also specify `max_output_tokens` to cap the total tokens returned.\n",
     "\n",
     "\n",
-    "You can experiment with different thinking budget values to see how the model's reasoning and response change.\n"
+    "You can experiment with different thinking level values to see how the model's reasoning and response change.\n"
    ]
   },
   {

--- a/asl_genai/notebooks/generative_ai_fundamentals/labs/gemini_for_multimodal_prompting.ipynb
+++ b/asl_genai/notebooks/generative_ai_fundamentals/labs/gemini_for_multimodal_prompting.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "import IPython.display\n",
     "from google import genai\n",
-    "from google.genai.types import GenerateContentConfig, Part\n",
+    "from google.genai.types import GenerateContentConfig, Part, ThinkingConfig\n",
     "from PIL import Image as PIL_Image\n",
     "from PIL import ImageOps as PIL_ImageOps\n",
     "from pydantic import BaseModel"
@@ -178,12 +178,12 @@
     "id": "tDK4XLdz3Oqv"
    },
    "source": [
-    "### Model parameters\n",
+    "### Thinking budget\n",
     "\n",
-    "Every prompt you send to the model includes parameter values that control how the model generates a response. The model can generate different results for different parameter values. The `temperature` parameter controls the amount of consistency in the response. With a temperature of 0 you'll consistently get the exact same answer to the same prompt, and as you increase the temperature you'll get more \"creative\" albeit less consistent answers. The `top_p` and `top_k` control the tokens that are considered by the LLM to generate the answer. If you set `top_p` to 0.2 for instance, the model will only consider the most probable token for an answer whose probability sums up to 0.2, while if you set `top_k` to 100, the model will only consider the top 100 most probable tokens.  `candidate_counts` determines the number of candidate answers you want to be generated, while `max_output_tokens` specifies the maximum number of tokens allowed per candidate answer. \n",
+    "Thinking budget controls the level of internal reasoning (thinking) the model performs before generating a response. Setting `thinking_level` via `ThinkingConfig` allows you to adjust the depth of the model's reasoning process. Options include `\"MINIMAL\"`, `\"LOW\"`, `\"MEDIUM\"`, and `\"HIGH\"`. You can also specify `max_output_tokens` to cap the total tokens returned.\n",
     "\n",
     "\n",
-    "You can experiment with different model parameters to see how the results change.\n"
+    "You can experiment with different thinking budget values to see how the model's reasoning and response change.\n"
    ]
   },
   {
@@ -192,7 +192,7 @@
    "source": [
     "**Exercise**\n",
     "\n",
-    "Create a configuration object setting the `temperature`, `top_p`, `top_k`, and `candidate_count` using `GenerateContentConfig` and pass this configuration object to `generate_content_stream`."
+    "Create a configuration object setting `thinking_level` to `\"MINIMAL\"` using `ThinkingConfig` within `GenerateContentConfig` and pass this configuration object to `generate_content_stream`."
    ]
   },
   {

--- a/asl_genai/notebooks/generative_ai_fundamentals/labs/gemini_for_multimodal_prompting.ipynb
+++ b/asl_genai/notebooks/generative_ai_fundamentals/labs/gemini_for_multimodal_prompting.ipynb
@@ -182,8 +182,11 @@
     "\n",
     "Thinking level controls the depth of internal reasoning (thinking) the model performs before generating a response. Setting `thinking_level` via `ThinkingConfig` allows you to adjust the level of reasoning. Options include `\"MINIMAL\"`, `\"LOW\"`, `\"MEDIUM\"`, and `\"HIGH\"`. You can also specify `max_output_tokens` to cap the total tokens returned.\n",
     "\n",
+    "Setting `include_thoughts=True` allows you to inspect the model's internal reasoning process (accessible where `part.thought` is `True`).\n",
     "\n",
-    "You can experiment with different thinking level values to see how the model's reasoning and response change.\n"
+    "Below, we test how Gemini handles a complex multi-constraint task (acrostic `S-T-A-R`, exact 8-syllable count per line, and `AABB` rhyme scheme):\n",
+    "- **`MINIMAL`**: Generates immediately with minimal or no thinking tokens. Fast and low-latency, but may miss strict constraints (like exact syllable counts).\n",
+    "- **`HIGH`**: Allocates internal reasoning tokens to plan, verify syllable counts, and self-correct before producing the final output."
    ]
   },
   {
@@ -192,7 +195,7 @@
    "source": [
     "**Exercise**\n",
     "\n",
-    "Create a configuration object setting `thinking_level` to `\"MINIMAL\"` using `ThinkingConfig` within `GenerateContentConfig` and pass this configuration object to `generate_content_stream`."
+    "Create a configuration object setting `thinking_level` to `\"MINIMAL\"` and `include_thoughts=True` using `ThinkingConfig` within `GenerateContentConfig` and pass this configuration object to `generate_content_stream`."
    ]
   },
   {
@@ -204,12 +207,51 @@
    },
    "outputs": [],
    "source": [
+    "PROMPT = \"\"\"\n",
+    "Write a 4-line poem about space. \n",
+    "Line 1 must start with 'S', line 2 with 'T', line 3 with 'A', line 4 with 'R'. \n",
+    "Each line must have exactly 8 syllables and rhyme AABB.\n",
+    "\"\"\"\n",
+    "\n",
     "generation_config = None  # TODO\n",
     "\n",
     "responses = client.models.generate_content_stream(None)  # TODO\n",
     "\n",
-    "for response in responses:\n",
-    "    print(response.text, end=\"\")"
+    "for chunk in responses:\n",
+    "    for candidate in chunk.candidates:\n",
+    "        if candidate.content and candidate.content.parts:\n",
+    "            for part in candidate.content.parts:\n",
+    "                if part.thought and part.text:\n",
+    "                    print(f\"🤔 Thinking...: {part.text}\", end=\"\", flush=True)\n",
+    "                elif part.text:\n",
+    "                    print(f\"{part.text}\", end=\"\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "generation_config = GenerateContentConfig(\n",
+    "    thinking_config=ThinkingConfig(\n",
+    "        thinking_level=\"HIGH\",\n",
+    "        include_thoughts=True\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "responses = client.models.generate_content_stream(\n",
+    "    model=MODEL, config=generation_config, contents=PROMPT\n",
+    ")\n",
+    "\n",
+    "for chunk in responses:\n",
+    "    for candidate in chunk.candidates:\n",
+    "        if candidate.content and candidate.content.parts:\n",
+    "            for part in candidate.content.parts:\n",
+    "                if part.thought and part.text:\n",
+    "                    print(f\"🤔 Thinking...: {part.text}\", end=\"\", flush=True)\n",
+    "                elif part.text:\n",
+    "                    print(f\"{part.text}\", end=\"\", flush=True)\n"
    ]
   },
   {

--- a/asl_genai/notebooks/generative_ai_fundamentals/solutions/gemini_for_multimodal_prompting.ipynb
+++ b/asl_genai/notebooks/generative_ai_fundamentals/solutions/gemini_for_multimodal_prompting.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "import IPython.display\n",
     "from google import genai\n",
-    "from google.genai.types import GenerateContentConfig, Part\n",
+    "from google.genai.types import GenerateContentConfig, Part, ThinkingConfig\n",
     "from PIL import Image as PIL_Image\n",
     "from PIL import ImageOps as PIL_ImageOps\n",
     "from pydantic import BaseModel"
@@ -191,12 +191,12 @@
     "id": "tDK4XLdz3Oqv"
    },
    "source": [
-    "### Model parameters\n",
+    "### Thinking budget\n",
     "\n",
-    "Every prompt you send to the model includes parameter values that control how the model generates a response. The model can generate different results for different parameter values. The `temperature` parameter controls the amount of consistency in the response. With a temperature of 0 you'll consistently get the exact same answer to the same prompt, and as you increase the temperature you'll get more \"creative\" albeit less consistent answers. The `top_p` and `top_k` control the tokens that are considered by the LLM to generate the answer. If you set `top_p` to 0.2 for instance, the model will only consider the most probable token for an answer whose probability sums up to 0.2, while if you set `top_k` to 100, the model will only consider the top 100 most probable tokens.  `candidate_counts` determines the number of candidate answers you want to be generated, while `max_output_tokens` specifies the maximum number of tokens allowed per candidate answer. \n",
+    "Thinking budget controls the level of internal reasoning (thinking) the model performs before generating a response. Setting `thinking_level` via `ThinkingConfig` allows you to adjust the depth of the model's reasoning process. Options include `\"MINIMAL\"`, `\"LOW\"`, `\"MEDIUM\"`, and `\"HIGH\"`. You can also specify `max_output_tokens` to cap the total tokens returned.\n",
     "\n",
     "\n",
-    "You can experiment with different model parameters to see how the results change.\n"
+    "You can experiment with different thinking budget values to see how the model's reasoning and response change.\n"
    ]
   },
   {
@@ -209,11 +209,9 @@
    "outputs": [],
    "source": [
     "generation_config = GenerateContentConfig(\n",
-    "    temperature=0.9,\n",
-    "    top_p=1.0,\n",
-    "    top_k=32,\n",
-    "    candidate_count=1,\n",
-    "    max_output_tokens=8192,\n",
+    "    thinking_config=ThinkingConfig(\n",
+    "        thinking_level=\"MINIMAL\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "responses = client.models.generate_content_stream(\n",

--- a/asl_genai/notebooks/generative_ai_fundamentals/solutions/gemini_for_multimodal_prompting.ipynb
+++ b/asl_genai/notebooks/generative_ai_fundamentals/solutions/gemini_for_multimodal_prompting.ipynb
@@ -191,12 +191,12 @@
     "id": "tDK4XLdz3Oqv"
    },
    "source": [
-    "### Thinking budget\n",
+    "### Thinking level\n",
     "\n",
-    "Thinking budget controls the level of internal reasoning (thinking) the model performs before generating a response. Setting `thinking_level` via `ThinkingConfig` allows you to adjust the depth of the model's reasoning process. Options include `\"MINIMAL\"`, `\"LOW\"`, `\"MEDIUM\"`, and `\"HIGH\"`. You can also specify `max_output_tokens` to cap the total tokens returned.\n",
+    "Thinking level controls the depth of internal reasoning (thinking) the model performs before generating a response. Setting `thinking_level` via `ThinkingConfig` allows you to adjust the level of reasoning. Options include `\"MINIMAL\"`, `\"LOW\"`, `\"MEDIUM\"`, and `\"HIGH\"`. You can also specify `max_output_tokens` to cap the total tokens returned.\n",
     "\n",
     "\n",
-    "You can experiment with different thinking budget values to see how the model's reasoning and response change.\n"
+    "You can experiment with different thinking level values to see how the model's reasoning and response change.\n"
    ]
   },
   {

--- a/asl_genai/notebooks/generative_ai_fundamentals/solutions/gemini_for_multimodal_prompting.ipynb
+++ b/asl_genai/notebooks/generative_ai_fundamentals/solutions/gemini_for_multimodal_prompting.ipynb
@@ -195,8 +195,11 @@
     "\n",
     "Thinking level controls the depth of internal reasoning (thinking) the model performs before generating a response. Setting `thinking_level` via `ThinkingConfig` allows you to adjust the level of reasoning. Options include `\"MINIMAL\"`, `\"LOW\"`, `\"MEDIUM\"`, and `\"HIGH\"`. You can also specify `max_output_tokens` to cap the total tokens returned.\n",
     "\n",
+    "Setting `include_thoughts=True` allows you to inspect the model's internal reasoning process (accessible where `part.thought` is `True`).\n",
     "\n",
-    "You can experiment with different thinking level values to see how the model's reasoning and response change.\n"
+    "Below, we test how Gemini handles a complex multi-constraint task (acrostic `S-T-A-R`, exact 8-syllable count per line, and `AABB` rhyme scheme):\n",
+    "- **`MINIMAL`**: Generates immediately with minimal or no thinking tokens. Fast and low-latency, but may miss strict constraints (like exact syllable counts).\n",
+    "- **`HIGH`**: Allocates internal reasoning tokens to plan, verify syllable counts, and self-correct before producing the final output."
    ]
   },
   {
@@ -208,18 +211,58 @@
    },
    "outputs": [],
    "source": [
+    "PROMPT = \"\"\"\n",
+    "Write a 4-line poem about space. \n",
+    "Line 1 must start with 'S', line 2 with 'T', line 3 with 'A', line 4 with 'R'. \n",
+    "Each line must have exactly 8 syllables and rhyme AABB.\n",
+    "\"\"\"\n",
+    "\n",
     "generation_config = GenerateContentConfig(\n",
     "    thinking_config=ThinkingConfig(\n",
     "        thinking_level=\"MINIMAL\",\n",
+    "        include_thoughts=True\n",
     "    ),\n",
     ")\n",
     "\n",
     "responses = client.models.generate_content_stream(\n",
-    "    model=MODEL, config=generation_config, contents=\"Why is the sky blue?\"\n",
+    "    model=MODEL, config=generation_config, contents=PROMPT\n",
     ")\n",
     "\n",
-    "for response in responses:\n",
-    "    print(response.text, end=\"\")"
+    "for chunk in responses:\n",
+    "    for candidate in chunk.candidates:\n",
+    "        if candidate.content and candidate.content.parts:\n",
+    "            for part in candidate.content.parts:\n",
+    "                if part.thought and part.text:\n",
+    "                    print(f\"🤔 Thinking...: {part.text}\", end=\"\", flush=True)\n",
+    "                elif part.text:\n",
+    "                    print(f\"{part.text}\", end=\"\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "generation_config = GenerateContentConfig(\n",
+    "    thinking_config=ThinkingConfig(\n",
+    "        thinking_level=\"HIGH\",\n",
+    "        include_thoughts=True\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "responses = client.models.generate_content_stream(\n",
+    "    model=MODEL, config=generation_config, contents=PROMPT\n",
+    ")\n",
+    "\n",
+    "for chunk in responses:\n",
+    "    for candidate in chunk.candidates:\n",
+    "        if candidate.content and candidate.content.parts:\n",
+    "            for part in candidate.content.parts:\n",
+    "                if part.thought and part.text:\n",
+    "                    print(f\"🤔 Thinking...: {part.text}\", end=\"\", flush=True)\n",
+    "                elif part.text:\n",
+    "                    print(f\"{part.text}\", end=\"\", flush=True)\n"
    ]
   },
   {


### PR DESCRIPTION
### Summary
`temperature`, `top_k`, and `top_p` are being deprecated in new models in favor of reasoning configuration. This PR updates the model configuration section in `gemini_for_multimodal_prompting.ipynb` (labs & solutions) to use `ThinkingConfig`.
### Changes
- **Imports**: Added `ThinkingConfig` to imports from `google.genai.types`.
- **Content**: Replaced the "Model parameters" section with a "Thinking budget" overview explaining `thinking_level` options (`"MINIMAL"`, `"LOW"`, `"MEDIUM"`, `"HIGH"`).
- **Notebook Exercises & Solutions**:
  - **Lab**: Updated exercise prompt to direct setting `thinking_level` to `"MINIMAL"` via `ThinkingConfig`.
  - **Solution**: Replaced legacy parameters (`temperature`, `top_p`, `top_k`, etc.) with `thinking_config=ThinkingConfig(thinking_level="MINIMAL")`.

### Reference
https://ai.google.dev/gemini-api/docs/generate-content/latest-model#sampling-parameter-deprecation